### PR TITLE
feat: account/server read modules with cli.BuildAPIClient wiring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `internal/account` and `internal/server` read modules with the first
+  end-to-end CLI subcommands: `kasapi-cli accounts list` (`get_accounts`),
+  `kasapi-cli accounts get` (`get_accountsettings`), `kasapi-cli accounts
+  resources` (`get_accountresources`), and `kasapi-cli server info`
+  (`get_server_information`). Domain types `Account`, `AccountSettings`
+  (with SSH fingerprints, user_prefs, direct-link flags), `AccountResources`
+  / `ResourceQuota`, and `Service` / `ServiceList` decode the KAS Map/Array
+  payloads into typed Go values; `ResourceQuota.Max == -1` is rendered as
+  `∞` in the table view to match the documented "unlimited" sentinel.
+  Mapping tests run against the shipped `testdata/account/get_*_response_success.xml`
+  fixtures. `cli.BuildAPIClient(opts)` is the new wiring helper that reads
+  config + env + flags, picks `api.StaticTokenSource` for `auth_type=plain`
+  and `auth.SessionTokenSource` for `auth_type=session`, and returns an
+  `*api.Client` that subcommands consume. (Closes #7.)
 - `internal/cli` CLI scaffold built on [spf13/cobra](https://github.com/spf13/cobra):
   `NewRootCmd()` returns the `kasapi-cli` root command with persistent
   global flags `--config`, `--profile`, `--login`, `--auth-data`,

--- a/cmd/kasapi-cli/main.go
+++ b/cmd/kasapi-cli/main.go
@@ -13,7 +13,11 @@ import (
 )
 
 func main() {
-	root, _ := cli.NewRootCmd()
+	root, opts := cli.NewRootCmd()
+	root.AddCommand(
+		cli.NewAccountCmd(opts),
+		cli.NewServerCmd(opts),
+	)
 	if err := root.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, "kasapi-cli:", err)
 		os.Exit(cli.CodeFor(err))

--- a/internal/account/account.go
+++ b/internal/account/account.go
@@ -1,0 +1,134 @@
+package account
+
+// Account is one row from get_accounts. The KAS API returns every field
+// as xsd:string, including the numeric quotas and the Y/N flags; this
+// package parses the obvious numerics into ints/floats but keeps Y/N
+// flags as strings since some fields (account_2fa) accept "inherited"
+// alongside Y and N.
+type Account struct {
+	Login            string  `json:"account_login" yaml:"account_login"`
+	Password         string  `json:"account_password" yaml:"account_password"`
+	MaxAccount       int     `json:"max_account" yaml:"max_account"`
+	MaxDomain        int     `json:"max_domain" yaml:"max_domain"`
+	MaxSubdomain     int     `json:"max_subdomain" yaml:"max_subdomain"`
+	MaxWebspace      int     `json:"max_webspace" yaml:"max_webspace"`
+	MaxMailAccount   int     `json:"max_mail_account" yaml:"max_mail_account"`
+	MaxMailForward   int     `json:"max_mail_forward" yaml:"max_mail_forward"`
+	MaxMailList      int     `json:"max_mail_list" yaml:"max_mail_list"`
+	MaxDatabases     int     `json:"max_databases" yaml:"max_databases"`
+	MaxFTPUser       int     `json:"max_ftpuser" yaml:"max_ftpuser"`
+	MaxSambaUser     int     `json:"max_sambauser" yaml:"max_sambauser"`
+	MaxCronjobs      int     `json:"max_cronjobs" yaml:"max_cronjobs"`
+	MaxWBK           int     `json:"max_wbk" yaml:"max_wbk"`
+	InstHtaccess     string  `json:"inst_htaccess" yaml:"inst_htaccess"`
+	InstFPSE         string  `json:"inst_fpse" yaml:"inst_fpse"`
+	InstSoftware     string  `json:"inst_software" yaml:"inst_software"`
+	KASAccessForbid  string  `json:"kas_access_forbidden" yaml:"kas_access_forbidden"`
+	Logging          string  `json:"logging" yaml:"logging"`
+	Statistic        string  `json:"statistic" yaml:"statistic"`
+	Logage           int     `json:"logage" yaml:"logage"`
+	ShowPassword     string  `json:"show_password" yaml:"show_password"`
+	DNSSettings      string  `json:"dns_settings" yaml:"dns_settings"`
+	ShowDirectLinks  int     `json:"show_direct_links" yaml:"show_direct_links"`
+	SSHAccess        string  `json:"ssh_access" yaml:"ssh_access"`
+	UsedAccountSpace float64 `json:"used_account_space" yaml:"used_account_space"`
+	Account2FA       string  `json:"account_2fa" yaml:"account_2fa"`
+	// Account2FAInherited is only present on superuser/main-login responses.
+	Account2FAInherited         string `json:"account_2fa_inherited,omitempty" yaml:"account_2fa_inherited,omitempty"`
+	ShowDirectLinksWBK          string `json:"show_direct_links_wbk" yaml:"show_direct_links_wbk"`
+	ShowDirectLinksSambausers   string `json:"show_direct_links_sambausers" yaml:"show_direct_links_sambausers"`
+	ShowDirectLinksAccounts     string `json:"show_direct_links_accounts" yaml:"show_direct_links_accounts"`
+	ShowDirectLinksMailaccounts string `json:"show_direct_links_mailaccounts" yaml:"show_direct_links_mailaccounts"`
+	ShowDirectLinksFTPUser      string `json:"show_direct_links_ftpuser" yaml:"show_direct_links_ftpuser"`
+	ShowDirectLinksDatabases    string `json:"show_direct_links_databases" yaml:"show_direct_links_databases"`
+	AccountComment              string `json:"account_comment" yaml:"account_comment"`
+	AccountContactMail          string `json:"account_contact_mail" yaml:"account_contact_mail"`
+	InProgress                  string `json:"in_progress" yaml:"in_progress"`
+}
+
+// AccountSettings is the payload of get_accountsettings, which returns
+// the settings for the authenticated account only. Most fields overlap
+// with Account but settings carries SSH keys and user_prefs that are
+// not part of the get_accounts list view.
+type AccountSettings struct {
+	Login              string                 `json:"account_login" yaml:"account_login"`
+	AccountComment     string                 `json:"account_comment" yaml:"account_comment"`
+	AccountContactMail string                 `json:"account_contact_mail" yaml:"account_contact_mail"`
+	IsSuperuser        string                 `json:"is_superuser" yaml:"is_superuser"`
+	AccountPassword    string                 `json:"account_password" yaml:"account_password"`
+	ShowPassword       string                 `json:"show_password" yaml:"show_password"`
+	Logging            string                 `json:"logging" yaml:"logging"`
+	Logage             int                    `json:"logage" yaml:"logage"`
+	Statistic          string                 `json:"statistic" yaml:"statistic"`
+	DNSSettings        string                 `json:"dns_settings" yaml:"dns_settings"`
+	InstHtaccess       string                 `json:"inst_htaccess" yaml:"inst_htaccess"`
+	InstFPSE           string                 `json:"inst_fpse" yaml:"inst_fpse"`
+	InstSoftware       string                 `json:"inst_software" yaml:"inst_software"`
+	SSHAccess          string                 `json:"ssh_access" yaml:"ssh_access"`
+	SSHKeys            string                 `json:"ssh_keys" yaml:"ssh_keys"`
+	SSHFingerprints    map[string]Fingerprint `json:"ssh_fingerprints" yaml:"ssh_fingerprints"`
+	SSHPHPVersion      string                 `json:"ssh_php_version" yaml:"ssh_php_version"`
+	Server             string                 `json:"server" yaml:"server"`
+	InProgress         string                 `json:"in_progress" yaml:"in_progress"`
+	ShowDirectLinks    DirectLinkPrefs        `json:"show_direct_links" yaml:"show_direct_links"`
+	Account2FA         string                 `json:"account_2fa" yaml:"account_2fa"`
+	Account2FAInherit  string                 `json:"account_2fa_inherited,omitempty" yaml:"account_2fa_inherited,omitempty"`
+	UserPrefs          UserPrefs              `json:"user_prefs" yaml:"user_prefs"`
+}
+
+// Fingerprint holds the per-algorithm SSH host-key fingerprints
+// returned under settings.ssh_fingerprints[<algo>].
+type Fingerprint struct {
+	MD5    string `json:"md5" yaml:"md5"`
+	SHA256 string `json:"sha256" yaml:"sha256"`
+}
+
+// DirectLinkPrefs groups the show_direct_links_* flags from settings.
+type DirectLinkPrefs struct {
+	WBK          string `json:"wbk" yaml:"wbk"`
+	Sambausers   string `json:"sambausers" yaml:"sambausers"`
+	Accounts     string `json:"accounts" yaml:"accounts"`
+	Mailaccounts string `json:"mailaccounts" yaml:"mailaccounts"`
+	FTPUser      string `json:"ftpuser" yaml:"ftpuser"`
+	Databases    string `json:"databases" yaml:"databases"`
+}
+
+// UserPrefs is the user_prefs Map under settings. Only PerPage is
+// well-typed; the table-related sub-keys are surfaced as raw maps so
+// downstream consumers that need them can introspect without a new
+// schema bump for every UI flag KAS adds.
+type UserPrefs struct {
+	PerPage          int                 `json:"per_page" yaml:"per_page"`
+	ExpandableTables map[string][]string `json:"expandable_tables,omitempty" yaml:"expandable_tables,omitempty"`
+	PinnedTables     map[string][]string `json:"pinned_tables,omitempty" yaml:"pinned_tables,omitempty"`
+}
+
+// ResourceQuota is one entry of the get_accountresources response. A
+// Max of -1 means "unlimited" in KAS terminology; Free is also -1 in
+// that case.
+type ResourceQuota struct {
+	Max      int  `json:"max" yaml:"max"`
+	Exceeded bool `json:"exceeded" yaml:"exceeded"`
+	Reserved int  `json:"reserved" yaml:"reserved"`
+	Created  int  `json:"created" yaml:"created"`
+	Used     int  `json:"used" yaml:"used"`
+	Free     int  `json:"free" yaml:"free"`
+}
+
+// AccountResources is the payload of get_accountresources: a fixed set
+// of named quotas. Unknown quota keys are dropped at the mapping layer
+// so adding a new one to the API is a non-breaking change.
+type AccountResources struct {
+	MaxSubdomain   ResourceQuota `json:"max_subdomain" yaml:"max_subdomain"`
+	MaxDomain      ResourceQuota `json:"max_domain" yaml:"max_domain"`
+	MaxWBK         ResourceQuota `json:"max_wbk" yaml:"max_wbk"`
+	MaxFTPUser     ResourceQuota `json:"max_ftpuser" yaml:"max_ftpuser"`
+	MaxSambaUser   ResourceQuota `json:"max_sambauser" yaml:"max_sambauser"`
+	MaxAccount     ResourceQuota `json:"max_account" yaml:"max_account"`
+	MaxWebspace    ResourceQuota `json:"max_webspace" yaml:"max_webspace"`
+	MaxDatabase    ResourceQuota `json:"max_database" yaml:"max_database"`
+	MaxMailAccount ResourceQuota `json:"max_mail_account" yaml:"max_mail_account"`
+	MaxMailForward ResourceQuota `json:"max_mail_forward" yaml:"max_mail_forward"`
+	MaxMailingList ResourceQuota `json:"max_mailinglist" yaml:"max_mailinglist"`
+	MaxCronjobs    ResourceQuota `json:"max_cronjobs" yaml:"max_cronjobs"`
+}

--- a/internal/account/account_test.go
+++ b/internal/account/account_test.go
@@ -1,0 +1,213 @@
+package account_test
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/chmmou/kasapi-cli/internal/account"
+	"github.com/chmmou/kasapi-cli/internal/soap"
+)
+
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	dir := filepath.Dir(file)
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatalf("repo root not found from %q", file)
+		}
+		dir = parent
+	}
+}
+
+func decodeFixture(t *testing.T, name string) *soap.Response {
+	t.Helper()
+	path := filepath.Join(repoRoot(t), "testdata", "account", name)
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open %s: %v", path, err)
+	}
+	defer func() { _ = f.Close() }()
+	resp, err := soap.Decode(f)
+	if err != nil {
+		t.Fatalf("decode %s: %v", path, err)
+	}
+	return resp
+}
+
+func TestDecodeAccounts(t *testing.T) {
+	t.Parallel()
+	resp := decodeFixture(t, "get_accounts_response_success.xml")
+	got, err := account.DecodeAccounts(resp.Body.ReturnInfo)
+	if err != nil {
+		t.Fatalf("DecodeAccounts: %v", err)
+	}
+	if len(got) != 4 {
+		t.Fatalf("len = %d, want 4", len(got))
+	}
+
+	w1 := got[0]
+	if w1.Login != "w0000001" {
+		t.Errorf("Login = %q, want w0000001", w1.Login)
+	}
+	if w1.MaxAccount != 10 {
+		t.Errorf("MaxAccount = %d, want 10", w1.MaxAccount)
+	}
+	if w1.MaxWebspace != 35600 {
+		t.Errorf("MaxWebspace = %d, want 35600", w1.MaxWebspace)
+	}
+	if w1.UsedAccountSpace == 0 {
+		t.Errorf("UsedAccountSpace not parsed: %v", w1.UsedAccountSpace)
+	}
+	if w1.Account2FA != "Y" {
+		t.Errorf("Account2FA = %q, want Y", w1.Account2FA)
+	}
+	if w1.AccountContactMail != "noreply@example.org" {
+		t.Errorf("AccountContactMail = %q", w1.AccountContactMail)
+	}
+
+	// w0000002 has account_2fa = "inherited" — verify it survives as a
+	// string rather than being coerced to a bool somewhere.
+	w2 := got[1]
+	if w2.Account2FA != "inherited" {
+		t.Errorf("w0000002.Account2FA = %q, want inherited", w2.Account2FA)
+	}
+}
+
+func TestDecodeAccountSettings(t *testing.T) {
+	t.Parallel()
+	resp := decodeFixture(t, "get_accountsettings_response_success.xml")
+	got, err := account.DecodeAccountSettings(resp.Body.ReturnInfo)
+	if err != nil {
+		t.Fatalf("DecodeAccountSettings: %v", err)
+	}
+	if got.Login != "w0000000" {
+		t.Errorf("Login = %q, want w0000000", got.Login)
+	}
+	if got.IsSuperuser != "Y" {
+		t.Errorf("IsSuperuser = %q, want Y", got.IsSuperuser)
+	}
+	if got.Server != "d012345" {
+		t.Errorf("Server = %q", got.Server)
+	}
+	if got.UserPrefs.PerPage != 25 {
+		t.Errorf("UserPrefs.PerPage = %d, want 25", got.UserPrefs.PerPage)
+	}
+	if len(got.SSHFingerprints) != 3 {
+		t.Errorf("len(SSHFingerprints) = %d, want 3", len(got.SSHFingerprints))
+	}
+	rsa, ok := got.SSHFingerprints["RSA"]
+	if !ok || rsa.SHA256 == "" {
+		t.Errorf("RSA fingerprint not populated: %+v", rsa)
+	}
+	exp := got.UserPrefs.ExpandableTables
+	if _, ok := exp["mailAccounts"]; !ok {
+		t.Errorf("ExpandableTables missing mailAccounts: %v", exp)
+	}
+}
+
+func TestDecodeAccountResources(t *testing.T) {
+	t.Parallel()
+	resp := decodeFixture(t, "get_accountresources_response_success.xml")
+	got, err := account.DecodeAccountResources(resp.Body.ReturnInfo)
+	if err != nil {
+		t.Fatalf("DecodeAccountResources: %v", err)
+	}
+	if got.MaxSubdomain.Max != 500 {
+		t.Errorf("MaxSubdomain.Max = %d, want 500", got.MaxSubdomain.Max)
+	}
+	if got.MaxSubdomain.Used != 15 {
+		t.Errorf("MaxSubdomain.Used = %d, want 15", got.MaxSubdomain.Used)
+	}
+	if got.MaxDomain.Max != -1 {
+		t.Errorf("MaxDomain.Max = %d, want -1 (unlimited)", got.MaxDomain.Max)
+	}
+	if got.MaxAccount.Free != 486 {
+		t.Errorf("MaxAccount.Free = %d, want 486", got.MaxAccount.Free)
+	}
+	if got.MaxDatabase.Max != 50 {
+		t.Errorf("MaxDatabase.Max = %d", got.MaxDatabase.Max)
+	}
+	if got.MaxMailingList.Max != -1 {
+		t.Errorf("MaxMailingList.Max = %d, want -1", got.MaxMailingList.Max)
+	}
+}
+
+// fakeCaller returns the response decoded from a fixture, ignoring the
+// requested action and params. It is enough to exercise Client.List /
+// Settings / Resources without a network roundtrip.
+type fakeCaller struct {
+	resp *soap.Response
+	err  error
+}
+
+func (f fakeCaller) Call(_ context.Context, _ string, _ map[string]any) (*soap.Response, error) {
+	return f.resp, f.err
+}
+
+func TestClientList(t *testing.T) {
+	t.Parallel()
+	resp := decodeFixture(t, "get_accounts_response_success.xml")
+	c := account.NewClient(fakeCaller{resp: resp})
+	got, err := c.List(context.Background())
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(got) != 4 {
+		t.Errorf("len = %d, want 4", len(got))
+	}
+}
+
+func TestClientPropagatesError(t *testing.T) {
+	t.Parallel()
+	want := errors.New("boom")
+	c := account.NewClient(fakeCaller{err: want})
+	if _, err := c.List(context.Background()); !errors.Is(err, want) {
+		t.Errorf("err = %v, want %v wrapped", err, want)
+	}
+}
+
+func TestAccountListTabular(t *testing.T) {
+	t.Parallel()
+	resp := decodeFixture(t, "get_accounts_response_success.xml")
+	accs, _ := account.DecodeAccounts(resp.Body.ReturnInfo)
+	list := account.AccountList(accs)
+	headers := list.TableHeaders()
+	if got, want := headers[0], "LOGIN"; got != want {
+		t.Errorf("headers[0] = %q, want %q", got, want)
+	}
+	rows := list.TableRows()
+	if len(rows) != 4 {
+		t.Fatalf("rows = %d, want 4", len(rows))
+	}
+	if rows[0][0] != "w0000001" {
+		t.Errorf("rows[0][0] = %q", rows[0][0])
+	}
+}
+
+func TestAccountResourcesTabular(t *testing.T) {
+	t.Parallel()
+	resp := decodeFixture(t, "get_accountresources_response_success.xml")
+	r, _ := account.DecodeAccountResources(resp.Body.ReturnInfo)
+	rows := r.TableRows()
+	if len(rows) != 12 {
+		t.Errorf("rows = %d, want 12", len(rows))
+	}
+	// max_domain has Max = -1 → "∞"
+	for _, row := range rows {
+		if row[0] == "max_domain" && row[1] != "∞" {
+			t.Errorf("max_domain.Max = %q, want ∞", row[1])
+		}
+	}
+}

