### PR TITLE
feat: KasAuth credential-token client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `internal/auth` KasAuth.php credential-token client: separate codec
+  (`tns:KasAuth` envelope, bare `xsd:string` token in `<return>`),
+  `Client.GetCredentialToken(ctx)` returning the 40-character token,
+  `Options{Lifetime, UpdateLifetime, OTP}` for the optional
+  `session_lifetime`, `session_update_lifetime`, and 2FA
+  `session_2fa` parameters. Faults surface as typed `*Error` with
+  helpers `IsLoginFailed`, `IsLoginLocked`, `IsOTPPinIncorrect`,
+  `IsUnknownSession`. `SessionTokenSource` adapts the client to the
+  `api.TokenSource` interface, caching the token and re-fetching on
+  `Invalidate` so `api.Client` can refresh transparently after an
+  auth failure. (Closes #5.)
 - `internal/api` generic KasApi.php call surface composing the soap codec
   with the http transport: `Client.Call(ctx, action, params)` encodes,
   posts, decodes, and feeds the server-reported `KasFloodDelay` back to

--- a/internal/auth/client.go
+++ b/internal/auth/client.go
@@ -1,0 +1,86 @@
+package auth
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/chmmou/kasapi-cli/internal/soap"
+	"github.com/chmmou/kasapi-cli/internal/transport"
+)
+
+// DefaultEndpoint is the production KasAuth.php URL. Set Client.Endpoint
+// to override (e.g. in tests against an httptest.Server).
+const DefaultEndpoint = "https://kasapi.kasserver.com/soap/KasAuth.php"
+
+// Options carries the optional KasAuth parameters. Lifetime in seconds
+// (1..30000); zero means "let the server apply its default". OTP is the
+// 2FA PIN; empty when 2FA is disabled. UpdateLifetime maps to
+// session_update_lifetime ("Y" / "N"); leave nil to omit.
+type Options struct {
+	Lifetime       int
+	UpdateLifetime *bool
+	OTP            string
+}
+
+// Client posts KasAuth requests through the supplied transport and
+// returns the credential token from the response. SOAP faults surface
+// as *Error with the stable KAS error string in Code.
+//
+// A zero Client is unusable; obtain one with New.
+type Client struct {
+	Transport *transport.Client
+	Login     string
+	AuthData  string
+	AuthType  soap.AuthType
+	Options   Options
+	Endpoint  string
+}
+
+// New returns a Client configured for the given credentials and options.
+// Endpoint defaults to DefaultEndpoint.
+func New(t *transport.Client, login, authData string, authType soap.AuthType, opts Options) *Client {
+	return &Client{
+		Transport: t,
+		Login:     login,
+		AuthData:  authData,
+		AuthType:  authType,
+		Options:   opts,
+		Endpoint:  DefaultEndpoint,
+	}
+}
+
+// GetCredentialToken posts the KasAuth request and returns the
+// 40-character credential token. Auth-specific faults surface as
+// *Error; transport-level errors are returned wrapped.
+func (c *Client) GetCredentialToken(ctx context.Context) (string, error) {
+	if c.Login == "" || c.AuthData == "" || c.AuthType == "" {
+		return "", errors.New("auth: Client has empty credential fields")
+	}
+	var buf bytes.Buffer
+	req := Request{
+		Login:          c.Login,
+		AuthType:       c.AuthType,
+		AuthData:       c.AuthData,
+		Lifetime:       c.Options.Lifetime,
+		UpdateLifetime: c.Options.UpdateLifetime,
+		OTP:            c.Options.OTP,
+	}
+	if err := EncodeRequest(&buf, req); err != nil {
+		return "", fmt.Errorf("auth: encode: %w", err)
+	}
+	body, err := c.Transport.Do(ctx, c.Endpoint, buf.Bytes())
+	if err != nil {
+		return "", fmt.Errorf("auth: transport: %w", err)
+	}
+	token, err := DecodeResponse(bytes.NewReader(body))
+	if err != nil {
+		var fe *soap.FaultError
+		if errors.As(err, &fe) {
+			return "", newError(c.Login, fe)
+		}
+		return "", fmt.Errorf("auth: decode: %w", err)
+	}
+	return token, nil
+}

