### PR TITLE
feat: interactive `kasapi-cli config init` (and `config show`/`path`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `kasapi-cli config` subcommand tree for first-run bootstrap and
+  inspection without hand-writing TOML: `config init` interactively
+  prompts for `login`, `auth_type` (`session`|`plain`, defaulting to
+  `session`), and `auth_data` (hidden via `golang.org/x/term.ReadPassword`),
+  writes the profile to the resolved config path with mode `0600`
+  (parent dirs created `0700`, atomic temp+rename), refuses to
+  overwrite an existing profile unless `--force`, and offers to set
+  `default_profile` when none is configured. `--profile` selects the
+  profile name (default `main`). Non-TTY stdin fails fast with a clear
+  error so CI and pipes do not hang. `config show` prints the resolved
+  effective configuration after the flag/env/profile merge with
+  `auth_data` redacted via `Credentials.String`. `config path` prints
+  the resolved config-file path. `config.Save` is the new persistence
+  helper that backs `config init`. (Closes #34.)
 - `--otp`, `--session-lifetime`, and `--session-update-lifetime`
   persistent flags on the root command, exposing the optional KasAuth
   parameters (`session_2fa`, `session_lifetime`, and

--- a/cmd/kasapi-cli/main.go
+++ b/cmd/kasapi-cli/main.go
@@ -17,6 +17,7 @@ func main() {
 	root.AddCommand(
 		cli.NewAccountCmd(opts),
 		cli.NewServerCmd(opts),
+		cli.NewConfigCmd(opts),
 	)
 	if err := root.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, "kasapi-cli:", err)

--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,16 @@
 module github.com/chmmou/kasapi-cli
 
-go 1.23
-
-require github.com/BurntSushi/toml v1.6.0
+go 1.23.0
 
 require (
-	github.com/goccy/go-yaml v1.19.2 // indirect
+	github.com/BurntSushi/toml v1.6.0
+	github.com/goccy/go-yaml v1.19.2
+	github.com/spf13/cobra v1.10.2
+	golang.org/x/term v0.30.0
+)
+
+require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/spf13/cobra v1.10.2 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
+	golang.org/x/sys v0.31.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -11,4 +11,8 @@ github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiT
 github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=
 github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
+golang.org/x/sys v0.31.0 h1:ioabZlmFYtWhL+TRYpcnNlLwhyxaM9kWTDEmfnprqik=
+golang.org/x/sys v0.31.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
+golang.org/x/term v0.30.0 h1:PQ39fJZ+mfadBm0y5WlL4vlM7Sx1Hgf13sMIY2+QS9Y=
+golang.org/x/term v0.30.0/go.mod h1:NYYFdzHoI5wRh/h5tDMdMqCqPJZEuNqVR5xJLd/n67g=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -1,0 +1,277 @@
+package cli
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"golang.org/x/term"
+
+	"github.com/chmmou/kasapi-cli/internal/config"
+)
+
+// NewConfigCmd returns the "kasapi-cli config" subcommand tree: init
+// (interactive bootstrap), show (resolved effective config with
+// auth_data redacted), and path (resolved config-file path).
+func NewConfigCmd(opts *RootOptions) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "config",
+		Short: "Inspect and bootstrap the kasapi-cli configuration",
+	}
+	cmd.AddCommand(
+		newConfigInitCmd(opts),
+		newConfigShowCmd(opts),
+		newConfigPathCmd(opts),
+	)
+	return cmd
+}
+
+func newConfigPathCmd(opts *RootOptions) *cobra.Command {
+	return &cobra.Command{
+		Use:   "path",
+		Short: "Print the resolved config-file path",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			path, err := resolveConfigPath(opts.ConfigPath)
+			if err != nil {
+				return UserError(err, "")
+			}
+			if _, err := fmt.Fprintln(cmd.OutOrStdout(), path); err != nil {
+				return UserError(err, "")
+			}
+			return nil
+		},
+	}
+}
+
+func newConfigShowCmd(opts *RootOptions) *cobra.Command {
+	return &cobra.Command{
+		Use:   "show",
+		Short: "Print the resolved effective config (auth_data redacted)",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runConfigShow(opts, cmd.OutOrStdout())
+		},
+	}
+}
+
+func runConfigShow(opts *RootOptions, out io.Writer) error {
+	path, err := resolveConfigPath(opts.ConfigPath)
+	if err != nil {
+		return UserError(err, "")
+	}
+	cfg, loadErr := config.Load(path)
+	if loadErr != nil && !errors.Is(loadErr, config.ErrNoConfig) {
+		return UserError(loadErr, "load config")
+	}
+	creds, resolveErr := cfg.Resolve(config.EnvFromOS(), config.Override{
+		Profile:  opts.Profile,
+		Login:    opts.Login,
+		AuthData: opts.AuthData,
+		AuthType: opts.AuthType,
+	})
+	w := &writeErr{w: out}
+	w.printf("config_path: %s\n", path)
+	if errors.Is(loadErr, config.ErrNoConfig) {
+		w.printf("config_file: <not found>\n")
+	} else {
+		w.printf("default_profile: %q\n", cfg.DefaultProfile)
+		w.printf("profiles: %s\n", profileNames(cfg))
+	}
+	if opts.Profile != "" {
+		w.printf("selected_profile: %q\n", opts.Profile)
+	}
+	if resolveErr != nil {
+		w.printf("resolved: error: %v\n", resolveErr)
+	} else {
+		w.printf("resolved: %s\n", creds.String())
+	}
+	if w.err != nil {
+		return UserError(w.err, "")
+	}
+	return nil
+}
+
+func newConfigInitCmd(opts *RootOptions) *cobra.Command {
+	var (
+		profileName string
+		force       bool
+	)
+	cmd := &cobra.Command{
+		Use:   "init",
+		Short: "Interactively create or replace a profile in the config file",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cio := defaultConfigIO()
+			cio.In = cmd.InOrStdin()
+			cio.Out = cmd.OutOrStdout()
+			return runConfigInit(opts.ConfigPath, profileName, force, cio)
+		},
+	}
+	cmd.Flags().StringVar(&profileName, "profile", "main", "profile name to write")
+	cmd.Flags().BoolVar(&force, "force", false, "overwrite an existing profile of the same name")
+	return cmd
+}
+
+// configIO bundles the user-interaction surface of `config init` so
+// tests can drive prompts and password input without a real terminal.
+type configIO struct {
+	In           io.Reader
+	Out          io.Writer
+	IsTTY        func() bool
+	ReadPassword func() (string, error)
+}
+
+func defaultConfigIO() configIO {
+	stdinFD := int(os.Stdin.Fd())
+	return configIO{
+		In:    os.Stdin,
+		Out:   os.Stdout,
+		IsTTY: func() bool { return term.IsTerminal(stdinFD) },
+		ReadPassword: func() (string, error) {
+			b, err := term.ReadPassword(stdinFD)
+			if _, perr := fmt.Fprintln(os.Stdout); perr != nil && err == nil {
+				err = perr
+			}
+			return string(b), err
+		},
+	}
+}
+
+func runConfigInit(configPath, profileName string, force bool, cio configIO) error {
+	if !cio.IsTTY() {
+		return UserError(errors.New("kasapi-cli config init requires an interactive terminal (stdin is not a TTY)"), "")
+	}
+	if profileName == "" {
+		return UserError(errors.New("--profile must not be empty"), "")
+	}
+	path, err := resolveConfigPath(configPath)
+	if err != nil {
+		return UserError(err, "")
+	}
+	cfg, err := config.Load(path)
+	if err != nil && !errors.Is(err, config.ErrNoConfig) {
+		return UserError(err, "load config")
+	}
+	if cfg == nil {
+		cfg = &config.Config{}
+	}
+	if cfg.Profiles == nil {
+		cfg.Profiles = map[string]config.Profile{}
+	}
+	if _, exists := cfg.Profiles[profileName]; exists && !force {
+		return UserError(fmt.Errorf("profile %q already exists in %s (rerun with --force to overwrite)", profileName, path), "")
+	}
+
+	r := bufio.NewReader(cio.In)
+	login, err := promptLine(r, cio.Out, "KAS login (e.g. w0000000): ")
+	if err != nil {
+		return UserError(err, "")
+	}
+	if login == "" {
+		return UserError(errors.New("login is required"), "")
+	}
+	authType, err := promptAuthType(r, cio.Out)
+	if err != nil {
+		return UserError(err, "")
+	}
+	if _, perr := fmt.Fprint(cio.Out, "auth_data (input hidden): "); perr != nil {
+		return UserError(perr, "")
+	}
+	authData, err := cio.ReadPassword()
+	if err != nil {
+		return UserError(err, "read password")
+	}
+	if authData == "" {
+		return UserError(errors.New("auth_data is required"), "")
+	}
+
+	cfg.Profiles[profileName] = config.Profile{
+		Login:    login,
+		AuthData: authData,
+		AuthType: authType,
+	}
+	if cfg.DefaultProfile == "" {
+		ans, perr := promptLine(r, cio.Out, fmt.Sprintf("Set %q as default_profile? [Y/n]: ", profileName))
+		if perr != nil {
+			return UserError(perr, "")
+		}
+		if ans == "" || strings.EqualFold(ans, "y") || strings.EqualFold(ans, "yes") {
+			cfg.DefaultProfile = profileName
+		}
+	}
+	if err := cfg.Save(path); err != nil {
+		return UserError(err, "")
+	}
+	if _, perr := fmt.Fprintf(cio.Out, "Wrote profile %q to %s\n", profileName, path); perr != nil {
+		return UserError(perr, "")
+	}
+	return nil
+}
+
+func resolveConfigPath(configPath string) (string, error) {
+	if configPath != "" {
+		return configPath, nil
+	}
+	return config.DefaultPath()
+}
+
+func promptLine(r *bufio.Reader, out io.Writer, prompt string) (string, error) {
+	if _, err := fmt.Fprint(out, prompt); err != nil {
+		return "", err
+	}
+	line, err := r.ReadString('\n')
+	if err != nil && !errors.Is(err, io.EOF) {
+		return "", err
+	}
+	return strings.TrimSpace(line), nil
+}
+
+func promptAuthType(r *bufio.Reader, out io.Writer) (string, error) {
+	for {
+		v, err := promptLine(r, out, fmt.Sprintf("auth_type (%s|%s) [%s]: ", config.AuthSession, config.AuthPlain, config.AuthSession))
+		if err != nil {
+			return "", err
+		}
+		switch v {
+		case "":
+			return config.AuthSession, nil
+		case config.AuthPlain, config.AuthSession:
+			return v, nil
+		}
+		if _, err := fmt.Fprintf(out, "  invalid auth_type %q (want %s or %s)\n", v, config.AuthSession, config.AuthPlain); err != nil {
+			return "", err
+		}
+	}
+}
+
+func profileNames(cfg *config.Config) string {
+	if cfg == nil {
+		return "[]"
+	}
+	names := make([]string, 0, len(cfg.Profiles))
+	for n := range cfg.Profiles {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	return "[" + strings.Join(names, ", ") + "]"
+}
+
+// writeErr is a fmt.Fprintf wrapper that records the first error so a
+// caller can issue a series of writes and only check err at the end.
+type writeErr struct {
+	w   io.Writer
+	err error
+}
+
+func (we *writeErr) printf(format string, args ...any) {
+	if we.err != nil {
+		return
+	}
+	_, we.err = fmt.Fprintf(we.w, format, args...)
+}

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -1,0 +1,288 @@
+package cli_test
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/BurntSushi/toml"
+
+	"github.com/chmmou/kasapi-cli/internal/cli"
+	"github.com/chmmou/kasapi-cli/internal/config"
+)
+
+func newIO(in string, password string) (*bytes.Buffer, cli.ConfigIO) {
+	out := &bytes.Buffer{}
+	cio := cli.ConfigIO{
+		In:           strings.NewReader(in),
+		Out:          out,
+		IsTTY:        func() bool { return true },
+		ReadPassword: func() (string, error) { return password, nil },
+	}
+	return out, cio
+}
+
+func TestRunConfigInitCreatesFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nested", "config.toml")
+	out, cio := newIO("w0000000\nsession\n\n", "supersecret")
+
+	if err := cli.RunConfigInit(path, "main", false, cio); err != nil {
+		t.Fatalf("RunConfigInit: %v", err)
+	}
+	cfg, err := config.Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.DefaultProfile != "main" {
+		t.Errorf("DefaultProfile = %q, want main", cfg.DefaultProfile)
+	}
+	got := cfg.Profiles["main"]
+	want := config.Profile{Login: "w0000000", AuthData: "supersecret", AuthType: "session"}
+	if got != want {
+		t.Errorf("profile = %+v, want %+v", got, want)
+	}
+	if !strings.Contains(out.String(), "Wrote profile") {
+		t.Errorf("missing success line: %q", out.String())
+	}
+	if runtime.GOOS != "windows" {
+		fi, err := os.Stat(path)
+		if err != nil {
+			t.Fatalf("stat: %v", err)
+		}
+		if mode := fi.Mode().Perm(); mode != 0o600 {
+			t.Errorf("file mode = %o, want 0600", mode)
+		}
+	}
+}
+
+func TestRunConfigInitDefaultsAuthTypeSession(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	// empty auth_type line → default session
+	_, cio := newIO("w0000000\n\n\n", "secret")
+
+	if err := cli.RunConfigInit(path, "main", false, cio); err != nil {
+		t.Fatalf("RunConfigInit: %v", err)
+	}
+	cfg, err := config.Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.Profiles["main"].AuthType != "session" {
+		t.Errorf("AuthType = %q, want session", cfg.Profiles["main"].AuthType)
+	}
+}
+
+func TestRunConfigInitRejectsAuthTypeUntilValid(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	out, cio := newIO("w0000000\nbogus\nplain\n\n", "secret")
+
+	if err := cli.RunConfigInit(path, "main", false, cio); err != nil {
+		t.Fatalf("RunConfigInit: %v", err)
+	}
+	cfg, err := config.Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.Profiles["main"].AuthType != "plain" {
+		t.Errorf("AuthType = %q, want plain", cfg.Profiles["main"].AuthType)
+	}
+	if !strings.Contains(out.String(), "invalid auth_type") {
+		t.Errorf("missing reprompt: %q", out.String())
+	}
+}
+
+func TestRunConfigInitRefusesOverwriteWithoutForce(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	pre := &config.Config{
+		DefaultProfile: "main",
+		Profiles: map[string]config.Profile{
+			"main": {Login: "w0000000", AuthData: "old", AuthType: "session"},
+		},
+	}
+	if err := pre.Save(path); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	_, cio := newIO("w0000001\nplain\n", "newsecret")
+
+	err := cli.RunConfigInit(path, "main", false, cio)
+	if err == nil {
+		t.Fatal("expected error for existing profile without --force")
+	}
+	var ee *cli.ExitError
+	if !errors.As(err, &ee) || ee.Code != cli.ExitUserError {
+		t.Errorf("expected ExitUserError, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "already exists") {
+		t.Errorf("error %q does not mention already exists", err)
+	}
+	cfg, _ := config.Load(path)
+	if cfg.Profiles["main"].AuthData != "old" {
+		t.Errorf("file was overwritten: AuthData = %q", cfg.Profiles["main"].AuthData)
+	}
+}
+
+func TestRunConfigInitForceOverwritesProfile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	pre := &config.Config{
+		DefaultProfile: "main",
+		Profiles: map[string]config.Profile{
+			"main": {Login: "w0000000", AuthData: "old", AuthType: "session"},
+		},
+	}
+	if err := pre.Save(path); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	_, cio := newIO("w0000001\nplain\n", "newsecret")
+
+	if err := cli.RunConfigInit(path, "main", true, cio); err != nil {
+		t.Fatalf("RunConfigInit: %v", err)
+	}
+	cfg, err := config.Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	want := config.Profile{Login: "w0000001", AuthData: "newsecret", AuthType: "plain"}
+	if cfg.Profiles["main"] != want {
+		t.Errorf("profile = %+v, want %+v", cfg.Profiles["main"], want)
+	}
+}
+
+func TestRunConfigInitNonInteractive(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	cio := cli.ConfigIO{
+		In:           strings.NewReader(""),
+		Out:          io.Discard,
+		IsTTY:        func() bool { return false },
+		ReadPassword: func() (string, error) { return "", nil },
+	}
+	err := cli.RunConfigInit(path, "main", false, cio)
+	if err == nil {
+		t.Fatal("expected non-TTY error")
+	}
+	var ee *cli.ExitError
+	if !errors.As(err, &ee) || ee.Code != cli.ExitUserError {
+		t.Errorf("expected ExitUserError, got %v", err)
+	}
+	if _, statErr := os.Stat(path); !os.IsNotExist(statErr) {
+		t.Errorf("file should not have been created on non-TTY error: %v", statErr)
+	}
+}
+
+func TestRunConfigInitRejectsEmptyLogin(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	_, cio := newIO("\n", "secret")
+	err := cli.RunConfigInit(path, "main", false, cio)
+	if err == nil {
+		t.Fatal("expected error for empty login")
+	}
+	if !strings.Contains(err.Error(), "login is required") {
+		t.Errorf("error %q does not mention login", err)
+	}
+}
+
+func TestRunConfigInitRejectsEmptyAuthData(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	_, cio := newIO("w0000000\nsession\n", "")
+	err := cli.RunConfigInit(path, "main", false, cio)
+	if err == nil {
+		t.Fatal("expected error for empty auth_data")
+	}
+	if !strings.Contains(err.Error(), "auth_data is required") {
+		t.Errorf("error %q does not mention auth_data", err)
+	}
+}
+
+func TestRunConfigInitDoesNotSetDefaultWhenDeclined(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	_, cio := newIO("w0000000\nsession\nn\n", "secret")
+
+	if err := cli.RunConfigInit(path, "main", false, cio); err != nil {
+		t.Fatalf("RunConfigInit: %v", err)
+	}
+	cfg, err := config.Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.DefaultProfile != "" {
+		t.Errorf("DefaultProfile = %q, want empty", cfg.DefaultProfile)
+	}
+}
+
+func TestRunConfigInitKeepsExistingDefaultProfile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	pre := &config.Config{
+		DefaultProfile: "main",
+		Profiles: map[string]config.Profile{
+			"main": {Login: "w0000000", AuthData: "secret", AuthType: "session"},
+		},
+	}
+	if err := pre.Save(path); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	// no default-profile prompt expected because one is already set
+	_, cio := newIO("w0000001\nplain\n", "stagingsecret")
+
+	if err := cli.RunConfigInit(path, "staging", false, cio); err != nil {
+		t.Fatalf("RunConfigInit: %v", err)
+	}
+	cfg, err := config.Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.DefaultProfile != "main" {
+		t.Errorf("DefaultProfile = %q, want main (must not change)", cfg.DefaultProfile)
+	}
+	if _, ok := cfg.Profiles["staging"]; !ok {
+		t.Errorf("staging profile missing")
+	}
+}
+
+func TestRunConfigInitDoesNotLeakAuthDataInOutput(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	out, cio := newIO("w0000000\nsession\n\n", "supersecretpwd")
+
+	if err := cli.RunConfigInit(path, "main", false, cio); err != nil {
+		t.Fatalf("RunConfigInit: %v", err)
+	}
+	if strings.Contains(out.String(), "supersecretpwd") {
+		t.Errorf("auth_data leaked to stdout: %q", out.String())
+	}
+}
+
+func TestConfigSaveReadback(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	cfg := &config.Config{
+		DefaultProfile: "main",
+		Profiles: map[string]config.Profile{
+			"main":    {Login: "w0000000", AuthData: "secret", AuthType: "session"},
+			"staging": {Login: "w0000001", AuthData: "other", AuthType: "plain"},
+		},
+	}
+	if err := cfg.Save(path); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	var got config.Config
+	if _, err := toml.DecodeFile(path, &got); err != nil {
+		t.Fatalf("DecodeFile: %v", err)
+	}
+	if got.DefaultProfile != "main" || len(got.Profiles) != 2 {
+		t.Errorf("readback mismatch: %+v", got)
+	}
+}

