### PR TITLE
feat: CLI scaffold with cobra root, output renderers, exit codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `internal/cli` CLI scaffold built on [spf13/cobra](https://github.com/spf13/cobra):
+  `NewRootCmd()` returns the `kasapi-cli` root command with persistent
+  global flags `--config`, `--profile`, `--login`, `--auth-data`,
+  `--auth-type`, `--output`, `--no-color`, `--verbose`, `--yes`, plus the
+  built-in `--help` and `--version`. Output renderers (`json`, `yaml`,
+  `table`) live behind a single `Render(w, format, v)` entry point;
+  `--output=table` requires the value to implement the `Tabular`
+  interface. A `Confirm(in, out, prompt)` helper covers the `[y/N]`
+  prompt for future destructive write commands. `ExitError`,
+  `UserError(...)`, `APIError(...)`, and `CodeFor(err)` translate failures
+  to the documented exit codes (`0` ok, `1` user error, `2` API error);
+  flag-parsing errors are routed through `UserError`. The binary is
+  intentionally without subcommands until #7 — `kasapi-cli` prints help
+  and `kasapi-cli --version` prints the build banner. Adds the
+  `goccy/go-yaml` (active fork replacing the archived `gopkg.in/yaml.v3`)
+  and `spf13/cobra` dependencies. (Closes #12.)
 - `internal/auth` KasAuth.php credential-token client: separate codec
   (`tns:KasAuth` envelope, bare `xsd:string` token in `<return>`),
   `Client.GetCredentialToken(ctx)` returning the 40-character token,

--- a/cmd/kasapi-cli/main.go
+++ b/cmd/kasapi-cli/main.go
@@ -6,22 +6,16 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 	"os"
 
-	"github.com/chmmou/kasapi-cli/internal/version"
+	"github.com/chmmou/kasapi-cli/internal/cli"
 )
 
 func main() {
-	showVersion := flag.Bool("version", false, "print version and exit")
-	flag.Parse()
-
-	if *showVersion {
-		fmt.Println(version.String())
-		return
+	root, _ := cli.NewRootCmd()
+	if err := root.Execute(); err != nil {
+		fmt.Fprintln(os.Stderr, "kasapi-cli:", err)
+		os.Exit(cli.CodeFor(err))
 	}
-
-	fmt.Fprintln(os.Stderr, "kasapi-cli: no subcommand wired up yet (see issues #2-#13)")
-	os.Exit(1)
 }

--- a/docs/go/PATTERNS.md
+++ b/docs/go/PATTERNS.md
@@ -46,8 +46,9 @@ Patterns here draw from Effective Go, Uber's Go Style Guide, Go Code Review Comm
 - Golden files only when output is stable and reviewed; keep them small and checked in.
 
 ## CLI/Tools Patterns
-- Use the standard `flag` package or minimal wrappers; avoid complex global state.
-- Provide `-help` output and reasonable defaults; exit codes should reflect success/failure.
+- For small, single-purpose tools the standard `flag` package is enough; avoid complex global state.
+- For multi-resource CLIs that follow a `<binary> <resource> <verb>` scheme (e.g. kasapi-cli, hcloud), use [spf13/cobra](https://github.com/spf13/cobra). Build the root command in an `internal/cli` package; bind global flags to a `RootOptions` struct that subcommands read.
+- Provide `--help` output and reasonable defaults; exit codes should reflect success/failure (e.g. `0` ok, `1` user error, `2` API/runtime error).
 
 ## Library Selection (Awesome Go)
 - Use the Awesome Go catalog to find libraries by category (web, database, testing, logging, crypto, etc.).

--- a/go.mod
+++ b/go.mod
@@ -3,3 +3,10 @@ module github.com/chmmou/kasapi-cli
 go 1.23
 
 require github.com/BurntSushi/toml v1.6.0
+
+require (
+	github.com/goccy/go-yaml v1.19.2 // indirect
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/spf13/cobra v1.10.2 // indirect
+	github.com/spf13/pflag v1.0.9 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,14 @@
 github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
 github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
+github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/goccy/go-yaml v1.19.2 h1:PmFC1S6h8ljIz6gMRBopkjP1TVT7xuwrButHID66PoM=
+github.com/goccy/go-yaml v1.19.2/go.mod h1:XBurs7gK8ATbW4ZPGKgcbrY1Br56PdM69F7LkFRi1kA=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
+github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
+github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=
+github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/internal/cli/confirm.go
+++ b/internal/cli/confirm.go
@@ -1,0 +1,32 @@
+package cli
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"strings"
+)
+
+// Confirm prompts the user on out with prompt + " [y/N]: " and reads a
+// reply from in. It returns true only on an explicit "y" or "yes"
+// (case-insensitive); empty input or any other string returns false.
+//
+// Confirm is intended for destructive write operations (#13). When the
+// global --yes flag is set, callers should skip the prompt entirely
+// rather than feeding the answer through this helper.
+func Confirm(in io.Reader, out io.Writer, prompt string) (bool, error) {
+	if _, err := fmt.Fprintf(out, "%s [y/N]: ", prompt); err != nil {
+		return false, err
+	}
+	r := bufio.NewReader(in)
+	line, err := r.ReadString('\n')
+	if err != nil && err != io.EOF {
+		return false, err
+	}
+	switch strings.ToLower(strings.TrimSpace(line)) {
+	case "y", "yes":
+		return true, nil
+	default:
+		return false, nil
+	}
+}

--- a/internal/cli/confirm_test.go
+++ b/internal/cli/confirm_test.go
@@ -1,0 +1,42 @@
+package cli_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/chmmou/kasapi-cli/internal/cli"
+)
+
+func TestConfirm(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		{"y\n", true},
+		{"Y\n", true},
+		{"yes\n", true},
+		{"YES\n", true},
+		{"  yes  \n", true},
+		{"n\n", false},
+		{"no\n", false},
+		{"\n", false},
+		{"maybe\n", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		var out bytes.Buffer
+		got, err := cli.Confirm(strings.NewReader(tt.input), &out, "delete?")
+		if err != nil {
+			t.Errorf("Confirm(%q) unexpected error: %v", tt.input, err)
+			continue
+		}
+		if got != tt.want {
+			t.Errorf("Confirm(%q) = %v, want %v", tt.input, got, tt.want)
+		}
+		if !strings.Contains(out.String(), "delete? [y/N]:") {
+			t.Errorf("Confirm(%q) prompt missing: %q", tt.input, out.String())
+		}
+	}
+}

--- a/internal/cli/doc.go
+++ b/internal/cli/doc.go
@@ -1,3 +1,10 @@
-// Package cli holds the root command, global flags, and shared output
-// renderers (json / yaml / table). See issue #12.
+// Package cli holds the kasapi-cli root command, global flags, and the
+// shared output renderers (json / yaml / table).
+//
+// The package is the outermost adapter on top of internal/api, internal/auth
+// and internal/config: subcommands (added with #7+) translate flags and args
+// into use-case calls and feed the typed result to a Renderer chosen by the
+// global --output flag.
+//
+// See issue #12.
 package cli

--- a/internal/cli/errors.go
+++ b/internal/cli/errors.go
@@ -1,0 +1,60 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+)
+
+// Exit codes used by the kasapi-cli binary. They follow the convention
+// declared in issue #12: 0 success, 1 user error (bad flags, bad config,
+// missing file), 2 API error (KAS fault, network failure).
+const (
+	ExitOK        = 0
+	ExitUserError = 1
+	ExitAPIError  = 2
+)
+
+// ExitError carries an exit code alongside the underlying error so the
+// binary entry point can translate failures to the documented codes.
+// Use UserError or APIError to construct one; falling through with a
+// raw error from a subcommand maps to ExitAPIError by convention.
+type ExitError struct {
+	Code int
+	Err  error
+}
+
+func (e *ExitError) Error() string { return e.Err.Error() }
+
+func (e *ExitError) Unwrap() error { return e.Err }
+
+// UserError wraps err as an ExitError with ExitUserError. msg is
+// optional; when non-empty it is prepended to the underlying message.
+func UserError(err error, msg string) *ExitError {
+	return &ExitError{Code: ExitUserError, Err: prefix(msg, err)}
+}
+
+// APIError wraps err as an ExitError with ExitAPIError.
+func APIError(err error, msg string) *ExitError {
+	return &ExitError{Code: ExitAPIError, Err: prefix(msg, err)}
+}
+
+// CodeFor returns the documented exit code for err. *ExitError values
+// carry their own code; any other non-nil error defaults to ExitAPIError
+// since user-input validation should always produce an *ExitError.
+func CodeFor(err error) int {
+	if err == nil {
+		return ExitOK
+	}
+	var ee *ExitError
+	if errors.As(err, &ee) {
+		return ee.Code
+	}
+	return ExitAPIError
+}
+
+func prefix(msg string, err error) error {
+	if msg == "" {
+		return err
+	}
+	return fmt.Errorf("%s: %w", msg, err)
+}

--- a/internal/cli/errors_test.go
+++ b/internal/cli/errors_test.go
@@ -1,0 +1,59 @@
+package cli_test
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/chmmou/kasapi-cli/internal/cli"
+)
+
+func TestExitErrorWraps(t *testing.T) {
+	t.Parallel()
+	base := errors.New("disk full")
+	ee := cli.UserError(base, "open config")
+	if !errors.Is(ee, base) {
+		t.Error("UserError should wrap the inner error so errors.Is works")
+	}
+	if got, want := ee.Error(), "open config: disk full"; got != want {
+		t.Errorf("Error() = %q, want %q", got, want)
+	}
+	if ee.Code != cli.ExitUserError {
+		t.Errorf("Code = %d, want %d", ee.Code, cli.ExitUserError)
+	}
+}
+
+func TestUserErrorWithoutPrefix(t *testing.T) {
+	t.Parallel()
+	ee := cli.UserError(errors.New("bad"), "")
+	if got, want := ee.Error(), "bad"; got != want {
+		t.Errorf("Error() = %q, want %q", got, want)
+	}
+}
+
+func TestAPIErrorCode(t *testing.T) {
+	t.Parallel()
+	ee := cli.APIError(errors.New("kas-api fault"), "call accounts.get")
+	if ee.Code != cli.ExitAPIError {
+		t.Errorf("Code = %d, want %d", ee.Code, cli.ExitAPIError)
+	}
+}
+
+func TestCodeFor(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		err  error
+		want int
+	}{
+		{nil, cli.ExitOK},
+		{cli.UserError(errors.New("x"), ""), cli.ExitUserError},
+		{cli.APIError(errors.New("x"), ""), cli.ExitAPIError},
+		{fmt.Errorf("wrapped: %w", cli.UserError(errors.New("x"), "")), cli.ExitUserError},
+		{errors.New("plain"), cli.ExitAPIError},
+	}
+	for _, tt := range tests {
+		if got := cli.CodeFor(tt.err); got != tt.want {
+			t.Errorf("CodeFor(%v) = %d, want %d", tt.err, got, tt.want)
+		}
+	}
+}

