### PR TITLE
feat: KasApi core client + typed error mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `internal/api` generic KasApi.php call surface composing the soap codec
+  with the http transport: `Client.Call(ctx, action, params)` encodes,
+  posts, decodes, and feeds the server-reported `KasFloodDelay` back to
+  the transport gate. SOAP-ENV:Fault bodies surface as typed `*Error`
+  values whose `Code` is the stable KAS error string, with predicates
+  (`IsAuthFailure`, `IsFloodProtection`, `IsNotFound`, `IsSyntaxError`,
+  `IsMaxReached`, `IsInProgress`, `IsMissingParameter`, `IsNothingToDo`).
+  A `TokenSource` interface plus `StaticTokenSource` provide credentials;
+  `no_auth` and `unknown_session` trigger one token refresh and retry.
+  (Closes #6.)
 - `internal/transport` HTTP client wrapping the KAS SOAP endpoints:
   POST with the SOAP 1.1 content type, version-stamped User-Agent,
   exponential backoff on 5xx and network errors (4xx and SOAP faults

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -1,0 +1,138 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/chmmou/kasapi-cli/internal/soap"
+	"github.com/chmmou/kasapi-cli/internal/transport"
+)
+
+// DefaultEndpoint is the production KasApi.php URL. Set Client.Endpoint
+// to override (e.g. in tests against an httptest.Server).
+const DefaultEndpoint = "https://kasapi.kasserver.com/soap/KasApi.php"
+
+// floodFallback is the gate applied when the server returns a
+// flood_protection fault, which carries no KasFloodDelay value.
+const floodFallback = 2 * time.Second
+
+// TokenSource supplies the credentials for one or more KasApi calls.
+// Plain auth returns the password as AuthData; session auth returns a
+// short-lived 40-char token. After an authentication failure, Client
+// calls Invalidate so the next Credentials call may obtain a fresh
+// token (e.g. by re-running the KasAuth flow).
+type TokenSource interface {
+	Credentials(ctx context.Context) (login, authData string, authType soap.AuthType, err error)
+	Invalidate()
+}
+
+// StaticTokenSource is a TokenSource that returns the same credentials
+// every call. Suitable for plain auth and for tests; session-token
+// callers should use the source provided by the auth package once the
+// KasAuth client (issue #5) is in place.
+type StaticTokenSource struct {
+	Login    string
+	AuthData string
+	AuthType soap.AuthType
+}
+
+// Credentials returns the stored values without modification.
+func (s *StaticTokenSource) Credentials(_ context.Context) (string, string, soap.AuthType, error) {
+	if s.Login == "" || s.AuthData == "" || s.AuthType == "" {
+		return "", "", "", errors.New("api: StaticTokenSource has empty fields")
+	}
+	return s.Login, s.AuthData, s.AuthType, nil
+}
+
+// Invalidate is a no-op for the static source. A static credential
+// cannot refresh itself; an auth failure is therefore terminal.
+func (s *StaticTokenSource) Invalidate() {}
+
+// Client posts KasApi calls through the transport, refreshes session
+// tokens on auth failures, and feeds the server-reported KasFloodDelay
+// back to the transport gate after every successful call.
+//
+// A zero Client is unusable; obtain one with New.
+type Client struct {
+	Transport *transport.Client
+	Tokens    TokenSource
+	Endpoint  string
+}
+
+// New returns a Client wired with the given transport and token source.
+// Endpoint defaults to DefaultEndpoint.
+func New(t *transport.Client, ts TokenSource) *Client {
+	return &Client{
+		Transport: t,
+		Tokens:    ts,
+		Endpoint:  DefaultEndpoint,
+	}
+}
+
+// Call posts one KasApi action with the given parameters and returns
+// the parsed response. SOAP-ENV:Fault bodies surface as *Error with the
+// stable KAS code in Error.Code. On no_auth or unknown_session, Call
+// invalidates the token source and retries once with fresh credentials.
+//
+// On flood_protection, Call seeds the transport gate with a short
+// fallback delay before returning the error so the caller's next Call
+// is throttled even though the fault carried no KasFloodDelay value.
+func (c *Client) Call(ctx context.Context, action string, params map[string]any) (*soap.Response, error) {
+	if action == "" {
+		return nil, errors.New("api: action is required")
+	}
+	resp, err := c.callOnce(ctx, action, params)
+	if err == nil {
+		return resp, nil
+	}
+	if IsAuthFailure(err) {
+		c.Tokens.Invalidate()
+		return c.callOnce(ctx, action, params)
+	}
+	return nil, err
+}
+
+func (c *Client) callOnce(ctx context.Context, action string, params map[string]any) (*soap.Response, error) {
+	login, authData, authType, err := c.Tokens.Credentials(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("api: credentials: %w", err)
+	}
+
+	var buf bytes.Buffer
+	req := soap.Request{
+		Login:    login,
+		AuthType: authType,
+		AuthData: authData,
+		Action:   action,
+		Params:   params,
+	}
+	if encErr := soap.EncodeRequest(&buf, req); encErr != nil {
+		return nil, fmt.Errorf("api: encode %s: %w", action, encErr)
+	}
+
+	body, err := c.Transport.Do(ctx, c.Endpoint, buf.Bytes())
+	if err != nil {
+		return nil, fmt.Errorf("api: transport %s: %w", action, err)
+	}
+
+	resp, err := soap.Decode(bytes.NewReader(body))
+	if err != nil {
+		var fe *soap.FaultError
+		if errors.As(err, &fe) {
+			apiErr := newError(action, c.Endpoint, fe)
+			if IsFloodProtection(apiErr) {
+				c.Transport.RecordDelay(floodFallback)
+			}
+			return nil, apiErr
+		}
+		return nil, fmt.Errorf("api: decode %s: %w", action, err)
+	}
+
+	if d := time.Duration(resp.Body.KasFloodDelay * float64(time.Second)); d > 0 {
+		c.Transport.RecordDelay(d)
+	}
+	return resp, nil
+}

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -1,0 +1,242 @@
+package api_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/chmmou/kasapi-cli/internal/api"
+	"github.com/chmmou/kasapi-cli/internal/soap"
+	"github.com/chmmou/kasapi-cli/internal/transport"
+)
+
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	dir := filepath.Dir(file)
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatalf("repo root not found from %q", file)
+		}
+		dir = parent
+	}
+}
+
+func loadFixture(t *testing.T, rel string) []byte {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join(repoRoot(t), "testdata", rel))
+	if err != nil {
+		t.Fatalf("load %s: %v", rel, err)
+	}
+	return b
+}
+
+func newAPIClient(srv *httptest.Server, ts api.TokenSource) *api.Client {
+	tr := transport.New()
+	tr.HTTPClient = srv.Client()
+	tr.MaxRetries = 0
+	tr.Now = time.Now
+	tr.Sleep = func(_ context.Context, _ time.Duration) error { return nil }
+	c := api.New(tr, ts)
+	c.Endpoint = srv.URL
+	return c
+}
+
+func staticTokens() *api.StaticTokenSource {
+	return &api.StaticTokenSource{
+		Login:    "w0000000",
+		AuthData: "secret",
+		AuthType: soap.AuthSession,
+	}
+}
+
+func TestCallSuccess(t *testing.T) {
+	body := loadFixture(t, "account/get_accounts_response_success.xml")
+	var got struct {
+		method string
+		body   []byte
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got.method = r.Method
+		got.body, _ = io.ReadAll(r.Body)
+		_, _ = w.Write(body)
+	}))
+	defer srv.Close()
+
+	c := newAPIClient(srv, staticTokens())
+	resp, err := c.Call(context.Background(), "get_accounts", nil)
+	if err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	if resp.Body.ReturnString != "TRUE" {
+		t.Errorf("ReturnString = %q, want TRUE", resp.Body.ReturnString)
+	}
+	if got.method != http.MethodPost {
+		t.Errorf("method = %q, want POST", got.method)
+	}
+	if !strings.Contains(string(got.body), `"kas_action":"get_accounts"`) {
+		t.Errorf("encoded request missing kas_action: %s", got.body)
+	}
+}
+
+func TestCallFeedsKasFloodDelayToTransport(t *testing.T) {
+	body := loadFixture(t, "account/get_accounts_response_success.xml")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(body)
+	}))
+	defer srv.Close()
+
+	tr := transport.New()
+	tr.HTTPClient = srv.Client()
+	tr.MaxRetries = 0
+	tr.Now = time.Now
+	var slept atomic.Int64
+	tr.Sleep = func(_ context.Context, d time.Duration) error {
+		slept.Add(int64(d))
+		return nil
+	}
+	c := api.New(tr, staticTokens())
+	c.Endpoint = srv.URL
+
+	if _, err := c.Call(context.Background(), "get_accounts", nil); err != nil {
+		t.Fatalf("Call 1: %v", err)
+	}
+	if slept.Load() != 0 {
+		t.Errorf("first call slept %v, want 0", time.Duration(slept.Load()))
+	}
+	if _, err := c.Call(context.Background(), "get_accounts", nil); err != nil {
+		t.Fatalf("Call 2: %v", err)
+	}
+	if got := time.Duration(slept.Load()); got < 400*time.Millisecond || got > 600*time.Millisecond {
+		t.Errorf("second call gate slept %v, want ~500ms (KasFloodDelay=0.5)", got)
+	}
+}
+
+func TestCallReturnsTypedFault(t *testing.T) {
+	body := loadFixture(t, "account/add_account_response_failed_max_account_reached.xml")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(body)
+	}))
+	defer srv.Close()
+
+	c := newAPIClient(srv, staticTokens())
+	_, err := c.Call(context.Background(), "add_account", nil)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	apiErr := api.AsError(err)
+	if apiErr == nil {
+		t.Fatalf("expected *api.Error, got %T: %v", err, err)
+	}
+	if apiErr.Code != "max_account_reached" {
+		t.Errorf("Code = %q, want max_account_reached", apiErr.Code)
+	}
+	if apiErr.Action != "add_account" {
+		t.Errorf("Action = %q, want add_account", apiErr.Action)
+	}
+	if !api.IsMaxReached(err) {
+		t.Error("IsMaxReached(err) = false, want true")
+	}
+	// Underlying SOAP fault must still be reachable via errors.As.
+	var fe *soap.FaultError
+	if !errors.As(err, &fe) {
+		t.Error("errors.As to *soap.FaultError failed")
+	}
+}
+
+func TestCallRetriesOnAuthFailure(t *testing.T) {
+	authBody := loadFixture(t, "response_failed_no_auth.xml")
+	okBody := loadFixture(t, "account/get_accounts_response_success.xml")
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if calls.Add(1) == 1 {
+			_, _ = w.Write(authBody)
+			return
+		}
+		_, _ = w.Write(okBody)
+	}))
+	defer srv.Close()
+
+	ts := &countingTokens{login: "w0", data: "tok-1", typ: soap.AuthSession, refresh: "tok-2"}
+	c := newAPIClient(srv, ts)
+	resp, err := c.Call(context.Background(), "get_accounts", nil)
+	if err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	if resp.Body.ReturnString != "TRUE" {
+		t.Errorf("ReturnString = %q, want TRUE", resp.Body.ReturnString)
+	}
+	if calls.Load() != 2 {
+		t.Errorf("server calls = %d, want 2", calls.Load())
+	}
+	if ts.invalidations != 1 {
+		t.Errorf("invalidations = %d, want 1", ts.invalidations)
+	}
+	if ts.lastData != "tok-2" {
+		t.Errorf("retry used data = %q, want tok-2", ts.lastData)
+	}
+}
+
+func TestCallNoRetryOnNonAuthFault(t *testing.T) {
+	body := loadFixture(t, "account/add_account_response_failed_max_account_reached.xml")
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls.Add(1)
+		_, _ = w.Write(body)
+	}))
+	defer srv.Close()
+
+	c := newAPIClient(srv, staticTokens())
+	if _, err := c.Call(context.Background(), "add_account", nil); err == nil {
+		t.Fatal("expected error")
+	}
+	if calls.Load() != 1 {
+		t.Errorf("server calls = %d, want 1 (no retry on max_account_reached)", calls.Load())
+	}
+}
+
+func TestCallRejectsEmptyAction(t *testing.T) {
+	c := newAPIClient(httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		t.Error("server should not be reached")
+	})), staticTokens())
+	if _, err := c.Call(context.Background(), "", nil); err == nil {
+		t.Fatal("expected error on empty action")
+	}
+}
+
+// countingTokens is a TokenSource that swaps AuthData on Invalidate so
+// tests can confirm the retry pulled fresh credentials.
+type countingTokens struct {
+	login         string
+	data          string
+	typ           soap.AuthType
+	refresh       string
+	lastData      string
+	invalidations int
+}
+
+func (c *countingTokens) Credentials(_ context.Context) (string, string, soap.AuthType, error) {
+	c.lastData = c.data
+	return c.login, c.data, c.typ, nil
+}
+
+func (c *countingTokens) Invalidate() {
+	c.invalidations++
+	c.data = c.refresh
+}