--- a/internal/account/client.go
+++ b/internal/account/client.go
@@ -1,0 +1,67 @@
+package account
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/chmmou/kasapi-cli/internal/soap"
+)
+
+// Caller is the subset of *api.Client this package depends on. The
+// indirection keeps tests free of network setup: a fake Caller can
+// return a *soap.Response decoded from a fixture.
+type Caller interface {
+	Call(ctx context.Context, action string, params map[string]any) (*soap.Response, error)
+}
+
+// Client groups the read endpoints for accounts: get_accounts,
+// get_accountsettings, get_accountresources.
+type Client struct {
+	API Caller
+}
+
+// NewClient returns a Client backed by the given Caller. It does not
+// retain ownership of c.
+func NewClient(c Caller) *Client { return &Client{API: c} }
+
+// List calls get_accounts and decodes the response into a slice of
+// Account values.
+func (c *Client) List(ctx context.Context) ([]Account, error) {
+	resp, err := c.API.Call(ctx, "get_accounts", nil)
+	if err != nil {
+		return nil, err
+	}
+	accs, err := DecodeAccounts(resp.Body.ReturnInfo)
+	if err != nil {
+		return nil, fmt.Errorf("account: get_accounts: %w", err)
+	}
+	return accs, nil
+}
+
+// Settings calls get_accountsettings and decodes the response into the
+// AccountSettings struct for the authenticated login.
+func (c *Client) Settings(ctx context.Context) (AccountSettings, error) {
+	resp, err := c.API.Call(ctx, "get_accountsettings", nil)
+	if err != nil {
+		return AccountSettings{}, err
+	}
+	s, err := DecodeAccountSettings(resp.Body.ReturnInfo)
+	if err != nil {
+		return AccountSettings{}, fmt.Errorf("account: get_accountsettings: %w", err)
+	}
+	return s, nil
+}
+
+// Resources calls get_accountresources and decodes the response into
+// the AccountResources struct.
+func (c *Client) Resources(ctx context.Context) (AccountResources, error) {
+	resp, err := c.API.Call(ctx, "get_accountresources", nil)
+	if err != nil {
+		return AccountResources{}, err
+	}
+	r, err := DecodeAccountResources(resp.Body.ReturnInfo)
+	if err != nil {
+		return AccountResources{}, fmt.Errorf("account: get_accountresources: %w", err)
+	}
+	return r, nil
+}

