### PR TITLE
fix: let net/http handle gzip on KAS responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `internal/transport`: drop the manual `Accept-Encoding: gzip`
+  request header. `net/http` only decompresses gzip responses
+  transparently when the caller has *not* set that header; the manual
+  set turned automatic decoding off and leaked raw gzip bytes into the
+  XML decoder, surfacing as `XML syntax error: invalid character
+  entity &…` on the first kasserver response that came back compressed.
+  Removing the header lets `net/http` add it (and decode the response)
+  itself.
+
 ### Added
 
 - `kasapi-cli config` subcommand tree for first-run bootstrap and

--- a/internal/transport/client.go
+++ b/internal/transport/client.go
@@ -120,7 +120,12 @@ func (c *Client) doOnce(ctx context.Context, endpoint string, body []byte) ([]by
 	req.Header.Set("Content-Type", "text/xml; charset=utf-8")
 	req.Header.Set("SOAPAction", "")
 	req.Header.Set("User-Agent", c.UserAgent)
-	req.Header.Set("Accept-Encoding", "gzip")
+	// Intentionally no Accept-Encoding here. net/http sets it to "gzip"
+	// itself and transparently decodes the response only when the
+	// caller has *not* set the header. Setting it manually disables
+	// automatic decompression and hands the gzip stream to the XML
+	// decoder, which surfaces as `XML syntax error: invalid character
+	// entity` on the first kasserver response that comes back compressed.
 
 	resp, err := c.HTTPClient.Do(req)
 	if err != nil {

--- a/internal/transport/client_test.go
+++ b/internal/transport/client_test.go
@@ -1,11 +1,14 @@
 package transport_test
 
 import (
+	"bytes"
+	"compress/gzip"
 	"context"
 	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -93,6 +96,46 @@ func TestDoSuccess(t *testing.T) {
 	}
 	if string(got.body) != sampleEnvelope {
 		t.Errorf("server received %q, want %q", got.body, sampleEnvelope)
+	}
+}
+
+// Regression for kasserver responses returned with Content-Encoding:
+// gzip. net/http only decompresses transparently when the caller has
+// *not* set Accept-Encoding; an explicit Accept-Encoding: gzip header
+// disables that and leaks raw gzip bytes into the XML decoder
+// ("invalid character entity &…").
+func TestDoTransparentlyDecompressesGzip(t *testing.T) {
+	const payload = `<?xml version="1.0"?><soapenv:Envelope><Body>ok</Body></soapenv:Envelope>`
+
+	var sentAcceptEncoding string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sentAcceptEncoding = r.Header.Get("Accept-Encoding")
+		// Only gzip-encode if the client claims to accept gzip — net/http
+		// adds it automatically when the caller did not set the header.
+		if !strings.Contains(sentAcceptEncoding, "gzip") {
+			_, _ = io.WriteString(w, payload)
+			return
+		}
+		var buf bytes.Buffer
+		gz := gzip.NewWriter(&buf)
+		_, _ = gz.Write([]byte(payload))
+		_ = gz.Close()
+		w.Header().Set("Content-Encoding", "gzip")
+		w.Header().Set("Content-Type", "text/xml")
+		_, _ = w.Write(buf.Bytes())
+	}))
+	defer srv.Close()
+
+	c := newClient(srv, newFakeClock())
+	resp, err := c.Do(context.Background(), srv.URL, []byte(sampleEnvelope))
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	if string(resp) != payload {
+		t.Errorf("body = %q, want %q", resp, payload)
+	}
+	if !strings.Contains(sentAcceptEncoding, "gzip") {
+		t.Errorf("Accept-Encoding = %q, want it to contain gzip (net/http auto-adds it)", sentAcceptEncoding)
 	}
 }
 


### PR DESCRIPTION
## Summary

Drop the manual `Accept-Encoding: gzip` request header in `internal/transport`. `net/http` only decodes gzip responses transparently when the caller has *not* set that header — so the manual set turned automatic decompression off, and the raw gzip stream was being handed to the XML decoder.

The user-visible symptom was, on a real `accounts list` call hitting a kasserver response that comes back compressed:

```
api: credentials: auth: decode: XML syntax error on line 1: invalid character entity &�� (no semicolon)
```

Regression test in `internal/transport/client_test.go`: the test server only gzip-encodes when the request claims `Accept-Encoding: gzip`, and asserts both that the header is present (proving `net/http` auto-added it) and that `Do` returns the decompressed XML payload.