--- a/internal/auth/client_test.go
+++ b/internal/auth/client_test.go
@@ -1,0 +1,162 @@
+package auth_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/chmmou/kasapi-cli/internal/auth"
+	"github.com/chmmou/kasapi-cli/internal/soap"
+	"github.com/chmmou/kasapi-cli/internal/transport"
+)
+
+func newAuthClient(srv *httptest.Server, login, data string, typ soap.AuthType, opts auth.Options) *auth.Client {
+	tr := transport.New()
+	tr.HTTPClient = srv.Client()
+	tr.MaxRetries = 0
+	tr.Now = time.Now
+	tr.Sleep = func(_ context.Context, _ time.Duration) error { return nil }
+	c := auth.New(tr, login, data, typ, opts)
+	c.Endpoint = srv.URL
+	return c
+}
+
+func TestGetCredentialTokenSuccess(t *testing.T) {
+	body := loadFixture(t, "session/add_session_response_success.xml")
+	var got struct {
+		body []byte
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got.body = readAll(r)
+		_, _ = w.Write(body)
+	}))
+	defer srv.Close()
+
+	c := newAuthClient(srv, "w0000000", "password", soap.AuthPlain, auth.Options{Lifetime: 1800, OTP: "123456"})
+	tok, err := c.GetCredentialToken(context.Background())
+	if err != nil {
+		t.Fatalf("GetCredentialToken: %v", err)
+	}
+	if tok != "01234567890abcdef0123456789abcdef0123456" {
+		t.Errorf("token = %q", tok)
+	}
+	for _, want := range []string{`"kas_login":"w0000000"`, `"kas_auth_type":"plain"`, `"session_2fa":"123456"`} {
+		if !strings.Contains(string(got.body), want) {
+			t.Errorf("request missing %q: %s", want, got.body)
+		}
+	}
+}
+
+func TestGetCredentialTokenSurfacesTypedFault(t *testing.T) {
+	body := loadFixture(t, "session/add_session_response_failed_otp_pin_incorrect.xml")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(body)
+	}))
+	defer srv.Close()
+
+	c := newAuthClient(srv, "w0", "secret", soap.AuthPlain, auth.Options{OTP: "wrong"})
+	_, err := c.GetCredentialToken(context.Background())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	e := auth.AsError(err)
+	if e == nil {
+		t.Fatalf("expected *auth.Error, got %T", err)
+	}
+	if e.Code != "otp_pin_incorrect" {
+		t.Errorf("Code = %q, want otp_pin_incorrect", e.Code)
+	}
+	if e.Login != "w0" {
+		t.Errorf("Login = %q, want w0", e.Login)
+	}
+	if !auth.IsOTPPinIncorrect(err) {
+		t.Error("IsOTPPinIncorrect = false, want true")
+	}
+}
+
+func TestGetCredentialTokenRejectsEmptyCreds(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		t.Error("server should not be reached")
+	}))
+	defer srv.Close()
+	c := newAuthClient(srv, "", "", "", auth.Options{})
+	if _, err := c.GetCredentialToken(context.Background()); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestSessionTokenSourceCachesAndRefreshes(t *testing.T) {
+	body := loadFixture(t, "session/add_session_response_success.xml")
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls.Add(1)
+		_, _ = w.Write(body)
+	}))
+	defer srv.Close()
+
+	c := newAuthClient(srv, "w0", "secret", soap.AuthPlain, auth.Options{})
+	src := auth.NewSessionTokenSource(c)
+
+	login, data, typ, err := src.Credentials(context.Background())
+	if err != nil {
+		t.Fatalf("Credentials: %v", err)
+	}
+	if login != "w0" || data == "" || typ != soap.AuthSession {
+		t.Errorf("first call: login=%q data=%q typ=%q", login, data, typ)
+	}
+	if calls.Load() != 1 {
+		t.Errorf("calls after first = %d, want 1", calls.Load())
+	}
+
+	// Second call must hit the cache, not the server.
+	if _, _, _, err := src.Credentials(context.Background()); err != nil {
+		t.Fatalf("second Credentials: %v", err)
+	}
+	if calls.Load() != 1 {
+		t.Errorf("calls after cached second = %d, want 1", calls.Load())
+	}
+
+	// Invalidate forces a re-fetch.
+	src.Invalidate()
+	if _, _, _, err := src.Credentials(context.Background()); err != nil {
+		t.Fatalf("third Credentials: %v", err)
+	}
+	if calls.Load() != 2 {
+		t.Errorf("calls after invalidate = %d, want 2", calls.Load())
+	}
+}
+
+func TestSessionTokenSourcePropagatesAuthError(t *testing.T) {
+	body := loadFixture(t, "session/add_session_response_failed_otp_pin_incorrect.xml")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(body)
+	}))
+	defer srv.Close()
+
+	src := auth.NewSessionTokenSource(newAuthClient(srv, "w0", "secret", soap.AuthPlain, auth.Options{}))
+	_, _, _, err := src.Credentials(context.Background())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !auth.IsOTPPinIncorrect(err) {
+		t.Errorf("expected IsOTPPinIncorrect, got %v", err)
+	}
+}
+
+func readAll(r *http.Request) []byte {
+	defer func() { _ = r.Body.Close() }()
+	out := make([]byte, 0, 1024)
+	buf := make([]byte, 1024)
+	for {
+		n, err := r.Body.Read(buf)
+		out = append(out, buf[:n]...)
+		if err != nil {
+			break
+		}
+	}
+	return out
+}