--- a/internal/account/decode.go
+++ b/internal/account/decode.go
@@ -1,0 +1,275 @@
+package account
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/chmmou/kasapi-cli/internal/soap"
+)
+
+// DecodeAccounts maps the ReturnInfo of a get_accounts response into
+// the typed slice. ReturnInfo must be a Map[]; each entry is itself a
+// Map carrying the documented fields.
+func DecodeAccounts(returnInfo soap.Value) ([]Account, error) {
+	if returnInfo.Kind != soap.KindArray {
+		return nil, fmt.Errorf("account: expected ReturnInfo array, got kind %d", returnInfo.Kind)
+	}
+	out := make([]Account, 0, len(returnInfo.Array))
+	for i, item := range returnInfo.Array {
+		if item.Kind != soap.KindMap {
+			return nil, fmt.Errorf("account: ReturnInfo[%d] is not a Map", i)
+		}
+		out = append(out, decodeAccount(item))
+	}
+	return out, nil
+}
+
+// DecodeAccountSettings maps the ReturnInfo of a get_accountsettings
+// response into AccountSettings. The KAS payload nests the settings
+// under ReturnInfo.settings.
+func DecodeAccountSettings(returnInfo soap.Value) (AccountSettings, error) {
+	settings, ok := returnInfo.Get("settings")
+	if !ok {
+		return AccountSettings{}, fmt.Errorf("account: ReturnInfo has no settings key")
+	}
+	if settings.Kind != soap.KindMap {
+		return AccountSettings{}, fmt.Errorf("account: settings is not a Map (kind=%d)", settings.Kind)
+	}
+	return decodeSettings(settings), nil
+}
+
+// DecodeAccountResources maps the ReturnInfo of get_accountresources
+// into the typed AccountResources struct. Unknown top-level keys are
+// silently dropped.
+func DecodeAccountResources(returnInfo soap.Value) (AccountResources, error) {
+	if returnInfo.Kind != soap.KindMap {
+		return AccountResources{}, fmt.Errorf("account: expected ReturnInfo Map, got kind %d", returnInfo.Kind)
+	}
+	var out AccountResources
+	for _, kv := range returnInfo.Map {
+		q := decodeQuota(kv.Value)
+		switch kv.Key {
+		case "max_subdomain":
+			out.MaxSubdomain = q
+		case "max_domain":
+			out.MaxDomain = q
+		case "max_wbk":
+			out.MaxWBK = q
+		case "max_ftpuser":
+			out.MaxFTPUser = q
+		case "max_sambauser":
+			out.MaxSambaUser = q
+		case "max_account":
+			out.MaxAccount = q
+		case "max_webspace":
+			out.MaxWebspace = q
+		case "max_database":
+			out.MaxDatabase = q
+		case "max_mail_account":
+			out.MaxMailAccount = q
+		case "max_mail_forward":
+			out.MaxMailForward = q
+		case "max_mailinglist":
+			out.MaxMailingList = q
+		case "max_cronjobs":
+			out.MaxCronjobs = q
+		}
+	}
+	return out, nil
+}
+
+func decodeAccount(m soap.Value) Account {
+	return Account{
+		Login:                       getString(m, "account_login"),
+		Password:                    getString(m, "account_password"),
+		MaxAccount:                  getInt(m, "max_account"),
+		MaxDomain:                   getInt(m, "max_domain"),
+		MaxSubdomain:                getInt(m, "max_subdomain"),
+		MaxWebspace:                 getInt(m, "max_webspace"),
+		MaxMailAccount:              getInt(m, "max_mail_account"),
+		MaxMailForward:              getInt(m, "max_mail_forward"),
+		MaxMailList:                 getInt(m, "max_mail_list"),
+		MaxDatabases:                getInt(m, "max_databases"),
+		MaxFTPUser:                  getInt(m, "max_ftpuser"),
+		MaxSambaUser:                getInt(m, "max_sambauser"),
+		MaxCronjobs:                 getInt(m, "max_cronjobs"),
+		MaxWBK:                      getInt(m, "max_wbk"),
+		InstHtaccess:                getString(m, "inst_htaccess"),
+		InstFPSE:                    getString(m, "inst_fpse"),
+		InstSoftware:                getString(m, "inst_software"),
+		KASAccessForbid:             getString(m, "kas_access_forbidden"),
+		Logging:                     getString(m, "logging"),
+		Statistic:                   getString(m, "statistic"),
+		Logage:                      getInt(m, "logage"),
+		ShowPassword:                getString(m, "show_password"),
+		DNSSettings:                 getString(m, "dns_settings"),
+		ShowDirectLinks:             getInt(m, "show_direct_links"),
+		SSHAccess:                   getString(m, "ssh_access"),
+		UsedAccountSpace:            getFloat(m, "used_account_space"),
+		Account2FA:                  getString(m, "account_2fa"),
+		Account2FAInherited:         getString(m, "account_2fa_inherited"),
+		ShowDirectLinksWBK:          getString(m, "show_direct_links_wbk"),
+		ShowDirectLinksSambausers:   getString(m, "show_direct_links_sambausers"),
+		ShowDirectLinksAccounts:     getString(m, "show_direct_links_accounts"),
+		ShowDirectLinksMailaccounts: getString(m, "show_direct_links_mailaccounts"),
+		ShowDirectLinksFTPUser:      getString(m, "show_direct_links_ftpuser"),
+		ShowDirectLinksDatabases:    getString(m, "show_direct_links_databases"),
+		AccountComment:              getString(m, "account_comment"),
+		AccountContactMail:          getString(m, "account_contact_mail"),
+		InProgress:                  getString(m, "in_progress"),
+	}
+}
+
+func decodeSettings(m soap.Value) AccountSettings {
+	return AccountSettings{
+		Login:              getString(m, "account_login"),
+		AccountComment:     getString(m, "account_comment"),
+		AccountContactMail: getString(m, "account_contact_mail"),
+		IsSuperuser:        getString(m, "is_superuser"),
+		AccountPassword:    getString(m, "account_password"),
+		ShowPassword:       getString(m, "show_password"),
+		Logging:            getString(m, "logging"),
+		Logage:             getInt(m, "logage"),
+		Statistic:          getString(m, "statistic"),
+		DNSSettings:        getString(m, "dns_settings"),
+		InstHtaccess:       getString(m, "inst_htaccess"),
+		InstFPSE:           getString(m, "inst_fpse"),
+		InstSoftware:       getString(m, "inst_software"),
+		SSHAccess:          getString(m, "ssh_access"),
+		SSHKeys:            getString(m, "ssh_keys"),
+		SSHFingerprints:    decodeFingerprints(m),
+		SSHPHPVersion:      getString(m, "ssh_php_version"),
+		Server:             getString(m, "server"),
+		InProgress:         getString(m, "in_progress"),
+		ShowDirectLinks: DirectLinkPrefs{
+			WBK:          getString(m, "show_direct_links_wbk"),
+			Sambausers:   getString(m, "show_direct_links_sambausers"),
+			Accounts:     getString(m, "show_direct_links_accounts"),
+			Mailaccounts: getString(m, "show_direct_links_mailaccounts"),
+			FTPUser:      getString(m, "show_direct_links_ftpuser"),
+			Databases:    getString(m, "show_direct_links_databases"),
+		},
+		Account2FA:        getString(m, "account_2fa"),
+		Account2FAInherit: getString(m, "account_2fa_inherited"),
+		UserPrefs:         decodeUserPrefs(m),
+	}
+}
+
+func decodeFingerprints(settings soap.Value) map[string]Fingerprint {
+	fp, ok := settings.Get("ssh_fingerprints")
+	if !ok || fp.Kind != soap.KindMap {
+		return nil
+	}
+	out := make(map[string]Fingerprint, len(fp.Map))
+	for _, kv := range fp.Map {
+		out[kv.Key] = Fingerprint{
+			MD5:    getString(kv.Value, "MD5:"),
+			SHA256: getString(kv.Value, "SHA256:"),
+		}
+	}
+	return out
+}
+
+func decodeUserPrefs(settings soap.Value) UserPrefs {
+	up, ok := settings.Get("user_prefs")
+	if !ok || up.Kind != soap.KindMap {
+		return UserPrefs{}
+	}
+	out := UserPrefs{
+		PerPage: getInt(up, "per_page"),
+	}
+	if exp, ok := up.Get("expandableTables"); ok && exp.Kind == soap.KindMap {
+		out.ExpandableTables = mapOfStringSlices(exp)
+	}
+	if pin, ok := up.Get("pinnedTables"); ok && pin.Kind == soap.KindMap {
+		out.PinnedTables = mapOfStringSlices(pin)
+	}
+	return out
+}
+
+func mapOfStringSlices(m soap.Value) map[string][]string {
+	out := make(map[string][]string, len(m.Map))
+	for _, kv := range m.Map {
+		switch kv.Value.Kind {
+		case soap.KindArray:
+			vals := make([]string, 0, len(kv.Value.Array))
+			for _, item := range kv.Value.Array {
+				vals = append(vals, item.AsString())
+			}
+			out[kv.Key] = vals
+		case soap.KindString:
+			out[kv.Key] = []string{kv.Value.String}
+		}
+	}
+	return out
+}
+
+func decodeQuota(v soap.Value) ResourceQuota {
+	if v.Kind != soap.KindMap {
+		return ResourceQuota{}
+	}
+	return ResourceQuota{
+		Max:      getInt(v, "max"),
+		Exceeded: getBool(v, "exceeded"),
+		Reserved: getInt(v, "reserved"),
+		Created:  getInt(v, "created"),
+		Used:     getInt(v, "used"),
+		Free:     getInt(v, "free"),
+	}
+}
+
+func getString(m soap.Value, key string) string {
+	v, ok := m.Get(key)
+	if !ok {
+		return ""
+	}
+	return v.AsString()
+}
+
+func getInt(m soap.Value, key string) int {
+	v, ok := m.Get(key)
+	if !ok {
+		return 0
+	}
+	switch v.Kind {
+	case soap.KindInt:
+		return int(v.Int)
+	case soap.KindFloat:
+		return int(v.Float)
+	case soap.KindString:
+		s := strings.TrimSpace(v.String)
+		if s == "" {
+			return 0
+		}
+		n, err := strconv.Atoi(s)
+		if err != nil {
+			return 0
+		}
+		return n
+	}
+	return 0
+}
+
+func getFloat(m soap.Value, key string) float64 {
+	v, ok := m.Get(key)
+	if !ok {
+		return 0
+	}
+	return v.AsFloat()
+}
+
+func getBool(m soap.Value, key string) bool {
+	v, ok := m.Get(key)
+	if !ok {
+		return false
+	}
+	if v.Kind == soap.KindBool {
+		return v.Bool
+	}
+	switch strings.ToLower(strings.TrimSpace(v.AsString())) {
+	case "true", "1", "y", "yes":
+		return true
+	}
+	return false
+}