--- a/internal/api/doc.go
+++ b/internal/api/doc.go
@@ -1,4 +1,16 @@
 // Package api is the generic KasApi.php call surface that all per-resource
-// modules build on. It owns error mapping from KAS error strings to typed
-// Go errors. See issue #6.
+// modules build on. It composes the soap codec with the http transport and
+// a TokenSource for credentials, feeds KasFloodDelay back to the transport's
+// gate after every successful call, and maps SOAP-ENV:Fault bodies into
+// typed *Error values whose Code is the stable KAS error string.
+//
+// Predicate helpers (IsAuthFailure, IsFloodProtection, IsNotFound,
+// IsSyntaxError, IsMaxReached, IsInProgress) are provided so callers can
+// branch on classes of errors without enumerating individual codes.
+//
+// On unknown_session or no_auth, Call invalidates the TokenSource and
+// retries once with fresh credentials. All other faults surface to the
+// caller without retry.
+//
+// See issue #6.
 package api

--- a/internal/api/errors.go
+++ b/internal/api/errors.go
@@ -1,0 +1,146 @@
+package api
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/chmmou/kasapi-cli/internal/soap"
+)
+
+// Stable KAS error codes referenced by name elsewhere in the package and
+// by callers. The full set of codes is open; new ones surface verbatim
+// in Error.Code.
+const (
+	CodeNoAuth           = "no_auth"
+	CodeAccessForbidden  = "kas_access_forbidden"
+	CodeNoAction         = "no_action"
+	CodeUnknownAction    = "unkown_action"
+	CodeGotNoLoginData   = "got_no_login_data"
+	CodeUnknownSession   = "unknown_session"
+	CodeFloodProtection  = "flood_protection"
+	CodeInProgress       = "in_progress"
+	CodeMissingParameter = "missing_parameter"
+	CodeNothingToDo      = "nothing_to_do"
+	CodeEmptyList        = "empty_list"
+)
+
+// Error is the typed wrapper for a SOAP-ENV:Fault body returned by the
+// KAS API. Code is the stable error string from <faultstring>; Message
+// carries the optional <detail> text. Action and Endpoint identify the
+// call that produced the fault.
+type Error struct {
+	Code     string
+	Message  string
+	Action   string
+	Endpoint string
+
+	fault *soap.FaultError
+}
+
+func (e *Error) Error() string {
+	parts := []string{fmt.Sprintf("kas %s: %s", e.Action, e.Code)}
+	if e.Message != "" {
+		parts = append(parts, e.Message)
+	}
+	return strings.Join(parts, ": ")
+}
+
+// Unwrap exposes the underlying *soap.FaultError so errors.As can recover
+// the original SOAP-level error if needed.
+func (e *Error) Unwrap() error { return e.fault }
+
+func newError(action, endpoint string, fe *soap.FaultError) *Error {
+	return &Error{
+		Code:     fe.Fault.String,
+		Message:  fe.Fault.Detail,
+		Action:   action,
+		Endpoint: endpoint,
+		fault:    fe,
+	}
+}
+
+// codeOf extracts the KAS error code from err. Returns "" if err is not
+// an *Error.
+func codeOf(err error) string {
+	var e *Error
+	if errors.As(err, &e) {
+		return e.Code
+	}
+	return ""
+}
+
+// IsCode reports whether err is an *Error with the given code.
+func IsCode(err error, code string) bool { return codeOf(err) == code }
+
+// IsAuthFailure reports whether err is an authentication failure that a
+// session-token client should respond to by re-authenticating. This
+// includes no_auth, unknown_session, kas_access_forbidden, and the
+// generic got_no_login_data envelope returned when the request lacked
+// kas_login.
+func IsAuthFailure(err error) bool {
+	switch codeOf(err) {
+	case CodeNoAuth, CodeUnknownSession, CodeAccessForbidden, CodeGotNoLoginData:
+		return true
+	}
+	return false
+}
+
+// IsFloodProtection reports whether err is the flood_protection fault.
+// Callers that observe this should back off; the transport gate alone
+// cannot prevent it because the fault carries no KasFloodDelay value.
+func IsFloodProtection(err error) bool { return IsCode(err, CodeFloodProtection) }
+
+// IsInProgress reports whether the fault is in_progress (a previous
+// asynchronous operation on the same target has not finished yet).
+func IsInProgress(err error) bool { return IsCode(err, CodeInProgress) }
+
+// IsMissingParameter reports whether err is missing_parameter.
+func IsMissingParameter(err error) bool { return IsCode(err, CodeMissingParameter) }
+
+// IsNothingToDo reports whether err is nothing_to_do (an update with no
+// actual changes).
+func IsNothingToDo(err error) bool { return IsCode(err, CodeNothingToDo) }
+
+// IsNotFound reports whether the fault code names a missing entity. The
+// KAS API uses several suffixes for this; the predicate covers all of
+// them: *_not_found, *_doesnt_exist, *_doenst_exist (server typo).
+func IsNotFound(err error) bool {
+	c := codeOf(err)
+	if c == "" {
+		return false
+	}
+	return strings.HasSuffix(c, "_not_found") ||
+		strings.HasSuffix(c, "_not_found_in_kas") ||
+		strings.HasSuffix(c, "_doesnt_exist") ||
+		strings.HasSuffix(c, "_doenst_exist")
+}
+
+// IsSyntaxError reports whether the fault code is a *_syntax_incorrect
+// validation error.
+func IsSyntaxError(err error) bool {
+	c := codeOf(err)
+	return c != "" && strings.HasSuffix(c, "_syntax_incorrect")
+}
+
+// IsMaxReached reports whether the fault code is a max_*_reached or a
+// generic *_limit_reached quota error.
+func IsMaxReached(err error) bool {
+	c := codeOf(err)
+	if c == "" {
+		return false
+	}
+	return (strings.HasPrefix(c, "max_") && strings.HasSuffix(c, "_reached")) ||
+		strings.HasSuffix(c, "_limit_reached")
+}
+
+// AsError extracts an *Error from err, returning nil if err is not an
+// api fault. Convenience wrapper around errors.As for callers that want
+// to inspect Code or Message directly.
+func AsError(err error) *Error {
+	var e *Error
+	if errors.As(err, &e) {
+		return e
+	}
+	return nil
+}

