### PR TITLE
feat: KasAuth session flags (--otp, --session-lifetime, --session-update-lifetime)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,15 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `--otp` persistent flag on the root command for the optional 2FA
-  one-time PIN. The value is plumbed through `BuildAPIClient` into
-  `auth.Options{OTP: ...}` so `auth.SessionTokenSource` forwards it
-  to KasAuth as `session_2fa` on the credential-token request. The
-  `--auth-type` and `--otp` help texts spell out that the KAS docs
-  only cover `session_2fa` on the KasAuth bootstrap (i.e. our
-  `auth_type=session` strategy), so combining `--otp` with
-  `auth_type=plain` is rejected up front with a user-error exit
-  code and a message that points to the correct strategy.
+- `--otp`, `--session-lifetime`, and `--session-update-lifetime`
+  persistent flags on the root command, exposing the optional KasAuth
+  parameters (`session_2fa`, `session_lifetime`, and
+  `session_update_lifetime`). All three are plumbed through
+  `BuildAPIClient` into `auth.Options` so `auth.SessionTokenSource`
+  forwards them on the credential-token bootstrap. `--session-lifetime`
+  is range-checked client-side (1..30000 seconds);
+  `--session-update-lifetime` accepts `Y` or `N` and maps to the tri-state
+  `*bool` field. The `--auth-type` help text spells out that these flags
+  are KasAuth-only (the KAS docs do not cover them on direct
+  `kas_auth_type=plain` calls), so combining any of them with
+  `auth_type=plain` is rejected up front with a user-error exit code and
+  a message that points to `auth_type=session`.
 - `internal/account` and `internal/server` read modules with the first
   end-to-end CLI subcommands: `kasapi-cli accounts list` (`get_accounts`),
   `kasapi-cli accounts get` (`get_accountsettings`), `kasapi-cli accounts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `--otp` persistent flag on the root command for the optional 2FA
+  one-time PIN. The value is plumbed through `BuildAPIClient` into
+  `auth.Options{OTP: ...}` so `auth.SessionTokenSource` forwards it
+  to KasAuth on the credential-token request. Combining `--otp` with
+  `auth_type=plain` is rejected up front with a user-error exit code,
+  since plain auth bypasses KasAuth entirely.
 - `internal/account` and `internal/server` read modules with the first
   end-to-end CLI subcommands: `kasapi-cli accounts list` (`get_accounts`),
   `kasapi-cli accounts get` (`get_accountsettings`), `kasapi-cli accounts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `--otp` persistent flag on the root command for the optional 2FA
   one-time PIN. The value is plumbed through `BuildAPIClient` into
   `auth.Options{OTP: ...}` so `auth.SessionTokenSource` forwards it