--- a/internal/account/table.go
+++ b/internal/account/table.go
@@ -1,0 +1,112 @@
+package account
+
+import "strconv"
+
+// AccountList is a slice wrapper that satisfies cli.Tabular so
+// kasapi-cli accounts list --output=table works without a per-command
+// renderer. The same Account values are emitted by --output=json|yaml
+// directly.
+type AccountList []Account
+
+// TableHeaders returns the column names for the account list view.
+func (AccountList) TableHeaders() []string {
+	return []string{"LOGIN", "COMMENT", "MAIL", "MAX_DOMAIN", "MAX_WEBSPACE", "USED_MB", "2FA", "IN_PROGRESS"}
+}
+
+// TableRows returns one row per account, in the order returned by KAS.
+func (l AccountList) TableRows() [][]string {
+	rows := make([][]string, 0, len(l))
+	for _, a := range l {
+		rows = append(rows, []string{
+			a.Login,
+			a.AccountComment,
+			a.AccountContactMail,
+			strconv.Itoa(a.MaxDomain),
+			strconv.Itoa(a.MaxWebspace),
+			strconv.FormatFloat(a.UsedAccountSpace/1024, 'f', 1, 64),
+			a.Account2FA,
+			a.InProgress,
+		})
+	}
+	return rows
+}
+
+// TableHeaders for AccountResources.
+func (AccountResources) TableHeaders() []string {
+	return []string{"RESOURCE", "MAX", "USED", "FREE", "RESERVED", "EXCEEDED"}
+}
+
+// TableRows emits the resource quotas in a stable, declared order.
+func (r AccountResources) TableRows() [][]string {
+	entries := []struct {
+		name string
+		q    ResourceQuota
+	}{
+		{"max_account", r.MaxAccount},
+		{"max_domain", r.MaxDomain},
+		{"max_subdomain", r.MaxSubdomain},
+		{"max_webspace", r.MaxWebspace},
+		{"max_database", r.MaxDatabase},
+		{"max_mail_account", r.MaxMailAccount},
+		{"max_mail_forward", r.MaxMailForward},
+		{"max_mailinglist", r.MaxMailingList},
+		{"max_ftpuser", r.MaxFTPUser},
+		{"max_sambauser", r.MaxSambaUser},
+		{"max_cronjobs", r.MaxCronjobs},
+		{"max_wbk", r.MaxWBK},
+	}
+	rows := make([][]string, 0, len(entries))
+	for _, e := range entries {
+		rows = append(rows, []string{
+			e.name,
+			quotaInt(e.q.Max),
+			strconv.Itoa(e.q.Used),
+			quotaInt(e.q.Free),
+			strconv.Itoa(e.q.Reserved),
+			strconv.FormatBool(e.q.Exceeded),
+		})
+	}
+	return rows
+}
+
+// TableHeaders for AccountSettings produces a key/value layout, since
+// the settings record is wide and tall-format is easier to read in a
+// terminal than a 30-column row.
+func (AccountSettings) TableHeaders() []string {
+	return []string{"FIELD", "VALUE"}
+}
+
+// TableRows emits one row per scalar field. SSH fingerprints and the
+// user_prefs sub-trees are summarised; consumers that need them should
+// use --output=json or --output=yaml.
+func (s AccountSettings) TableRows() [][]string {
+	rows := [][]string{
+		{"account_login", s.Login},
+		{"account_comment", s.AccountComment},
+		{"account_contact_mail", s.AccountContactMail},
+		{"is_superuser", s.IsSuperuser},
+		{"server", s.Server},
+		{"logging", s.Logging},
+		{"logage", strconv.Itoa(s.Logage)},
+		{"statistic", s.Statistic},
+		{"dns_settings", s.DNSSettings},
+		{"inst_htaccess", s.InstHtaccess},
+		{"inst_fpse", s.InstFPSE},
+		{"inst_software", s.InstSoftware},
+		{"ssh_access", s.SSHAccess},
+		{"ssh_php_version", s.SSHPHPVersion},
+		{"account_2fa", s.Account2FA},
+		{"in_progress", s.InProgress},
+		{"user_prefs.per_page", strconv.Itoa(s.UserPrefs.PerPage)},
+	}
+	return rows
+}
+
+// quotaInt formats -1 (KAS sentinel for "unlimited") as the symbol "∞"
+// so table users do not have to know the convention.
+func quotaInt(n int) string {
+	if n < 0 {
+		return "∞"
+	}
+	return strconv.Itoa(n)
+}