--- a/internal/api/errors_test.go
+++ b/internal/api/errors_test.go
@@ -1,0 +1,130 @@
+package api_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/chmmou/kasapi-cli/internal/api"
+	"github.com/chmmou/kasapi-cli/internal/soap"
+)
+
+func mkAPIErr(code, detail string) *api.Error {
+	fe := &soap.FaultError{Fault: soap.Fault{String: code, Detail: detail}}
+	return api.NewErrorForTest("test_action", "https://example.invalid/", fe)
+}
+
+func TestPredicateClassesByCode(t *testing.T) {
+	cases := []struct {
+		code      string
+		auth      bool
+		flood     bool
+		notFound  bool
+		syntax    bool
+		maxR      bool
+		inProg    bool
+		missingP  bool
+		nothingTD bool
+	}{
+		{code: "no_auth", auth: true},
+		{code: "unknown_session", auth: true},
+		{code: "kas_access_forbidden", auth: true},
+		{code: "got_no_login_data", auth: true},
+		{code: "flood_protection", flood: true},
+		{code: "in_progress", inProg: true},
+		{code: "missing_parameter", missingP: true},
+		{code: "nothing_to_do", nothingTD: true},
+		{code: "account_login_not_found", notFound: true},
+		{code: "kas_login_not_found", notFound: true},
+		{code: "domain_doesnt_exist", notFound: true},
+		{code: "subdomain_doenst_exist", notFound: true}, // server typo
+		{code: "domain_not_found_in_kas", notFound: true},
+		{code: "domain_syntax_incorrect", syntax: true},
+		{code: "account_kas_password_syntax_incorrect", syntax: true},
+		{code: "max_account_reached", maxR: true},
+		{code: "max_webspace_reached", maxR: true},
+		{code: "ddns_limit_reached", maxR: true},
+		{code: "targets_limit_reached", maxR: true},
+		// max_*_syntax_incorrect must classify as syntax, not as max-reached.
+		{code: "max_database_syntax_incorrect", syntax: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.code, func(t *testing.T) {
+			e := mkAPIErr(tc.code, "")
+			if got := api.IsAuthFailure(e); got != tc.auth {
+				t.Errorf("IsAuthFailure = %v, want %v", got, tc.auth)
+			}
+			if got := api.IsFloodProtection(e); got != tc.flood {
+				t.Errorf("IsFloodProtection = %v, want %v", got, tc.flood)
+			}
+			if got := api.IsNotFound(e); got != tc.notFound {
+				t.Errorf("IsNotFound = %v, want %v", got, tc.notFound)
+			}
+			if got := api.IsSyntaxError(e); got != tc.syntax {
+				t.Errorf("IsSyntaxError = %v, want %v", got, tc.syntax)
+			}
+			if got := api.IsMaxReached(e); got != tc.maxR {
+				t.Errorf("IsMaxReached = %v, want %v", got, tc.maxR)
+			}
+			if got := api.IsInProgress(e); got != tc.inProg {
+				t.Errorf("IsInProgress = %v, want %v", got, tc.inProg)
+			}
+			if got := api.IsMissingParameter(e); got != tc.missingP {
+				t.Errorf("IsMissingParameter = %v, want %v", got, tc.missingP)
+			}
+			if got := api.IsNothingToDo(e); got != tc.nothingTD {
+				t.Errorf("IsNothingToDo = %v, want %v", got, tc.nothingTD)
+			}
+		})
+	}
+}
+
+func TestPredicatesIgnoreNonAPIErrors(t *testing.T) {
+	plain := errors.New("transport: connection reset")
+	for name, pred := range map[string]func(error) bool{
+		"IsAuthFailure":      api.IsAuthFailure,
+		"IsFloodProtection":  api.IsFloodProtection,
+		"IsNotFound":         api.IsNotFound,
+		"IsSyntaxError":      api.IsSyntaxError,
+		"IsMaxReached":       api.IsMaxReached,
+		"IsInProgress":       api.IsInProgress,
+		"IsMissingParameter": api.IsMissingParameter,
+		"IsNothingToDo":      api.IsNothingToDo,
+	} {
+		if pred(plain) {
+			t.Errorf("%s(non-api err) = true, want false", name)
+		}
+	}
+}
+
+func TestErrorMessageIncludesActionAndCode(t *testing.T) {
+	e := mkAPIErr("missing_parameter", "kas_action missing")
+	if e.Code != "missing_parameter" {
+		t.Errorf("Code = %q, want missing_parameter", e.Code)
+	}
+	if e.Action != "test_action" {
+		t.Errorf("Action = %q, want test_action", e.Action)
+	}
+	msg := e.Error()
+	if !errors.Is(e, e) {
+		t.Error("errors.Is(e, e) = false")
+	}
+	for _, want := range []string{"test_action", "missing_parameter", "kas_action missing"} {
+		if !contains(msg, want) {
+			t.Errorf("Error() = %q, missing %q", msg, want)
+		}
+	}
+	var fe *soap.FaultError
+	if !errors.As(e, &fe) {
+		t.Error("errors.As to *soap.FaultError failed")
+	}
+}
+
+func contains(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/api/export_test.go
+++ b/internal/api/export_test.go
@@ -1,0 +1,10 @@
+package api
+
+import "github.com/chmmou/kasapi-cli/internal/soap"
+
+// NewErrorForTest exposes the unexported newError constructor so the
+// predicate tests in api_test can build *Error values directly without
+// going through Call.
+func NewErrorForTest(action, endpoint string, fe *soap.FaultError) *Error {
+	return newError(action, endpoint, fe)
+}


### PR DESCRIPTION
Generic `KasApi.php` call surface that all per-resource modules will build on.

- `api.Client.Call(ctx, action, params)` composes `soap.EncodeRequest` + `transport.Client.Do` + `soap.Decode`, and feeds `KasFloodDelay` back to the transport gate after each successful call.
- `TokenSource` interface (`Credentials` + `Invalidate`) with a `StaticTokenSource` for plain auth and tests; the session-token source ships with #5.
- SOAP faults surface as typed `*api.Error` with the stable KAS code; predicates `IsAuthFailure`, `IsFloodProtection`, `IsNotFound`, `IsSyntaxError`, `IsMaxReached`, `IsInProgress`, `IsMissingParameter`, `IsNothingToDo`.
- `no_auth` and `unknown_session` trigger one token refresh + retry; `flood_protection` seeds the transport gate with a fallback delay before surfacing the error.

Closes #6.