--- a/internal/cli/output.go
+++ b/internal/cli/output.go
@@ -1,0 +1,111 @@
+package cli
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/goccy/go-yaml"
+)
+
+// Format identifies an output renderer chosen via --output.
+type Format string
+
+// Output formats accepted by --output. AllFormats is the canonical
+// ordered listing; DefaultFormat is what an unset --output resolves to.
+const (
+	FormatJSON  Format = "json"
+	FormatYAML  Format = "yaml"
+	FormatTable Format = "table"
+)
+
+// DefaultFormat is what --output defaults to when the flag is unset.
+const DefaultFormat = FormatTable
+
+// AllFormats is the canonical, ordered list of accepted --output values.
+// Used by the root command help text and validation.
+var AllFormats = []Format{FormatJSON, FormatYAML, FormatTable}
+
+// ParseFormat returns the Format matching s or an error listing valid
+// values. The empty string maps to DefaultFormat.
+func ParseFormat(s string) (Format, error) {
+	if s == "" {
+		return DefaultFormat, nil
+	}
+	for _, f := range AllFormats {
+		if string(f) == s {
+			return f, nil
+		}
+	}
+	names := make([]string, len(AllFormats))
+	for i, f := range AllFormats {
+		names[i] = string(f)
+	}
+	return "", fmt.Errorf("invalid output format %q (want one of %s)", s, strings.Join(names, ", "))
+}
+
+// Tabular is implemented by values that can render themselves as a
+// fixed-column table. Subcommand result types satisfy it so --output=table
+// works without per-renderer special cases.
+type Tabular interface {
+	TableHeaders() []string
+	TableRows() [][]string
+}
+
+// Render writes v to w in the requested format. For FormatTable the
+// value must implement Tabular; otherwise Render returns an error so
+// callers can surface it as a user error.
+func Render(w io.Writer, format Format, v any) error {
+	switch format {
+	case FormatJSON:
+		return renderJSON(w, v)
+	case FormatYAML:
+		return renderYAML(w, v)
+	case FormatTable:
+		return renderTable(w, v)
+	default:
+		return fmt.Errorf("cli: unknown output format %q", format)
+	}
+}
+
+func renderJSON(w io.Writer, v any) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(v)
+}
+
+func renderYAML(w io.Writer, v any) error {
+	out, err := yaml.Marshal(v)
+	if err != nil {
+		return err
+	}
+	_, err = w.Write(out)
+	return err
+}
+
+// ErrTableNotSupported is returned by Render when --output=table is
+// requested for a value that does not implement Tabular.
+var ErrTableNotSupported = errors.New("table output not supported for this command (try --output=json or --output=yaml)")
+
+func renderTable(w io.Writer, v any) error {
+	t, ok := v.(Tabular)
+	if !ok {
+		return ErrTableNotSupported
+	}
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	headers := t.TableHeaders()
+	if len(headers) > 0 {
+		if _, err := fmt.Fprintln(tw, strings.Join(headers, "\t")); err != nil {
+			return err
+		}
+	}
+	for _, row := range t.TableRows() {
+		if _, err := fmt.Fprintln(tw, strings.Join(row, "\t")); err != nil {
+			return err
+		}
+	}
+	return tw.Flush()
+}