--- a/internal/cli/account.go
+++ b/internal/cli/account.go
@@ -1,0 +1,89 @@
+package cli
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/chmmou/kasapi-cli/internal/account"
+)
+
+// NewAccountCmd returns the "kasapi-cli accounts" subcommand tree:
+// list (get_accounts), get (get_accountsettings), and resources
+// (get_accountresources).
+func NewAccountCmd(opts *RootOptions) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "accounts",
+		Short: "Inspect KAS accounts owned by the authenticated login",
+	}
+	cmd.AddCommand(
+		newAccountsListCmd(opts),
+		newAccountsGetCmd(opts),
+		newAccountsResourcesCmd(opts),
+	)
+	return cmd
+}
+
+func newAccountsListCmd(opts *RootOptions) *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Short: "List all sub-accounts (get_accounts)",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			api, err := BuildAPIClient(opts)
+			if err != nil {
+				return err
+			}
+			accs, err := account.NewClient(api).List(cmd.Context())
+			if err != nil {
+				return APIError(err, "get_accounts")
+			}
+			if err := Render(cmd.OutOrStdout(), opts.Output, account.AccountList(accs)); err != nil {
+				return UserError(err, "render")
+			}
+			return nil
+		},
+	}
+}
+
+func newAccountsGetCmd(opts *RootOptions) *cobra.Command {
+	return &cobra.Command{
+		Use:   "get",
+		Short: "Show settings for the authenticated account (get_accountsettings)",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			api, err := BuildAPIClient(opts)
+			if err != nil {
+				return err
+			}
+			s, err := account.NewClient(api).Settings(cmd.Context())
+			if err != nil {
+				return APIError(err, "get_accountsettings")
+			}
+			if err := Render(cmd.OutOrStdout(), opts.Output, s); err != nil {
+				return UserError(err, "render")
+			}
+			return nil
+		},
+	}
+}
+
+func newAccountsResourcesCmd(opts *RootOptions) *cobra.Command {
+	return &cobra.Command{
+		Use:   "resources",
+		Short: "Show quota counters for the authenticated account (get_accountresources)",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			api, err := BuildAPIClient(opts)
+			if err != nil {
+				return err
+			}
+			r, err := account.NewClient(api).Resources(cmd.Context())
+			if err != nil {
+				return APIError(err, "get_accountresources")
+			}
+			if err := Render(cmd.OutOrStdout(), opts.Output, r); err != nil {
+				return UserError(err, "render")
+			}
+			return nil
+		},
+	}
+}