--- a/internal/cli/export_test.go
+++ b/internal/cli/export_test.go
@@ -1,0 +1,12 @@
+package cli
+
+// Internal hooks exported for tests in the cli_test package.
+
+// ConfigIO mirrors the unexported configIO struct used by `config init`.
+// Tests construct one to drive prompts and password input without a TTY.
+type ConfigIO = configIO
+
+// RunConfigInit runs the `config init` flow with the supplied IO.
+// Tests use it instead of executing the cobra subcommand directly so
+// the IsTTY/ReadPassword hooks can be substituted.
+var RunConfigInit = runConfigInit

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 
@@ -65,6 +66,57 @@ func Load(path string) (*Config, error) {
 		return nil, fmt.Errorf("config: %s: %w", path, err)
 	}
 	return &cfg, nil
+}
+
+// Save writes c as TOML to path. Empty path resolves to DefaultPath.
+// Parent directories are created with mode 0700; the file is written
+// with mode 0600. The write goes through a temp file in the same
+// directory and an atomic rename so a crash mid-write cannot corrupt
+// an existing config.
+func (c *Config) Save(path string) error {
+	if path == "" {
+		var err error
+		path, err = DefaultPath()
+		if err != nil {
+			return err
+		}
+	}
+	if err := c.validate(); err != nil {
+		return fmt.Errorf("config: %w", err)
+	}
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("config: create dir %s: %w", dir, err)
+	}
+	tmp, err := os.CreateTemp(dir, ".config-*.toml")
+	if err != nil {
+		return fmt.Errorf("config: create temp: %w", err)
+	}
+	tmpPath := tmp.Name()
+	cleanup := func() { _ = os.Remove(tmpPath) }
+	if err := tmp.Chmod(0o600); err != nil {
+		_ = tmp.Close()
+		cleanup()
+		return fmt.Errorf("config: chmod %s: %w", tmpPath, err)
+	}
+	if err := c.encode(tmp); err != nil {
+		_ = tmp.Close()
+		cleanup()
+		return fmt.Errorf("config: encode: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		cleanup()
+		return fmt.Errorf("config: close temp: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		cleanup()
+		return fmt.Errorf("config: rename to %s: %w", path, err)
+	}
+	return nil
+}
+
+func (c *Config) encode(w io.Writer) error {
+	return toml.NewEncoder(w).Encode(c)
 }
 
 func (c *Config) validate() error {


### PR DESCRIPTION
## Summary

Adds a `config` subcommand tree so first-run users no longer have to hand-write TOML:

- `config init` — interactive prompts for `login`, `auth_type` (`session`|`plain`), `auth_data` (input hidden via `golang.org/x/term.ReadPassword`); writes mode `0600` through an atomic temp+rename; refuses to overwrite without `--force`; offers to set `default_profile` when none is configured. Non-TTY stdin fails fast.
- `config show` — resolved effective config (after flag/env/profile merge) with `auth_data` redacted via `Credentials.String`.
- `config path` — resolved config-file path.

`config.Save` is the new persistence helper backing init.

Closes #34.