--- a/internal/cli/output_test.go
+++ b/internal/cli/output_test.go
@@ -1,0 +1,101 @@
+package cli_test
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/chmmou/kasapi-cli/internal/cli"
+)
+
+type sample struct {
+	Name  string `json:"name" yaml:"name"`
+	Count int    `json:"count" yaml:"count"`
+}
+
+type sampleTable struct {
+	rows [][]string
+}
+
+func (sampleTable) TableHeaders() []string  { return []string{"Name", "Count"} }
+func (s sampleTable) TableRows() [][]string { return s.rows }
+
+func TestParseFormat(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		in      string
+		want    cli.Format
+		wantErr bool
+	}{
+		{"", cli.DefaultFormat, false},
+		{"json", cli.FormatJSON, false},
+		{"yaml", cli.FormatYAML, false},
+		{"table", cli.FormatTable, false},
+		{"JSON", "", true},
+		{"xml", "", true},
+	}
+	for _, tt := range tests {
+		got, err := cli.ParseFormat(tt.in)
+		if tt.wantErr {
+			if err == nil {
+				t.Errorf("ParseFormat(%q): want error, got %q", tt.in, got)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("ParseFormat(%q): unexpected error: %v", tt.in, err)
+		}
+		if got != tt.want {
+			t.Errorf("ParseFormat(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestRenderJSON(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	if err := cli.Render(&buf, cli.FormatJSON, sample{Name: "alpha", Count: 7}); err != nil {
+		t.Fatal(err)
+	}
+	got := buf.String()
+	if !strings.Contains(got, `"name": "alpha"`) || !strings.Contains(got, `"count": 7`) {
+		t.Errorf("json output missing fields: %q", got)
+	}
+}
+
+func TestRenderYAML(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	if err := cli.Render(&buf, cli.FormatYAML, sample{Name: "beta", Count: 9}); err != nil {
+		t.Fatal(err)
+	}
+	got := buf.String()
+	if !strings.Contains(got, "name: beta") || !strings.Contains(got, "count: 9") {
+		t.Errorf("yaml output missing fields: %q", got)
+	}
+}
+
+func TestRenderTableTabular(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	tbl := sampleTable{rows: [][]string{{"a", "1"}, {"bb", "22"}}}
+	if err := cli.Render(&buf, cli.FormatTable, tbl); err != nil {
+		t.Fatal(err)
+	}
+	got := buf.String()
+	for _, want := range []string{"Name", "Count", "a", "1", "bb", "22"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("table output missing %q: %q", want, got)
+		}
+	}
+}
+
+func TestRenderTableNonTabularReturnsError(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	err := cli.Render(&buf, cli.FormatTable, sample{Name: "x", Count: 1})
+	if !errors.Is(err, cli.ErrTableNotSupported) {
+		t.Fatalf("want ErrTableNotSupported, got %v", err)
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -1,0 +1,90 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/chmmou/kasapi-cli/internal/version"
+)
+
+// RootOptions captures the values bound to the root command's
+// persistent flags. Subcommands read it to obtain credentials,
+// configuration paths, and the chosen output format.
+//
+// Output is parsed from the raw --output string in PersistentPreRunE so
+// invalid values are rejected before any subcommand runs.
+type RootOptions struct {
+	ConfigPath string
+	Profile    string
+	Login      string
+	AuthData   string
+	AuthType   string
+
+	OutputRaw string
+	Output    Format
+
+	NoColor bool
+	Verbose bool
+	Yes     bool
+}
+
+// NewRootCmd builds the kasapi-cli root command and registers all
+// persistent global flags on it. Subcommands are registered by callers
+// (cmd/kasapi-cli) so the cli package does not import every resource
+// package directly.
+//
+// The returned *RootOptions is updated in place by cobra as flags are
+// parsed; subcommands receive it through closure capture or by reading
+// it back from cmd.Context().
+func NewRootCmd() (*cobra.Command, *RootOptions) {
+	opts := &RootOptions{}
+	cmd := &cobra.Command{
+		Use:           "kasapi-cli",
+		Short:         "Command-line client for the All-Inkl KAS API",
+		Long:          "kasapi-cli is a command-line client for the All-Inkl Kunden-Administrations-System SOAP API.",
+		Version:       version.String(),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
+			f, err := ParseFormat(opts.OutputRaw)
+			if err != nil {
+				return UserError(err, "")
+			}
+			opts.Output = f
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return cmd.Help()
+		},
+	}
+
+	cmd.SetVersionTemplate("{{.Version}}\n")
+	cmd.SetFlagErrorFunc(func(_ *cobra.Command, err error) error {
+		return UserError(err, "")
+	})
+
+	pf := cmd.PersistentFlags()
+	pf.StringVar(&opts.ConfigPath, "config", "", "path to the kasapi-cli config file (overrides the default location)")
+	pf.StringVar(&opts.Profile, "profile", "", "profile to select from the config file (overrides default_profile)")
+	pf.StringVar(&opts.Login, "login", "", "KAS login (overrides config and KAS_LOGIN)")
+	pf.StringVar(&opts.AuthData, "auth-data", "", "KAS auth data (overrides config and KAS_AUTHDATA)")
+	pf.StringVar(&opts.AuthType, "auth-type", "", "KAS auth type, plain or session (overrides config and KAS_AUTHTYPE)")
+	pf.StringVarP(&opts.OutputRaw, "output", "o", "", fmt.Sprintf("output format: %s (default %s)", joinFormats(), DefaultFormat))
+	pf.BoolVar(&opts.NoColor, "no-color", false, "disable coloured output")
+	pf.BoolVarP(&opts.Verbose, "verbose", "v", false, "enable verbose logging on stderr")
+	pf.BoolVarP(&opts.Yes, "yes", "y", false, "skip confirmation prompts on destructive operations")
+
+	return cmd, opts
+}
+
+func joinFormats() string {
+	out := ""
+	for i, f := range AllFormats {
+		if i > 0 {
+			out += "|"
+		}
+		out += string(f)
+	}
+	return out
+}

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -1,0 +1,117 @@
+package cli_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/chmmou/kasapi-cli/internal/cli"
+)
+
+func TestRootHelpListsAllPersistentFlags(t *testing.T) {
+	t.Parallel()
+	root, _ := cli.NewRootCmd()
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&out)
+	root.SetArgs([]string{"--help"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("Execute --help: %v", err)
+	}
+	got := out.String()
+	for _, flag := range []string{
+		"--config", "--profile", "--login", "--auth-data", "--auth-type",
+		"--output", "--no-color", "--verbose", "--yes",
+	} {
+		if !strings.Contains(got, flag) {
+			t.Errorf("help is missing flag %s; got:\n%s", flag, got)
+		}
+	}
+}
+
+func TestRootBindsFlagsToOptions(t *testing.T) {
+	t.Parallel()
+	root, opts := cli.NewRootCmd()
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&out)
+	root.SetArgs([]string{
+		"--config", "/tmp/cfg.toml",
+		"--profile", "prod",
+		"--login", "w012345",
+		"--auth-data", "secret",
+		"--auth-type", "session",
+		"--output", "json",
+		"--no-color",
+		"--verbose",
+		"--yes",
+	})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if opts.ConfigPath != "/tmp/cfg.toml" {
+		t.Errorf("ConfigPath = %q", opts.ConfigPath)
+	}
+	if opts.Profile != "prod" {
+		t.Errorf("Profile = %q", opts.Profile)
+	}
+	if opts.Login != "w012345" || opts.AuthData != "secret" || opts.AuthType != "session" {
+		t.Errorf("credential overrides not bound: %+v", opts)
+	}
+	if opts.Output != cli.FormatJSON {
+		t.Errorf("Output = %q, want json", opts.Output)
+	}
+	if !opts.NoColor || !opts.Verbose || !opts.Yes {
+		t.Errorf("bool flags not bound: NoColor=%v Verbose=%v Yes=%v", opts.NoColor, opts.Verbose, opts.Yes)
+	}
+}
+
+func TestRootRejectsInvalidOutputFormat(t *testing.T) {
+	t.Parallel()
+	root, _ := cli.NewRootCmd()
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&out)
+	root.SetArgs([]string{"--output", "xml"})
+	err := root.Execute()
+	if err == nil {
+		t.Fatal("Execute --output xml: want error, got nil")
+	}
+	if cli.CodeFor(err) != cli.ExitUserError {
+		t.Errorf("invalid --output should map to ExitUserError, got %d", cli.CodeFor(err))
+	}
+	if !strings.Contains(err.Error(), "invalid output format") {
+		t.Errorf("error message: %q", err.Error())
+	}
+}
+
+func TestRootRejectsUnknownFlag(t *testing.T) {
+	t.Parallel()
+	root, _ := cli.NewRootCmd()
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&out)
+	root.SetArgs([]string{"--frobnicate"})
+	err := root.Execute()
+	if err == nil {
+		t.Fatal("Execute --frobnicate: want error, got nil")
+	}
+	if cli.CodeFor(err) != cli.ExitUserError {
+		t.Errorf("unknown flag should map to ExitUserError, got %d", cli.CodeFor(err))
+	}
+}
+
+func TestRootDefaultOutputIsTable(t *testing.T) {
+	t.Parallel()
+	root, opts := cli.NewRootCmd()
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&out)
+	root.SetArgs(nil)
+	if err := root.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if opts.Output != cli.FormatTable {
+		t.Errorf("default Output = %q, want %q", opts.Output, cli.FormatTable)
+	}
+}


### PR DESCRIPTION
## Summary

Lay down the kasapi-cli root command on top of spf13/cobra with the persistent global flags, output renderers, confirmation helper, and exit-code mapping listed in #12. The binary intentionally stays subcommand-less — `kasapi-cli` prints help, `kasapi-cli --version` prints the build banner. First real subcommands land with #7.

- Globals: `--config`, `--profile`, `--login`, `--auth-data`, `--auth-type`, `--output`, `--no-color`, `--verbose`, `--yes`.
- `Render(w, format, v)` for json / yaml / table; table requires a `Tabular` implementation.
- `Confirm(in, out, prompt)` reserved for destructive write commands.
- `ExitError` + `CodeFor(err)` map flag errors to exit 1, API errors to exit 2.
- Adds `spf13/cobra` and `goccy/go-yaml` (active replacement for archived `gopkg.in/yaml.v3`) and updates `docs/go/PATTERNS.md` to allow cobra for multi-resource CLIs.

Closes #12.