--- a/internal/cli/account_test.go
+++ b/internal/cli/account_test.go
@@ -1,0 +1,46 @@
+package cli_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/chmmou/kasapi-cli/internal/cli"
+)
+
+func TestAccountCmdHelpListsSubcommands(t *testing.T) {
+	t.Parallel()
+	root, opts := cli.NewRootCmd()
+	root.AddCommand(cli.NewAccountCmd(opts))
+
+	var buf bytes.Buffer
+	root.SetOut(&buf)
+	root.SetErr(&buf)
+	root.SetArgs([]string{"accounts", "--help"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{"list", "get", "resources"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("--help output missing %q\n%s", want, out)
+		}
+	}
+}
+
+func TestServerCmdHelpListsInfo(t *testing.T) {
+	t.Parallel()
+	root, opts := cli.NewRootCmd()
+	root.AddCommand(cli.NewServerCmd(opts))
+
+	var buf bytes.Buffer
+	root.SetOut(&buf)
+	root.SetErr(&buf)
+	root.SetArgs([]string{"server", "--help"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !strings.Contains(buf.String(), "info") {
+		t.Errorf("server --help missing 'info' subcommand:\n%s", buf.String())
+	}
+}

--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -1,0 +1,40 @@
+package cli
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/chmmou/kasapi-cli/internal/server"
+)
+
+// NewServerCmd returns the "kasapi-cli server" subcommand tree. For
+// now it carries a single child, "info" (get_server_information).
+func NewServerCmd(opts *RootOptions) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "server",
+		Short: "Inspect the host server kasapi-cli is talking to",
+	}
+	cmd.AddCommand(newServerInfoCmd(opts))
+	return cmd
+}
+
+func newServerInfoCmd(opts *RootOptions) *cobra.Command {
+	return &cobra.Command{
+		Use:   "info",
+		Short: "List installed services and versions (get_server_information)",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			api, err := BuildAPIClient(opts)
+			if err != nil {
+				return err
+			}
+			list, err := server.NewClient(api).Information(cmd.Context())
+			if err != nil {
+				return APIError(err, "get_server_information")
+			}
+			if err := Render(cmd.OutOrStdout(), opts.Output, list); err != nil {
+				return UserError(err, "render")
+			}
+			return nil
+		},
+	}
+}