--- a/internal/auth/codec.go
+++ b/internal/auth/codec.go
@@ -1,0 +1,183 @@
+package auth
+
+import (
+	"encoding/json"
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/chmmou/kasapi-cli/internal/soap"
+)
+
+// Request is the typed payload for a KasAuth call. Lifetime and
+// UpdateLifetime / OTP map to session_lifetime, session_update_lifetime,
+// and session_2fa per the KasAuth documentation. Zero-valued optionals
+// are omitted from the encoded JSON so the server applies its defaults.
+type Request struct {
+	Login          string
+	AuthType       soap.AuthType
+	AuthData       string
+	Lifetime       int
+	UpdateLifetime *bool
+	OTP            string
+}
+
+const requestTemplate = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:tns="https://kasserver.com/">
+    <soapenv:Body>
+        <tns:KasAuth>
+            <Params>%s</Params>
+        </tns:KasAuth>
+    </soapenv:Body>
+</soapenv:Envelope>`
+
+// EncodeRequest writes a SOAP request envelope for a KasAuth call.
+func EncodeRequest(w io.Writer, r Request) error {
+	if r.Login == "" {
+		return errors.New("auth: Request.Login is required")
+	}
+	if r.AuthType == "" {
+		return errors.New("auth: Request.AuthType is required")
+	}
+	if r.AuthData == "" {
+		return errors.New("auth: Request.AuthData is required")
+	}
+	payload := map[string]any{
+		"kas_login":     r.Login,
+		"kas_auth_type": string(r.AuthType),
+		"kas_auth_data": r.AuthData,
+	}
+	if r.Lifetime > 0 {
+		payload["session_lifetime"] = r.Lifetime
+	}
+	if r.UpdateLifetime != nil {
+		if *r.UpdateLifetime {
+			payload["session_update_lifetime"] = "Y"
+		} else {
+			payload["session_update_lifetime"] = "N"
+		}
+	}
+	if r.OTP != "" {
+		payload["session_2fa"] = r.OTP
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("auth: marshal params: %w", err)
+	}
+	_, err = fmt.Fprintf(w, requestTemplate, body)
+	return err
+}
+
+// DecodeResponse parses a KasAuth SOAP envelope. On success it returns
+// the credential token; on a SOAP-ENV:Fault body it returns
+// *soap.FaultError so callers can wrap it into auth.Error.
+func DecodeResponse(r io.Reader) (string, error) {
+	dec := xml.NewDecoder(r)
+	for {
+		tok, err := dec.Token()
+		if err == io.EOF {
+			return "", errors.New("auth: empty document")
+		}
+		if err != nil {
+			return "", err
+		}
+		start, ok := tok.(xml.StartElement)
+		if !ok {
+			continue
+		}
+		if start.Name.Local == "Body" {
+			return decodeBody(dec, start)
+		}
+	}
+}
+
+func decodeBody(d *xml.Decoder, parent xml.StartElement) (string, error) {
+	for {
+		tok, err := d.Token()
+		if err != nil {
+			return "", err
+		}
+		switch t := tok.(type) {
+		case xml.StartElement:
+			switch t.Name.Local {
+			case "KasAuthResponse":
+				return decodeKasAuthResponse(d, t)
+			case "Fault":
+				fault, err := decodeFault(d, t)
+				if err != nil {
+					return "", err
+				}
+				return "", &soap.FaultError{Fault: *fault}
+			default:
+				if err := d.Skip(); err != nil {
+					return "", err
+				}
+			}
+		case xml.EndElement:
+			if t.Name == parent.Name {
+				return "", errors.New("auth: empty Body")
+			}
+		}
+	}
+}
+
+func decodeKasAuthResponse(d *xml.Decoder, parent xml.StartElement) (string, error) {
+	for {
+		tok, err := d.Token()
+		if err != nil {
+			return "", err
+		}
+		switch t := tok.(type) {
+		case xml.StartElement:
+			if t.Name.Local == "return" {
+				var s string
+				if err := d.DecodeElement(&s, &t); err != nil {
+					return "", err
+				}
+				if s == "" {
+					return "", errors.New("auth: empty <return> element")
+				}
+				return s, nil
+			}
+			if err := d.Skip(); err != nil {
+				return "", err
+			}
+		case xml.EndElement:
+			if t.Name == parent.Name {
+				return "", errors.New("auth: missing <return> element")
+			}
+		}
+	}
+}
+
+func decodeFault(d *xml.Decoder, parent xml.StartElement) (*soap.Fault, error) {
+	out := &soap.Fault{}
+	for {
+		tok, err := d.Token()
+		if err != nil {
+			return nil, err
+		}
+		switch t := tok.(type) {
+		case xml.StartElement:
+			var s string
+			if err := d.DecodeElement(&s, &t); err != nil {
+				return nil, err
+			}
+			switch t.Name.Local {
+			case "faultcode":
+				out.Code = s
+			case "faultstring":
+				out.String = s
+			case "faultactor":
+				out.Actor = s
+			case "detail":
+				out.Detail = s
+			}
+		case xml.EndElement:
+			if t.Name == parent.Name {
+				return out, nil
+			}
+		}
+	}
+}

--- a/internal/auth/codec_test.go
+++ b/internal/auth/codec_test.go
@@ -1,0 +1,140 @@
+package auth_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/chmmou/kasapi-cli/internal/auth"
+	"github.com/chmmou/kasapi-cli/internal/soap"
+)
+
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	dir := filepath.Dir(file)
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatalf("repo root not found from %q", file)
+		}
+		dir = parent
+	}
+}
+
+func loadFixture(t *testing.T, rel string) []byte {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join(repoRoot(t), "testdata", rel))
+	if err != nil {
+		t.Fatalf("load %s: %v", rel, err)
+	}
+	return b
+}
+
+func TestEncodeRequestRequiredFields(t *testing.T) {
+	cases := []auth.Request{
+		{AuthType: soap.AuthPlain, AuthData: "x"}, // missing Login
+		{Login: "w0", AuthData: "x"},              // missing AuthType
+		{Login: "w0", AuthType: soap.AuthPlain},   // missing AuthData
+	}
+	for i, r := range cases {
+		var buf bytes.Buffer
+		if err := auth.EncodeRequest(&buf, r); err == nil {
+			t.Errorf("case %d: expected error", i)
+		}
+	}
+}
+
+func TestEncodeRequestOptionalFields(t *testing.T) {
+	yes := true
+	r := auth.Request{
+		Login:          "w0000000",
+		AuthType:       soap.AuthPlain,
+		AuthData:       "secret",
+		Lifetime:       1800,
+		UpdateLifetime: &yes,
+		OTP:            "123456",
+	}
+	var buf bytes.Buffer
+	if err := auth.EncodeRequest(&buf, r); err != nil {
+		t.Fatalf("EncodeRequest: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "<tns:KasAuth>") {
+		t.Error("envelope missing <tns:KasAuth>")
+	}
+	// Extract JSON between <Params> and </Params> and round-trip it so
+	// we can assert on field presence without depending on key order.
+	start := strings.Index(out, "<Params>") + len("<Params>")
+	end := strings.Index(out, "</Params>")
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(out[start:end]), &payload); err != nil {
+		t.Fatalf("json: %v\npayload=%q", err, out[start:end])
+	}
+	for _, k := range []string{"kas_login", "kas_auth_type", "kas_auth_data",
+		"session_lifetime", "session_update_lifetime", "session_2fa"} {
+		if _, ok := payload[k]; !ok {
+			t.Errorf("payload missing %q: %v", k, payload)
+		}
+	}
+	if payload["session_update_lifetime"] != "Y" {
+		t.Errorf("session_update_lifetime = %v, want Y", payload["session_update_lifetime"])
+	}
+}
+
+func TestEncodeRequestOmitsZeroOptionals(t *testing.T) {
+	r := auth.Request{Login: "w0", AuthType: soap.AuthPlain, AuthData: "secret"}
+	var buf bytes.Buffer
+	if err := auth.EncodeRequest(&buf, r); err != nil {
+		t.Fatalf("EncodeRequest: %v", err)
+	}
+	out := buf.String()
+	for _, k := range []string{"session_lifetime", "session_update_lifetime", "session_2fa"} {
+		if strings.Contains(out, k) {
+			t.Errorf("payload should omit %q: %s", k, out)
+		}
+	}
+}
+
+func TestDecodeResponseSuccessFixture(t *testing.T) {
+	body := loadFixture(t, "session/add_session_response_success.xml")
+	tok, err := auth.DecodeResponse(bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("DecodeResponse: %v", err)
+	}
+	if tok != "01234567890abcdef0123456789abcdef0123456" {
+		t.Errorf("token = %q", tok)
+	}
+}
+
+func TestDecodeResponseFaultFixture(t *testing.T) {
+	body := loadFixture(t, "session/add_session_response_failed_otp_pin_incorrect.xml")
+	_, err := auth.DecodeResponse(bytes.NewReader(body))
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	var fe *soap.FaultError
+	if !errors.As(err, &fe) {
+		t.Fatalf("expected *soap.FaultError, got %T", err)
+	}
+	if fe.Fault.String != "otp_pin_incorrect" {
+		t.Errorf("fault = %q, want otp_pin_incorrect", fe.Fault.String)
+	}
+}
+
+func TestDecodeResponseEmptyDocument(t *testing.T) {
+	if _, err := auth.DecodeResponse(strings.NewReader("")); err == nil {
+		t.Fatal("expected error")
+	}
+}

--- a/internal/auth/doc.go
+++ b/internal/auth/doc.go
@@ -1,3 +1,18 @@
-// Package auth implements the KasAuth.php credential-token flow
-// (plain / session / 2FA). See issue #5.
+// Package auth implements the KasAuth.php credential-token flow.
+//
+// KasAuth differs from KasApi in two ways: the request element is
+// <tns:KasAuth> instead of <tns:KasApi>, and the success body is a bare
+// xsd:string carrying the 40-character credential token instead of the
+// ns2:Map response shape. Faults use the standard SOAP-ENV:Fault element
+// and are decoded by the soap package.
+//
+// Client.GetCredentialToken posts the auth request and returns the
+// token. Auth-specific faults surface as *Error with helpers
+// IsLoginFailed, IsLoginLocked, and IsOTPPinIncorrect.
+//
+// SessionTokenSource adapts the client to the api.TokenSource interface,
+// caching the token and refreshing it the next time api.Client observes
+// an auth failure and calls Invalidate.
+//
+// See issue #5.
 package auth

--- a/internal/auth/errors.go
+++ b/internal/auth/errors.go
@@ -1,0 +1,84 @@
+package auth
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/chmmou/kasapi-cli/internal/soap"
+)
+
+// Stable KasAuth fault codes that callers commonly branch on. The full
+// set of codes is open; new ones surface verbatim in Error.Code.
+const (
+	CodeLoginFailed     = "kas_login_failed"
+	CodeLoginLocked     = "kas_login_locked"
+	CodeOTPPinIncorrect = "otp_pin_incorrect"
+	CodeUnknownSession  = "unknown_session"
+	CodeGotNoLoginData  = "got_no_login_data"
+)
+
+// Error is the typed wrapper for a SOAP-ENV:Fault returned by KasAuth.
+// Login identifies the credential whose authentication failed; Code is
+// the stable KAS error string.
+type Error struct {
+	Code    string
+	Message string
+	Login   string
+
+	fault *soap.FaultError
+}
+
+func (e *Error) Error() string {
+	if e.Message != "" {
+		return fmt.Sprintf("kas-auth %s: %s: %s", e.Login, e.Code, e.Message)
+	}
+	return fmt.Sprintf("kas-auth %s: %s", e.Login, e.Code)
+}
+
+// Unwrap returns the underlying *soap.FaultError so errors.As can
+// recover the SOAP-level error if needed.
+func (e *Error) Unwrap() error { return e.fault }
+
+func newError(login string, fe *soap.FaultError) *Error {
+	return &Error{
+		Code:    fe.Fault.String,
+		Message: fe.Fault.Detail,
+		Login:   login,
+		fault:   fe,
+	}
+}
+
+func codeOf(err error) string {
+	var e *Error
+	if errors.As(err, &e) {
+		return e.Code
+	}
+	return ""
+}
+
+// IsCode reports whether err is an *Error with the given code.
+func IsCode(err error, code string) bool { return codeOf(err) == code }
+
+// IsLoginFailed reports whether err is the kas_login_failed fault.
+func IsLoginFailed(err error) bool { return IsCode(err, CodeLoginFailed) }
+
+// IsLoginLocked reports whether err is the kas_login_locked fault.
+func IsLoginLocked(err error) bool { return IsCode(err, CodeLoginLocked) }
+
+// IsOTPPinIncorrect reports whether err is the otp_pin_incorrect fault.
+func IsOTPPinIncorrect(err error) bool { return IsCode(err, CodeOTPPinIncorrect) }
+
+// IsUnknownSession reports whether err is the unknown_session fault,
+// returned when authenticating with kas_auth_type=session against a
+// stale or revoked token.
+func IsUnknownSession(err error) bool { return IsCode(err, CodeUnknownSession) }
+
+// AsError extracts an *Error from err, returning nil if err is not an
+// auth fault.
+func AsError(err error) *Error {
+	var e *Error
+	if errors.As(err, &e) {
+		return e
+	}
+	return nil
+}

--- a/internal/auth/source.go
+++ b/internal/auth/source.go
@@ -1,0 +1,53 @@
+package auth
+
+import (
+	"context"
+	"sync"
+
+	"github.com/chmmou/kasapi-cli/internal/soap"
+)
+
+// SessionTokenSource caches a credential token fetched via Client and
+// re-fetches it on demand. It implements api.TokenSource: api.Client
+// calls Credentials before every request and Invalidate after an auth
+// failure, which causes the next Credentials call to obtain a fresh
+// token via the underlying KasAuth client.
+//
+// SessionTokenSource is safe for concurrent use.
+type SessionTokenSource struct {
+	Client *Client
+
+	mu    sync.Mutex
+	token string
+}
+
+// NewSessionTokenSource returns a source that lazily fetches the token
+// on first use. The login it reports to api.Client is the one stored on
+// the underlying KasAuth client; the auth_type for KasApi calls is
+// always session, since the credential token is a session token.
+func NewSessionTokenSource(c *Client) *SessionTokenSource {
+	return &SessionTokenSource{Client: c}
+}
+
+// Credentials returns the cached token, fetching a new one if the
+// cache is empty.
+func (s *SessionTokenSource) Credentials(ctx context.Context) (string, string, soap.AuthType, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.token == "" {
+		t, err := s.Client.GetCredentialToken(ctx)
+		if err != nil {
+			return "", "", "", err
+		}
+		s.token = t
+	}
+	return s.Client.Login, s.token, soap.AuthSession, nil
+}
+
+// Invalidate clears the cached token so the next Credentials call
+// re-authenticates against KasAuth.
+func (s *SessionTokenSource) Invalidate() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.token = ""
+}


### PR DESCRIPTION
KasAuth.php flow on top of the shared transport.

- `auth.Client.GetCredentialToken(ctx)` posts the `tns:KasAuth` envelope and returns the 40-character credential token.
- `auth.Options{Lifetime, UpdateLifetime, OTP}` covers the optional `session_lifetime`, `session_update_lifetime` (Y/N), and 2FA `session_2fa` parameters.
- Faults surface as typed `*auth.Error` with helpers `IsLoginFailed`, `IsLoginLocked`, `IsOTPPinIncorrect`, `IsUnknownSession`.
- `SessionTokenSource` implements `api.TokenSource`: lazy fetch + cache, re-fetch on `Invalidate` so `api.Client` refreshes transparently after `no_auth` / `unknown_session`.

Closes #5.