### PR TITLE
chore: rename kasctl to kasapi-cli

### DIFF
--- a/.claude/skills/kasapi-cli-git-workflow/SKILL.md
+++ b/.claude/skills/kasapi-cli-git-workflow/SKILL.md
@@ -1,9 +1,9 @@
 ---
-name: kasctl-git-workflow
-description: Git, commit, and PR workflow for kasctl. TRIGGER on every `git commit` / `git push` / `gh pr create` / `gh pr merge`, when creating a feature or fix branch, on rebase/merge conflicts against `main`, or when the user asks for a code-review pass. Adapted from the libqasapi `qasapi-module` skill, reduced to what applies to a fresh greenfield project.
+name: kasapi-cli-git-workflow
+description: Git, commit, and PR workflow for kasapi-cli. TRIGGER on every `git commit` / `git push` / `gh pr create` / `gh pr merge`, when creating a feature or fix branch, on rebase/merge conflicts against `main`, or when the user asks for a code-review pass. Adapted from the libqasapi `qasapi-module` skill, reduced to what applies to a fresh greenfield project.
 ---
 
-# kasctl Git Workflow
+# kasapi-cli Git Workflow
 
 Mandatory workflow for branches, commits, PRs, and review rounds. Applies only to git actions — the domain-specific module slicing from the libqasapi original is **not** carried over.
 

--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,7 @@
 *.env
 .env.*
 config.local.*
-kasctl.local.*
+kasapi-cli.local.*
 
 # IDE / editor noise
 /.idea/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,9 +14,9 @@ When asked to "start" or "bootstrap", expect to be the one creating the module l
 
 There is no predecessor library and no inherited backlog. Do not assume or import patterns from any other KAS client; design from the KAS API docs and the fixtures in `testdata/`.
 
-## What kasctl Is
+## What kasapi-cli Is
 
-`kasctl` is a CLI for the **All-Inkl KAS API** (Kunden-Administrations-System — a SOAP/XML hosting-control API). The only external references for the API surface are:
+`kasapi-cli` is a CLI for the **All-Inkl KAS API** (Kunden-Administrations-System — a SOAP/XML hosting-control API). The only external references for the API surface are:
 
 - The two KAS endpoint URLs (auth and API), to be supplied by the user / config.
     - api: https://kasapi.kasserver.com/soap/KasApi.php
@@ -35,7 +35,7 @@ Go style, architecture, patterns, and linting rules for this repo live in:
 
 - `AGENTS.md` — top-level operating rules (always run `gofmt`/`goimports`, `go vet`, `golangci-lint`, `go test`; clean-architecture layering; no business logic depending on transport).
 - `docs/go/STYLE_GUIDE.md`
-- `docs/go/ARCHITECTURE.md` — clean-architecture layering: `cmd/kasctl` wires; domain/use cases in `internal/<domain>/`; SOAP/HTTP/CLI are outer-layer adapters.
+- `docs/go/ARCHITECTURE.md` — clean-architecture layering: `cmd/kasapi-cli` wires; domain/use cases in `internal/<domain>/`; SOAP/HTTP/CLI are outer-layer adapters.
 - `docs/go/PATTERNS.md`
 - `docs/go/LINTING.md` — CI gate set.
 
@@ -52,7 +52,7 @@ golangci-lint run ./...
 go test ./...
 go test -race ./...                     # for packages with concurrency
 go test ./internal/<pkg> -run TestXxx   # single test
-go build ./cmd/kasctl
+go build ./cmd/kasapi-cli
 ```
 
 There is no build/test runnable yet — running these in the current tree will fail until the module is bootstrapped.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <p align="center">
-  <img src="assets/logo.png" alt="kasctl logo" width="180">
+  <img src="assets/logo.png" alt="kasapi-cli logo" width="180">
 </p>
 
-# kasctl
+# kasapi-cli
 
 > [!IMPORTANT]
 > An independent open-source KAS-API CLI written in Go that communicates with the KAS-API from All-Inkl.com. Not affiliated with All-Inkl.com.
@@ -26,7 +26,7 @@ Early development. No functional Go code yet — the repository currently holds 
 
 ## What it does (planned)
 
-`kasctl` is a command-line client for the All-Inkl KAS-API. It wraps the SOAP/`ns2:Map` wire format the API uses, handles the `KasAuth` credential-token flow (plain or session, optional 2FA), enforces the `KasFloodDelay` between calls, and exposes read and write operations for the resources documented at <https://kasapi.kasserver.com/dokumentation/phpdoc/>:
+`kasapi-cli` is a command-line client for the All-Inkl KAS-API. It wraps the SOAP/`ns2:Map` wire format the API uses, handles the `KasAuth` credential-token flow (plain or session, optional 2FA), enforces the `KasFloodDelay` between calls, and exposes read and write operations for the resources documented at <https://kasapi.kasserver.com/dokumentation/phpdoc/>:
 
 - accounts, account settings, account resources
 - server information, space, space usage, traffic
@@ -43,29 +43,29 @@ Early development. No functional Go code yet — the repository currently holds 
 
 ## Configuration (planned)
 
-`kasctl` reads credentials from a config file or from environment variables (`KAS_LOGIN`, `KAS_AUTHDATA`, `KAS_AUTHTYPE`). Profiles let you switch between accounts. Secrets never appear in `--help` or in default log output.
+`kasapi-cli` reads credentials from a config file or from environment variables (`KAS_LOGIN`, `KAS_AUTHDATA`, `KAS_AUTHTYPE`). Profiles let you switch between accounts. Secrets never appear in `--help` or in default log output.
 
 ## Building
 
 Once the Go module is bootstrapped:
 
 ```sh
-go build ./cmd/kasctl
+go build ./cmd/kasapi-cli
 go test ./...
 ```
 
 ## Repository layout
 
-- `cmd/kasctl/` — CLI entry point (planned).
+- `cmd/kasapi-cli/` — CLI entry point (planned).
 - `internal/` — domain types, transport, mappers (planned).
 - `testdata/` — recorded KAS-API SOAP responses; the source of truth for response shape, used by offline parser tests.
 - `docs/go/` — Go style, architecture, patterns, and linting reference for this repo.
-- `.claude/skills/kasctl-git-workflow/` — git/PR workflow skill enforced for this project.
+- `.claude/skills/kasapi-cli-git-workflow/` — git/PR workflow skill enforced for this project.
 - `AGENTS.md`, `CLAUDE.md` — agent guidance.
 
 ## Contributing
 
-Read `AGENTS.md` and `docs/go/ARCHITECTURE.md` before opening a PR. The git workflow (branch naming, commit style, PR shape, CI gate) is captured in `.claude/skills/kasctl-git-workflow/SKILL.md`.
+Read `AGENTS.md` and `docs/go/ARCHITECTURE.md` before opening a PR. The git workflow (branch naming, commit style, PR shape, CI gate) is captured in `.claude/skills/kasapi-cli-git-workflow/SKILL.md`.
 
 ## License
 


### PR DESCRIPTION
Aligns the project name with the renamed repo (`chmmou/kasapi-cli`) and the new logo.

- README headings, prose, build commands, repo-layout list
- CLAUDE.md project description, architecture pointer, build command
- `.claude/skills/kasctl-git-workflow/` renamed to `.claude/skills/kasapi-cli-git-workflow/` (folder + SKILL frontmatter + heading + description)
- `.gitignore` pattern `kasctl.local.*` → `kasapi-cli.local.*`

The CLI binary, module path, package layout (`cmd/kasapi-cli/`) will be set when the Go module is bootstrapped (issue #1).