-  to KasAuth on the credential-token request. Combining `--otp` with
-  `auth_type=plain` is rejected up front with a user-error exit code,
-  since plain auth bypasses KasAuth entirely.
+  to KasAuth as `session_2fa` on the credential-token request. The
+  `--auth-type` and `--otp` help texts spell out that the KAS docs
+  only cover `session_2fa` on the KasAuth bootstrap (i.e. our
+  `auth_type=session` strategy), so combining `--otp` with
+  `auth_type=plain` is rejected up front with a user-error exit
+  code and a message that points to the correct strategy.
 - `internal/account` and `internal/server` read modules with the first
   end-to-end CLI subcommands: `kasapi-cli accounts list` (`get_accounts`),
   `kasapi-cli accounts get` (`get_accountsettings`), `kasapi-cli accounts

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -22,6 +22,9 @@ type RootOptions struct {
 	AuthType   string
 	OTP        string
 
+	SessionLifetime       int
+	SessionUpdateLifetime string
+
 	OutputRaw string
 	Output    Format
 
@@ -76,6 +79,12 @@ func NewRootCmd() (*cobra.Command, *RootOptions) {
 	pf.StringVar(&opts.OTP, "otp", "",
 		"2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. "+
 			"Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.")
+	pf.IntVar(&opts.SessionLifetime, "session-lifetime", 0,
+		"session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. "+
+			"Requires auth_type=session.")
+	pf.StringVar(&opts.SessionUpdateLifetime, "session-update-lifetime", "",
+		"session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). "+
+			"Empty omits the parameter. Requires auth_type=session.")
 	pf.StringVarP(&opts.OutputRaw, "output", "o", "", fmt.Sprintf("output format: %s (default %s)", joinFormats(), DefaultFormat))
 	pf.BoolVar(&opts.NoColor, "no-color", false, "disable coloured output")
 	pf.BoolVarP(&opts.Verbose, "verbose", "v", false, "enable verbose logging on stderr")

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -70,8 +70,12 @@ func NewRootCmd() (*cobra.Command, *RootOptions) {
 	pf.StringVar(&opts.Profile, "profile", "", "profile to select from the config file (overrides default_profile)")
 	pf.StringVar(&opts.Login, "login", "", "KAS login (overrides config and KAS_LOGIN)")
 	pf.StringVar(&opts.AuthData, "auth-data", "", "KAS auth data (overrides config and KAS_AUTHDATA)")
-	pf.StringVar(&opts.AuthType, "auth-type", "", "KAS auth type, plain or session (overrides config and KAS_AUTHTYPE)")
-	pf.StringVar(&opts.OTP, "otp", "", "2FA one-time PIN passed to KasAuth (only used with auth_type=session)")
+	pf.StringVar(&opts.AuthType, "auth-type", "",
+		"KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); "+
+			"'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.")
+	pf.StringVar(&opts.OTP, "otp", "",
+		"2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. "+
+			"Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.")
 	pf.StringVarP(&opts.OutputRaw, "output", "o", "", fmt.Sprintf("output format: %s (default %s)", joinFormats(), DefaultFormat))
 	pf.BoolVar(&opts.NoColor, "no-color", false, "disable coloured output")
 	pf.BoolVarP(&opts.Verbose, "verbose", "v", false, "enable verbose logging on stderr")

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -20,6 +20,7 @@ type RootOptions struct {
 	Login      string
 	AuthData   string
 	AuthType   string
+	OTP        string
 
 	OutputRaw string
 	Output    Format
@@ -70,6 +71,7 @@ func NewRootCmd() (*cobra.Command, *RootOptions) {
 	pf.StringVar(&opts.Login, "login", "", "KAS login (overrides config and KAS_LOGIN)")
 	pf.StringVar(&opts.AuthData, "auth-data", "", "KAS auth data (overrides config and KAS_AUTHDATA)")
 	pf.StringVar(&opts.AuthType, "auth-type", "", "KAS auth type, plain or session (overrides config and KAS_AUTHTYPE)")
+	pf.StringVar(&opts.OTP, "otp", "", "2FA one-time PIN passed to KasAuth (only used with auth_type=session)")
 	pf.StringVarP(&opts.OutputRaw, "output", "o", "", fmt.Sprintf("output format: %s (default %s)", joinFormats(), DefaultFormat))
 	pf.BoolVar(&opts.NoColor, "no-color", false, "disable coloured output")
 	pf.BoolVarP(&opts.Verbose, "verbose", "v", false, "enable verbose logging on stderr")

--- a/internal/cli/wire.go
+++ b/internal/cli/wire.go
@@ -44,23 +44,26 @@ func BuildAPIClient(opts *RootOptions) (*api.Client, error) {
 	}
 
 	tr := transport.New()
-	ts, err := tokenSource(tr, creds)
+	ts, err := tokenSource(tr, creds, opts.OTP)
 	if err != nil {
 		return nil, UserError(err, "")
 	}
 	return api.New(tr, ts), nil
 }
 
-func tokenSource(tr *transport.Client, creds config.Credentials) (api.TokenSource, error) {
+func tokenSource(tr *transport.Client, creds config.Credentials, otp string) (api.TokenSource, error) {
 	switch creds.AuthType {
 	case config.AuthPlain:
+		if otp != "" {
+			return nil, fmt.Errorf("--otp is only valid with auth_type=session")
+		}
 		return &api.StaticTokenSource{
 			Login:    creds.Login,
 			AuthData: creds.AuthData,
 			AuthType: soap.AuthPlain,
 		}, nil
 	case config.AuthSession:
-		authClient := auth.New(tr, creds.Login, creds.AuthData, soap.AuthPlain, auth.Options{})
+		authClient := auth.New(tr, creds.Login, creds.AuthData, soap.AuthPlain, auth.Options{OTP: otp})
 		return auth.NewSessionTokenSource(authClient), nil
 	default:
 		return nil, fmt.Errorf("config: unsupported auth_type %q", creds.AuthType)

--- a/internal/cli/wire.go
+++ b/internal/cli/wire.go
@@ -16,15 +16,14 @@ import (
 // source matching the requested auth_type.
 //
 // auth_type=plain  → credentials are passed verbatim to KasApi each
-// call via api.StaticTokenSource. KasAuth is not contacted; --otp
-// is therefore not supported in this mode (the KAS docs only cover
-// session_2fa on the KasAuth bootstrap, not on direct KasApi-plain
-// calls).
+// call via api.StaticTokenSource. KasAuth is not contacted; --otp,
+// --session-lifetime, and --session-update-lifetime are therefore
+// not supported in this mode (these are KasAuth-only parameters).
 // auth_type=session → the configured AuthData is treated as the
 // account password; auth.SessionTokenSource fetches a 40-char session
-// token from KasAuth on first use (sending --otp as session_2fa when
-// set) and refreshes it transparently after no_auth / unknown_session
-// faults.
+// token from KasAuth on first use (forwarding --otp, --session-lifetime,
+// and --session-update-lifetime when set) and refreshes it
+// transparently after no_auth / unknown_session faults.
 //
 // Errors are wrapped as *ExitError with ExitUserError so cmd/kasapi-cli
 // surfaces them with the expected exit code.
@@ -48,21 +47,37 @@ func BuildAPIClient(opts *RootOptions) (*api.Client, error) {
 	}
 
 	tr := transport.New()
-	ts, err := tokenSource(tr, creds, opts.OTP)
+	ts, err := tokenSource(tr, creds, sessionOpts{
+		OTP:            opts.OTP,
+		Lifetime:       opts.SessionLifetime,
+		UpdateLifetime: opts.SessionUpdateLifetime,
+	})
 	if err != nil {
 		return nil, UserError(err, "")
 	}
 	return api.New(tr, ts), nil
 }
 
-func tokenSource(tr *transport.Client, creds config.Credentials, otp string) (api.TokenSource, error) {
+// sessionOpts groups the KasAuth-only flag values plumbed through to
+// auth.Options. All fields are optional; zero values mean "omit".
+type sessionOpts struct {
+	OTP            string
+	Lifetime       int
+	UpdateLifetime string
+}
+
+func (s sessionOpts) any() bool {
+	return s.OTP != "" || s.Lifetime != 0 || s.UpdateLifetime != ""
+}
+
+func tokenSource(tr *transport.Client, creds config.Credentials, s sessionOpts) (api.TokenSource, error) {
 	switch creds.AuthType {
 	case config.AuthPlain:
-		if otp != "" {
+		if s.any() {
 			return nil, fmt.Errorf(
-				"--otp cannot be used with auth_type=plain: the KAS API only accepts session_2fa " +
-					"on the KasAuth bootstrap call, which is performed in auth_type=session mode " +
-					"(switch to auth_type=session for 2FA-enabled accounts)")
+				"--otp / --session-lifetime / --session-update-lifetime cannot be used with " +
+					"auth_type=plain: these are KasAuth-only parameters and KasAuth is not " +
+					"contacted in plain mode (switch to auth_type=session)")
 		}
 		return &api.StaticTokenSource{
 			Login:    creds.Login,
@@ -70,9 +85,36 @@ func tokenSource(tr *transport.Client, creds config.Credentials, otp string) (ap
 			AuthType: soap.AuthPlain,
 		}, nil
 	case config.AuthSession:
-		authClient := auth.New(tr, creds.Login, creds.AuthData, soap.AuthPlain, auth.Options{OTP: otp})
+		authOpts, err := buildAuthOptions(s)
+		if err != nil {
+			return nil, err
+		}
+		authClient := auth.New(tr, creds.Login, creds.AuthData, soap.AuthPlain, authOpts)
 		return auth.NewSessionTokenSource(authClient), nil
 	default:
 		return nil, fmt.Errorf("config: unsupported auth_type %q", creds.AuthType)
 	}
+}
+
+func buildAuthOptions(s sessionOpts) (auth.Options, error) {
+	out := auth.Options{OTP: s.OTP}
+	if s.Lifetime != 0 {
+		if s.Lifetime < 1 || s.Lifetime > 30000 {
+			return auth.Options{}, fmt.Errorf("--session-lifetime must be between 1 and 30000 seconds, got %d", s.Lifetime)
+		}
+		out.Lifetime = s.Lifetime
+	}
+	switch s.UpdateLifetime {
+	case "":
+		// omit
+	case "Y":
+		v := true
+		out.UpdateLifetime = &v
+	case "N":
+		v := false
+		out.UpdateLifetime = &v
+	default:
+		return auth.Options{}, fmt.Errorf("--session-update-lifetime must be 'Y' or 'N', got %q", s.UpdateLifetime)
+	}
+	return out, nil
 }

--- a/internal/cli/wire.go
+++ b/internal/cli/wire.go
@@ -16,11 +16,15 @@ import (
 // source matching the requested auth_type.
 //
 // auth_type=plain  → credentials are passed verbatim to KasApi each
-// call via api.StaticTokenSource.
+// call via api.StaticTokenSource. KasAuth is not contacted; --otp
+// is therefore not supported in this mode (the KAS docs only cover
+// session_2fa on the KasAuth bootstrap, not on direct KasApi-plain
+// calls).
 // auth_type=session → the configured AuthData is treated as the
 // account password; auth.SessionTokenSource fetches a 40-char session
-// token from KasAuth on first use and refreshes it transparently
-// after no_auth / unknown_session faults.
+// token from KasAuth on first use (sending --otp as session_2fa when
+// set) and refreshes it transparently after no_auth / unknown_session
+// faults.
 //
 // Errors are wrapped as *ExitError with ExitUserError so cmd/kasapi-cli
 // surfaces them with the expected exit code.
@@ -55,7 +59,10 @@ func tokenSource(tr *transport.Client, creds config.Credentials, otp string) (ap
 	switch creds.AuthType {
 	case config.AuthPlain:
 		if otp != "" {
-			return nil, fmt.Errorf("--otp is only valid with auth_type=session")
+			return nil, fmt.Errorf(
+				"--otp cannot be used with auth_type=plain: the KAS API only accepts session_2fa " +
+					"on the KasAuth bootstrap call, which is performed in auth_type=session mode " +
+					"(switch to auth_type=session for 2FA-enabled accounts)")
 		}
 		return &api.StaticTokenSource{
 			Login:    creds.Login,

--- a/internal/cli/wire_test.go
+++ b/internal/cli/wire_test.go
@@ -78,3 +78,46 @@ func TestBuildAPIClientNilOpts(t *testing.T) {
 		t.Errorf("got %v, want ExitUserError", err)
 	}
 }
+
+func TestBuildAPIClientSessionWithOTP(t *testing.T) {
+	t.Setenv("KAS_LOGIN", "")
+	t.Setenv("KAS_AUTHDATA", "")
+	t.Setenv("KAS_AUTHTYPE", "")
+
+	opts := &cli.RootOptions{
+		ConfigPath: filepath.Join(t.TempDir(), "missing-config.toml"),
+		Login:      "w0000000",
+		AuthData:   "secret-password",
+		AuthType:   "session",
+		OTP:        "123456",
+	}
+	c, err := cli.BuildAPIClient(opts)
+	if err != nil {
+		t.Fatalf("BuildAPIClient: %v", err)
+	}
+	if c == nil || c.Tokens == nil {
+		t.Fatalf("client incomplete: %+v", c)
+	}
+}
+
+func TestBuildAPIClientPlainWithOTPRejected(t *testing.T) {
+	t.Setenv("KAS_LOGIN", "")
+	t.Setenv("KAS_AUTHDATA", "")
+	t.Setenv("KAS_AUTHTYPE", "")
+
+	opts := &cli.RootOptions{
+		ConfigPath: filepath.Join(t.TempDir(), "missing-config.toml"),
+		Login:      "w0000000",
+		AuthData:   "secret-password",
+		AuthType:   "plain",
+		OTP:        "123456",
+	}
+	_, err := cli.BuildAPIClient(opts)
+	if err == nil {
+		t.Fatal("expected error when --otp combined with auth_type=plain")
+	}
+	var ee *cli.ExitError
+	if !errors.As(err, &ee) || ee.Code != cli.ExitUserError {
+		t.Errorf("got %v, want ExitUserError", err)
+	}
+}

--- a/internal/cli/wire_test.go
+++ b/internal/cli/wire_test.go
@@ -121,3 +121,108 @@ func TestBuildAPIClientPlainWithOTPRejected(t *testing.T) {
 		t.Errorf("got %v, want ExitUserError", err)
 	}
 }
+
+func TestBuildAPIClientSessionWithLifetimeFlags(t *testing.T) {
+	t.Setenv("KAS_LOGIN", "")
+	t.Setenv("KAS_AUTHDATA", "")
+	t.Setenv("KAS_AUTHTYPE", "")
+
+	for _, ulv := range []string{"Y", "N", ""} {
+		ulv := ulv
+		t.Run("update-lifetime="+ulv, func(t *testing.T) {
+			t.Parallel()
+			opts := &cli.RootOptions{
+				ConfigPath:            filepath.Join(t.TempDir(), "missing-config.toml"),
+				Login:                 "w0000000",
+				AuthData:              "secret-password",
+				AuthType:              "session",
+				SessionLifetime:       1800,
+				SessionUpdateLifetime: ulv,
+			}
+			c, err := cli.BuildAPIClient(opts)
+			if err != nil {
+				t.Fatalf("BuildAPIClient: %v", err)
+			}
+			if c == nil || c.Tokens == nil {
+				t.Fatalf("client incomplete: %+v", c)
+			}
+		})
+	}
+}
+
+func TestBuildAPIClientPlainWithLifetimeFlagsRejected(t *testing.T) {
+	t.Setenv("KAS_LOGIN", "")
+	t.Setenv("KAS_AUTHDATA", "")
+	t.Setenv("KAS_AUTHTYPE", "")
+
+	cases := []struct {
+		name string
+		opts *cli.RootOptions
+	}{
+		{"lifetime", &cli.RootOptions{
+			Login: "w0000000", AuthData: "p", AuthType: "plain",
+			SessionLifetime: 1800,
+		}},
+		{"update-lifetime", &cli.RootOptions{
+			Login: "w0000000", AuthData: "p", AuthType: "plain",
+			SessionUpdateLifetime: "Y",
+		}},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			tc.opts.ConfigPath = filepath.Join(t.TempDir(), "missing-config.toml")
+			_, err := cli.BuildAPIClient(tc.opts)
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			var ee *cli.ExitError
+			if !errors.As(err, &ee) || ee.Code != cli.ExitUserError {
+				t.Errorf("got %v, want ExitUserError", err)
+			}
+		})
+	}
+}
+
+func TestBuildAPIClientLifetimeRangeRejected(t *testing.T) {
+	t.Setenv("KAS_LOGIN", "")
+	t.Setenv("KAS_AUTHDATA", "")
+	t.Setenv("KAS_AUTHTYPE", "")
+
+	for _, lt := range []int{-1, 30001} {
+		lt := lt
+		t.Run("lifetime", func(t *testing.T) {
+			t.Parallel()
+			opts := &cli.RootOptions{
+				ConfigPath:      filepath.Join(t.TempDir(), "missing-config.toml"),
+				Login:           "w0000000",
+				AuthData:        "secret-password",
+				AuthType:        "session",
+				SessionLifetime: lt,
+			}
+			_, err := cli.BuildAPIClient(opts)
+			if err == nil {
+				t.Fatalf("expected error for lifetime=%d", lt)
+			}
+		})
+	}
+}
+
+func TestBuildAPIClientUpdateLifetimeInvalidRejected(t *testing.T) {
+	t.Setenv("KAS_LOGIN", "")
+	t.Setenv("KAS_AUTHDATA", "")
+	t.Setenv("KAS_AUTHTYPE", "")
+
+	opts := &cli.RootOptions{
+		ConfigPath:            filepath.Join(t.TempDir(), "missing-config.toml"),
+		Login:                 "w0000000",
+		AuthData:              "secret-password",
+		AuthType:              "session",
+		SessionUpdateLifetime: "yes",
+	}
+	_, err := cli.BuildAPIClient(opts)
+	if err == nil {
+		t.Fatal("expected error for invalid update-lifetime")
+	}
+}


### PR DESCRIPTION
## Summary

Adds three persistent root-command flags exposing the optional KasAuth bootstrap parameters:

- `--otp` → `session_2fa`
- `--session-lifetime` → `session_lifetime` (1..30000 seconds, range-checked client-side)
- `--session-update-lifetime` → `session_update_lifetime` (`Y`/`N`)

All three flow through `BuildAPIClient` into `auth.Options` so `auth.SessionTokenSource` forwards them on the credential-token request. They are KasAuth-only (the KAS docs do not cover them on direct `kas_auth_type=plain` calls), so combining any of them with `auth_type=plain` is rejected up front with a user-error exit code that points to the correct strategy.

The `--auth-type` and per-flag help texts spell out the KAS-protocol vs. CLI-config-strategy distinction so the duplicated word "plain" no longer misleads.