--- a/internal/cli/wire.go
+++ b/internal/cli/wire.go
@@ -1,0 +1,68 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/chmmou/kasapi-cli/internal/api"
+	"github.com/chmmou/kasapi-cli/internal/auth"
+	"github.com/chmmou/kasapi-cli/internal/config"
+	"github.com/chmmou/kasapi-cli/internal/soap"
+	"github.com/chmmou/kasapi-cli/internal/transport"
+)
+
+// BuildAPIClient resolves credentials from config + env + flags and
+// returns an *api.Client wired with a fresh transport and a token
+// source matching the requested auth_type.
+//
+// auth_type=plain  → credentials are passed verbatim to KasApi each
+// call via api.StaticTokenSource.
+// auth_type=session → the configured AuthData is treated as the
+// account password; auth.SessionTokenSource fetches a 40-char session
+// token from KasAuth on first use and refreshes it transparently
+// after no_auth / unknown_session faults.
+//
+// Errors are wrapped as *ExitError with ExitUserError so cmd/kasapi-cli
+// surfaces them with the expected exit code.
+func BuildAPIClient(opts *RootOptions) (*api.Client, error) {
+	if opts == nil {
+		return nil, UserError(errors.New("nil RootOptions"), "cli")
+	}
+
+	cfg, err := config.Load(opts.ConfigPath)
+	if err != nil && !errors.Is(err, config.ErrNoConfig) {
+		return nil, UserError(err, "load config")
+	}
+	creds, err := cfg.Resolve(config.EnvFromOS(), config.Override{
+		Profile:  opts.Profile,
+		Login:    opts.Login,
+		AuthData: opts.AuthData,
+		AuthType: opts.AuthType,
+	})
+	if err != nil {
+		return nil, UserError(err, "")
+	}
+
+	tr := transport.New()
+	ts, err := tokenSource(tr, creds)
+	if err != nil {
+		return nil, UserError(err, "")
+	}
+	return api.New(tr, ts), nil
+}
+
+func tokenSource(tr *transport.Client, creds config.Credentials) (api.TokenSource, error) {
+	switch creds.AuthType {
+	case config.AuthPlain:
+		return &api.StaticTokenSource{
+			Login:    creds.Login,
+			AuthData: creds.AuthData,
+			AuthType: soap.AuthPlain,
+		}, nil
+	case config.AuthSession:
+		authClient := auth.New(tr, creds.Login, creds.AuthData, soap.AuthPlain, auth.Options{})
+		return auth.NewSessionTokenSource(authClient), nil
+	default:
+		return nil, fmt.Errorf("config: unsupported auth_type %q", creds.AuthType)
+	}
+}

