### PR TITLE
refactor: share Fault decoder via soap.DecodeFault

### DIFF
--- a/internal/auth/codec.go
+++ b/internal/auth/codec.go
@@ -104,7 +104,7 @@ func decodeBody(d *xml.Decoder, parent xml.StartElement) (string, error) {
 			case "KasAuthResponse":
 				return decodeKasAuthResponse(d, t)
 			case "Fault":
-				fault, err := decodeFault(d, t)
+				fault, err := soap.DecodeFault(d, t)
 				if err != nil {
 					return "", err
 				}
@@ -146,37 +146,6 @@ func decodeKasAuthResponse(d *xml.Decoder, parent xml.StartElement) (string, err
 		case xml.EndElement:
 			if t.Name == parent.Name {
 				return "", errors.New("auth: missing <return> element")
-			}
-		}
-	}
-}
-
-func decodeFault(d *xml.Decoder, parent xml.StartElement) (*soap.Fault, error) {
-	out := &soap.Fault{}
-	for {
-		tok, err := d.Token()
-		if err != nil {
-			return nil, err
-		}
-		switch t := tok.(type) {
-		case xml.StartElement:
-			var s string
-			if err := d.DecodeElement(&s, &t); err != nil {
-				return nil, err
-			}
-			switch t.Name.Local {
-			case "faultcode":
-				out.Code = s
-			case "faultstring":
-				out.String = s
-			case "faultactor":
-				out.Actor = s
-			case "detail":
-				out.Detail = s
-			}
-		case xml.EndElement:
-			if t.Name == parent.Name {
-				return out, nil
 			}
 		}
 	}

--- a/internal/soap/envelope.go
+++ b/internal/soap/envelope.go
@@ -79,7 +79,7 @@ func decodeBody(d *xml.Decoder, parent xml.StartElement) (*Response, error) {
 			case "KasApiResponse":
 				return decodeKasApiResponse(d, t)
 			case "Fault":
-				fault, err := decodeFault(d, t)
+				fault, err := DecodeFault(d, t)
 				if err != nil {
 					return nil, err
 				}
@@ -164,7 +164,11 @@ func buildResponseBody(v Value) (ResponseBody, error) {
 	return out, nil
 }
 
-func decodeFault(d *xml.Decoder, parent xml.StartElement) (*Fault, error) {
+// DecodeFault parses a <SOAP-ENV:Fault> element. The decoder must be
+// positioned just past the start element, which is passed as parent so
+// the function knows when to stop. It is exported so other packages
+// (e.g. auth) can decode KAS faults from their own envelope layouts.
+func DecodeFault(d *xml.Decoder, parent xml.StartElement) (*Fault, error) {
 	out := &Fault{}
 	for {
 		tok, err := d.Token()


### PR DESCRIPTION
## Summary

Promote `soap.decodeFault` to exported `soap.DecodeFault` and drop the near-identical copy in `internal/auth/codec.go`. Both KasApi and KasAuth envelopes carry the same `SOAP-ENV:Fault` shape, so the auth codec now delegates fault parsing to `soap`.

No behaviour change.