--- a/internal/cli/wire_test.go
+++ b/internal/cli/wire_test.go
@@ -1,0 +1,80 @@
+package cli_test
+
+import (
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"github.com/chmmou/kasapi-cli/internal/cli"
+)
+
+func TestBuildAPIClientPlain(t *testing.T) {
+	t.Setenv("KAS_LOGIN", "")
+	t.Setenv("KAS_AUTHDATA", "")
+	t.Setenv("KAS_AUTHTYPE", "")
+
+	opts := &cli.RootOptions{
+		ConfigPath: filepath.Join(t.TempDir(), "missing-config.toml"),
+		Login:      "w0000000",
+		AuthData:   "secret-password",
+		AuthType:   "plain",
+	}
+	c, err := cli.BuildAPIClient(opts)
+	if err != nil {
+		t.Fatalf("BuildAPIClient: %v", err)
+	}
+	if c == nil || c.Tokens == nil || c.Transport == nil {
+		t.Fatalf("client incomplete: %+v", c)
+	}
+}
+
+func TestBuildAPIClientSession(t *testing.T) {
+	t.Setenv("KAS_LOGIN", "")
+	t.Setenv("KAS_AUTHDATA", "")
+	t.Setenv("KAS_AUTHTYPE", "")
+
+	opts := &cli.RootOptions{
+		ConfigPath: filepath.Join(t.TempDir(), "missing-config.toml"),
+		Login:      "w0000000",
+		AuthData:   "secret-password",
+		AuthType:   "session",
+	}
+	c, err := cli.BuildAPIClient(opts)
+	if err != nil {
+		t.Fatalf("BuildAPIClient: %v", err)
+	}
+	if c == nil || c.Tokens == nil {
+		t.Fatalf("client incomplete: %+v", c)
+	}
+}
+
+func TestBuildAPIClientMissingCreds(t *testing.T) {
+	t.Setenv("KAS_LOGIN", "")
+	t.Setenv("KAS_AUTHDATA", "")
+	t.Setenv("KAS_AUTHTYPE", "")
+
+	opts := &cli.RootOptions{
+		ConfigPath: filepath.Join(t.TempDir(), "missing-config.toml"),
+	}
+	_, err := cli.BuildAPIClient(opts)
+	if err == nil {
+		t.Fatal("expected error for missing credentials")
+	}
+	var ee *cli.ExitError
+	if !errors.As(err, &ee) {
+		t.Errorf("err is not *ExitError: %T", err)
+	} else if ee.Code != cli.ExitUserError {
+		t.Errorf("Code = %d, want %d", ee.Code, cli.ExitUserError)
+	}
+}
+
+func TestBuildAPIClientNilOpts(t *testing.T) {
+	_, err := cli.BuildAPIClient(nil)
+	if err == nil {
+		t.Fatal("expected error for nil opts")
+	}
+	var ee *cli.ExitError
+	if !errors.As(err, &ee) || ee.Code != cli.ExitUserError {
+		t.Errorf("got %v, want ExitUserError", err)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,0 +1,110 @@
+package server
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/chmmou/kasapi-cli/internal/soap"
+)
+
+// Caller is the subset of *api.Client this package depends on.
+type Caller interface {
+	Call(ctx context.Context, action string, params map[string]any) (*soap.Response, error)
+}
+
+// Service is one entry from get_server_information. The KAS API
+// returns a heterogeneous list: mysql carries a version_type, php
+// entries carry interface and file_extension, the os entry carries a
+// distribution. We keep all known fields as optional strings so the
+// struct survives KAS adding new service kinds.
+type Service struct {
+	Service       string `json:"service" yaml:"service"`
+	Version       string `json:"version" yaml:"version"`
+	VersionType   string `json:"version_type,omitempty" yaml:"version_type,omitempty"`
+	Interface     string `json:"interface,omitempty" yaml:"interface,omitempty"`
+	FileExtension string `json:"file_extension,omitempty" yaml:"file_extension,omitempty"`
+	Distribution  string `json:"distribution,omitempty" yaml:"distribution,omitempty"`
+}
+
+// ServiceList is the typed payload of get_server_information; it
+// satisfies cli.Tabular so --output=table works without a special
+// renderer.
+type ServiceList []Service
+
+// Client groups the read endpoints scoped to the host server.
+type Client struct {
+	API Caller
+}
+
+// NewClient returns a Client backed by the given Caller.
+func NewClient(c Caller) *Client { return &Client{API: c} }
+
+// Information calls get_server_information and decodes the response.
+func (c *Client) Information(ctx context.Context) (ServiceList, error) {
+	resp, err := c.API.Call(ctx, "get_server_information", nil)
+	if err != nil {
+		return nil, err
+	}
+	list, err := DecodeServices(resp.Body.ReturnInfo)
+	if err != nil {
+		return nil, fmt.Errorf("server: get_server_information: %w", err)
+	}
+	return list, nil
+}
+
+// DecodeServices maps ReturnInfo (an array of Maps) into the typed
+// ServiceList.
+func DecodeServices(returnInfo soap.Value) (ServiceList, error) {
+	if returnInfo.Kind != soap.KindArray {
+		return nil, fmt.Errorf("server: expected ReturnInfo array, got kind %d", returnInfo.Kind)
+	}
+	out := make(ServiceList, 0, len(returnInfo.Array))
+	for i, item := range returnInfo.Array {
+		if item.Kind != soap.KindMap {
+			return nil, fmt.Errorf("server: ReturnInfo[%d] is not a Map", i)
+		}
+		out = append(out, Service{
+			Service:       getString(item, "service"),
+			Version:       getString(item, "version"),
+			VersionType:   getString(item, "version_type"),
+			Interface:     getString(item, "interface"),
+			FileExtension: getString(item, "file_extension"),
+			Distribution:  getString(item, "distribution"),
+		})
+	}
+	return out, nil
+}
+
+func getString(m soap.Value, key string) string {
+	v, ok := m.Get(key)
+	if !ok {
+		return ""
+	}
+	return v.AsString()
+}
+
+// TableHeaders returns the columns used by --output=table.
+func (ServiceList) TableHeaders() []string {
+	return []string{"SERVICE", "VERSION", "INTERFACE", "FILE_EXT", "DETAIL"}
+}
+
+// TableRows emits one row per service entry. The DETAIL column merges
+// version_type and distribution so heterogeneous entries fit in one
+// rectangular table.
+func (l ServiceList) TableRows() [][]string {
+	rows := make([][]string, 0, len(l))
+	for _, s := range l {
+		detail := s.VersionType
+		if detail == "" {
+			detail = s.Distribution
+		}
+		rows = append(rows, []string{
+			s.Service,
+			s.Version,
+			s.Interface,
+			s.FileExtension,
+			detail,
+		})
+	}
+	return rows
+}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1,0 +1,113 @@
+package server_test
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/chmmou/kasapi-cli/internal/server"
+	"github.com/chmmou/kasapi-cli/internal/soap"
+)
+
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	dir := filepath.Dir(file)
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatalf("repo root not found from %q", file)
+		}
+		dir = parent
+	}
+}
+
+func decodeFixture(t *testing.T) *soap.Response {
+	t.Helper()
+	path := filepath.Join(repoRoot(t), "testdata", "account", "get_server_information_response_success.xml")
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+	resp, err := soap.Decode(f)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	return resp
+}
+
+func TestDecodeServices(t *testing.T) {
+	t.Parallel()
+	resp := decodeFixture(t)
+	got, err := server.DecodeServices(resp.Body.ReturnInfo)
+	if err != nil {
+		t.Fatalf("DecodeServices: %v", err)
+	}
+	if len(got) != 8 {
+		t.Fatalf("len = %d, want 8", len(got))
+	}
+	if got[0].Service != "mysql" || got[0].Version != "10.6.12" || got[0].VersionType != "server" {
+		t.Errorf("got[0] = %+v", got[0])
+	}
+	if got[1].Service != "php" || got[1].FileExtension != "php56" || got[1].Interface != "cgi-fcgi" {
+		t.Errorf("got[1] = %+v", got[1])
+	}
+	last := got[len(got)-1]
+	if last.Service != "os" || last.Distribution != "ubuntu" || last.Version != "22" {
+		t.Errorf("os entry = %+v", last)
+	}
+}
+
+type fakeCaller struct {
+	resp *soap.Response
+	err  error
+}
+
+func (f fakeCaller) Call(_ context.Context, _ string, _ map[string]any) (*soap.Response, error) {
+	return f.resp, f.err
+}
+
+func TestClientInformation(t *testing.T) {
+	t.Parallel()
+	resp := decodeFixture(t)
+	c := server.NewClient(fakeCaller{resp: resp})
+	list, err := c.Information(context.Background())
+	if err != nil {
+		t.Fatalf("Information: %v", err)
+	}
+	if len(list) != 8 {
+		t.Errorf("len = %d, want 8", len(list))
+	}
+}
+
+func TestClientInformationPropagatesError(t *testing.T) {
+	t.Parallel()
+	want := errors.New("boom")
+	c := server.NewClient(fakeCaller{err: want})
+	if _, err := c.Information(context.Background()); !errors.Is(err, want) {
+		t.Errorf("err = %v, want %v wrapped", err, want)
+	}
+}
+
+func TestServiceListTabular(t *testing.T) {
+	t.Parallel()
+	resp := decodeFixture(t)
+	list, _ := server.DecodeServices(resp.Body.ReturnInfo)
+	rows := list.TableRows()
+	if len(rows) != 8 {
+		t.Errorf("rows = %d, want 8", len(rows))
+	}
+	if rows[0][0] != "mysql" || rows[0][4] != "server" {
+		t.Errorf("rows[0] = %v", rows[0])
+	}
+}


### PR DESCRIPTION
## Summary

- adds `internal/account` (`get_accounts`, `get_accountsettings`, `get_accountresources`) and `internal/server` (`get_server_information`) with typed Go domain structs and table renderers
- registers `kasapi-cli accounts list|get|resources` and `kasapi-cli server info` subcommands
- introduces `cli.BuildAPIClient(opts)` as the shared wiring helper that turns config + env + flags into an `*api.Client`, picking `api.StaticTokenSource` for `auth_type=plain` and `auth.SessionTokenSource` for `auth_type=session`

Closes #7.