### PR TITLE
feat: persist session tokens across CLI invocations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `internal/session` persistent session-token cache so a successful
+  KasAuth login (including 2FA via `--otp`) survives across CLI
+  invocations: a new `sessions.toml` next to the config file (mode
+  `0600`, atomic temp+rename) stores `{token, expires_at,
+  lifetime_seconds, update_lifetime}` keyed by login.
+  `auth.SessionTokenSource` now loads the cached entry on first use,
+  reuses it while `expires_at` has not been reached, persists every
+  fresh KasAuth response, and deletes the entry on `Invalidate`.
+  Lifetime defaults to `session.DefaultLifetime` (24 h, matching the
+  KasAuth `session_lifetime` default) when `--session-lifetime` was
+  not set; otherwise it mirrors the flag value. With
+  `--session-update-lifetime Y`, `api.Client.Call` now invokes a new
+  optional `Heartbeater` interface on the token source after every
+  successful call so the local `expires_at` rolls forward in lockstep
+  with the server-side window. Practical effect: rerun a command and
+  no `--otp` prompt is needed for as long as the session is alive.
+
 ### Fixed
 
 - `internal/transport`: drop the manual `Accept-Encoding: gzip`

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -29,6 +29,14 @@ type TokenSource interface {
 	Invalidate()
 }
 
+// Heartbeater is an optional TokenSource extension. After every
+// successful Call, Client invokes Heartbeat so a session-token source
+// configured with session_update_lifetime=Y can extend its locally
+// cached expiry to mirror the rolling window the server applies.
+type Heartbeater interface {
+	Heartbeat()
+}
+
 // StaticTokenSource is a TokenSource that returns the same credentials
 // every call. Suitable for plain auth and for tests; session-token
 // callers should use the source provided by the auth package once the
@@ -85,12 +93,15 @@ func (c *Client) Call(ctx context.Context, action string, params map[string]any)
 		return nil, errors.New("api: action is required")
 	}
 	resp, err := c.callOnce(ctx, action, params)
-	if err == nil {
-		return resp, nil
-	}
-	if IsAuthFailure(err) {
+	if err != nil && IsAuthFailure(err) {
 		c.Tokens.Invalidate()
-		return c.callOnce(ctx, action, params)
+		resp, err = c.callOnce(ctx, action, params)
+	}
+	if err == nil {
+		if hb, ok := c.Tokens.(Heartbeater); ok {
+			hb.Heartbeat()
+		}
+		return resp, nil
 	}
 	return nil, err
 }

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -220,6 +220,40 @@ func TestCallRejectsEmptyAction(t *testing.T) {
 	}
 }
 
+func TestCallHeartbeatsTokenSourceOnSuccess(t *testing.T) {
+	body := loadFixture(t, "account/get_accounts_response_success.xml")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(body)
+	}))
+	defer srv.Close()
+
+	ts := &beatingTokens{login: "w0", data: "tok", typ: soap.AuthSession}
+	c := newAPIClient(srv, ts)
+	if _, err := c.Call(context.Background(), "get_accounts", nil); err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	if ts.heartbeats != 1 {
+		t.Errorf("heartbeats = %d, want 1", ts.heartbeats)
+	}
+}
+
+func TestCallNoHeartbeatOnFailure(t *testing.T) {
+	body := loadFixture(t, "account/add_account_response_failed_max_account_reached.xml")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(body)
+	}))
+	defer srv.Close()
+
+	ts := &beatingTokens{login: "w0", data: "tok", typ: soap.AuthSession}
+	c := newAPIClient(srv, ts)
+	if _, err := c.Call(context.Background(), "add_account", nil); err == nil {
+		t.Fatal("expected error")
+	}
+	if ts.heartbeats != 0 {
+		t.Errorf("heartbeats = %d, want 0 on fault", ts.heartbeats)
+	}
+}
+
 // countingTokens is a TokenSource that swaps AuthData on Invalidate so
 // tests can confirm the retry pulled fresh credentials.
 type countingTokens struct {
@@ -240,3 +274,18 @@ func (c *countingTokens) Invalidate() {
 	c.invalidations++
 	c.data = c.refresh
 }
+
+// beatingTokens implements TokenSource + Heartbeater to verify the
+// post-success hook in Client.Call.
+type beatingTokens struct {
+	login      string
+	data       string
+	typ        soap.AuthType
+	heartbeats int
+}
+
+func (b *beatingTokens) Credentials(_ context.Context) (string, string, soap.AuthType, error) {
+	return b.login, b.data, b.typ, nil
+}
+func (b *beatingTokens) Invalidate() {}
+func (b *beatingTokens) Heartbeat()  { b.heartbeats++ }

--- a/internal/auth/client_test.go
+++ b/internal/auth/client_test.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/chmmou/kasapi-cli/internal/auth"
+	"github.com/chmmou/kasapi-cli/internal/session"
 	"github.com/chmmou/kasapi-cli/internal/soap"
 	"github.com/chmmou/kasapi-cli/internal/transport"
 )
@@ -145,6 +147,181 @@ func TestSessionTokenSourcePropagatesAuthError(t *testing.T) {
 	if !auth.IsOTPPinIncorrect(err) {
 		t.Errorf("expected IsOTPPinIncorrect, got %v", err)
 	}
+}
+
+func TestSessionTokenSourceLoadsFromStore(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		t.Error("server should not be reached when a valid cached token exists")
+	}))
+	defer srv.Close()
+
+	now := time.Date(2026, 5, 3, 12, 0, 0, 0, time.UTC)
+	store := newStore(t, now)
+	if err := store.Save("w0", session.Entry{
+		Token:           "cached-tok",
+		ExpiresAt:       now.Add(time.Hour),
+		LifetimeSeconds: 3600,
+	}); err != nil {
+		t.Fatalf("seed Save: %v", err)
+	}
+
+	src := auth.NewSessionTokenSource(newAuthClient(srv, "w0", "secret", soap.AuthPlain, auth.Options{}))
+	src.Store = store
+	src.Now = func() time.Time { return now }
+
+	login, data, typ, err := src.Credentials(context.Background())
+	if err != nil {
+		t.Fatalf("Credentials: %v", err)
+	}
+	if login != "w0" || data != "cached-tok" || typ != soap.AuthSession {
+		t.Errorf("Credentials = (%q,%q,%q), want (w0, cached-tok, session)", login, data, typ)
+	}
+}
+
+func TestSessionTokenSourceFetchesWhenStoredEntryExpired(t *testing.T) {
+	body := loadFixture(t, "session/add_session_response_success.xml")
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls.Add(1)
+		_, _ = w.Write(body)
+	}))
+	defer srv.Close()
+
+	now := time.Date(2026, 5, 3, 12, 0, 0, 0, time.UTC)
+	store := newStore(t, now)
+	if err := store.Save("w0", session.Entry{
+		Token:     "stale",
+		ExpiresAt: now.Add(-time.Second),
+	}); err != nil {
+		t.Fatalf("seed Save: %v", err)
+	}
+
+	src := auth.NewSessionTokenSource(newAuthClient(srv, "w0", "secret", soap.AuthPlain, auth.Options{}))
+	src.Store = store
+	src.Lifetime = time.Hour
+	src.Now = func() time.Time { return now }
+
+	_, data, _, err := src.Credentials(context.Background())
+	if err != nil {
+		t.Fatalf("Credentials: %v", err)
+	}
+	if data == "stale" {
+		t.Error("expected fresh token, got the stale cached one")
+	}
+	if calls.Load() != 1 {
+		t.Errorf("KasAuth calls = %d, want 1", calls.Load())
+	}
+	saved, err := store.Load("w0")
+	if err != nil || saved == nil {
+		t.Fatalf("expected fresh entry persisted, got %v %v", saved, err)
+	}
+	if !saved.ExpiresAt.Equal(now.Add(time.Hour)) {
+		t.Errorf("ExpiresAt = %v, want %v", saved.ExpiresAt, now.Add(time.Hour))
+	}
+}
+
+func TestSessionTokenSourceInvalidateDeletesPersisted(t *testing.T) {
+	body := loadFixture(t, "session/add_session_response_success.xml")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(body)
+	}))
+	defer srv.Close()
+
+	now := time.Date(2026, 5, 3, 12, 0, 0, 0, time.UTC)
+	store := newStore(t, now)
+	src := auth.NewSessionTokenSource(newAuthClient(srv, "w0", "secret", soap.AuthPlain, auth.Options{}))
+	src.Store = store
+	src.Lifetime = time.Hour
+	src.Now = func() time.Time { return now }
+
+	if _, _, _, err := src.Credentials(context.Background()); err != nil {
+		t.Fatalf("Credentials: %v", err)
+	}
+	if got, _ := store.Load("w0"); got == nil {
+		t.Fatal("expected entry persisted after fresh fetch")
+	}
+	src.Invalidate()
+	if got, _ := store.Load("w0"); got != nil {
+		t.Errorf("expected entry deleted after Invalidate, got %+v", got)
+	}
+}
+
+func TestSessionTokenSourceHeartbeatExtendsExpiry(t *testing.T) {
+	body := loadFixture(t, "session/add_session_response_success.xml")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(body)
+	}))
+	defer srv.Close()
+
+	tNow := time.Date(2026, 5, 3, 12, 0, 0, 0, time.UTC)
+	store := newStore(t, tNow)
+	src := auth.NewSessionTokenSource(newAuthClient(srv, "w0", "secret", soap.AuthPlain, auth.Options{}))
+	src.Store = store
+	src.Lifetime = time.Hour
+	src.UpdateLifetime = true
+	src.Now = func() time.Time { return tNow }
+
+	if _, _, _, err := src.Credentials(context.Background()); err != nil {
+		t.Fatalf("Credentials: %v", err)
+	}
+	first, _ := store.Load("w0")
+	if first == nil {
+		t.Fatal("expected initial entry")
+	}
+
+	tNow = tNow.Add(15 * time.Minute)
+	store.Now = func() time.Time { return tNow }
+	src.Heartbeat()
+
+	got, _ := store.Load("w0")
+	if got == nil {
+		t.Fatal("expected entry after Heartbeat")
+	}
+	want := tNow.Add(time.Hour)
+	if !got.ExpiresAt.Equal(want) {
+		t.Errorf("ExpiresAt after Heartbeat = %v, want %v", got.ExpiresAt, want)
+	}
+}
+
+func TestSessionTokenSourceHeartbeatNoopWithoutUpdateLifetime(t *testing.T) {
+	body := loadFixture(t, "session/add_session_response_success.xml")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(body)
+	}))
+	defer srv.Close()
+
+	tNow := time.Date(2026, 5, 3, 12, 0, 0, 0, time.UTC)
+	store := newStore(t, tNow)
+	src := auth.NewSessionTokenSource(newAuthClient(srv, "w0", "secret", soap.AuthPlain, auth.Options{}))
+	src.Store = store
+	src.Lifetime = time.Hour
+	src.Now = func() time.Time { return tNow }
+
+	if _, _, _, err := src.Credentials(context.Background()); err != nil {
+		t.Fatalf("Credentials: %v", err)
+	}
+	original, _ := store.Load("w0")
+	if original == nil {
+		t.Fatal("expected initial entry")
+	}
+
+	tNow = tNow.Add(15 * time.Minute)
+	src.Heartbeat()
+
+	got, _ := store.Load("w0")
+	if got == nil || !got.ExpiresAt.Equal(original.ExpiresAt) {
+		t.Errorf("ExpiresAt changed without UpdateLifetime: %+v", got)
+	}
+}
+
+func newStore(t *testing.T, now time.Time) *session.Store {
+	t.Helper()
+	s, err := session.New(filepath.Join(t.TempDir(), "sessions.toml"))
+	if err != nil {
+		t.Fatalf("session.New: %v", err)
+	}
+	s.Now = func() time.Time { return now }
+	return s
 }
 
 func readAll(r *http.Request) []byte {

--- a/internal/auth/client_test.go
+++ b/internal/auth/client_test.go
@@ -283,6 +283,49 @@ func TestSessionTokenSourceHeartbeatExtendsExpiry(t *testing.T) {
 	}
 }
 
+func TestSessionTokenSourceAdoptsLifetimeFromCachedEntry(t *testing.T) {
+	// Source created with no lifetime / update flags (e.g. a CLI run
+	// without the KasAuth flags). It picks up a token persisted by an
+	// earlier run that *did* enable session_update_lifetime, and must
+	// honour those server-side properties on Heartbeat.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		t.Error("server should not be reached when a valid cached token exists")
+	}))
+	defer srv.Close()
+
+	tNow := time.Date(2026, 5, 3, 12, 0, 0, 0, time.UTC)
+	store := newStore(t, tNow)
+	if err := store.Save("w0", session.Entry{
+		Token:           "cached",
+		ExpiresAt:       tNow.Add(time.Hour),
+		LifetimeSeconds: 3600,
+		UpdateLifetime:  true,
+	}); err != nil {
+		t.Fatalf("seed Save: %v", err)
+	}
+
+	src := auth.NewSessionTokenSource(newAuthClient(srv, "w0", "secret", soap.AuthPlain, auth.Options{}))
+	src.Store = store
+	src.Now = func() time.Time { return tNow }
+
+	if _, _, _, err := src.Credentials(context.Background()); err != nil {
+		t.Fatalf("Credentials: %v", err)
+	}
+
+	tNow = tNow.Add(15 * time.Minute)
+	store.Now = func() time.Time { return tNow }
+	src.Heartbeat()
+
+	got, _ := store.Load("w0")
+	if got == nil {
+		t.Fatal("expected entry after Heartbeat")
+	}
+	want := tNow.Add(time.Hour)
+	if !got.ExpiresAt.Equal(want) {
+		t.Errorf("ExpiresAt after adopted-Heartbeat = %v, want %v (lifetime should come from cached entry)", got.ExpiresAt, want)
+	}
+}
+
 func TestSessionTokenSourceHeartbeatNoopWithoutUpdateLifetime(t *testing.T) {
 	body := loadFixture(t, "session/add_session_response_success.xml")
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/internal/auth/source.go
+++ b/internal/auth/source.go
@@ -63,6 +63,15 @@ func (s *SessionTokenSource) Credentials(ctx context.Context) (string, string, s
 			s.token = e.Token
 			s.expiresAt = e.ExpiresAt
 			if s.cachedValid() {
+				// Adopt the server-side properties of this session so
+				// later Heartbeats use the lifetime the session was
+				// created with, not whatever flags the current CLI run
+				// happens to carry. session_update_lifetime is a
+				// KasAuth-time decision, not a runtime knob.
+				if e.LifetimeSeconds > 0 {
+					s.Lifetime = time.Duration(e.LifetimeSeconds) * time.Second
+				}
+				s.UpdateLifetime = e.UpdateLifetime
 				return s.Client.Login, s.token, soap.AuthSession, nil
 			}
 			s.token = ""

--- a/internal/auth/source.go
+++ b/internal/auth/source.go
@@ -3,51 +3,146 @@ package auth
 import (
 	"context"
 	"sync"
+	"time"
 
+	"github.com/chmmou/kasapi-cli/internal/session"
 	"github.com/chmmou/kasapi-cli/internal/soap"
 )
 
 // SessionTokenSource caches a credential token fetched via Client and
-// re-fetches it on demand. It implements api.TokenSource: api.Client
-// calls Credentials before every request and Invalidate after an auth
-// failure, which causes the next Credentials call to obtain a fresh
-// token via the underlying KasAuth client.
+// re-fetches it on demand. It implements api.TokenSource.
+//
+// When Store is set, the cache is also persisted to disk so a token
+// obtained interactively (with --otp) survives across CLI invocations
+// for as long as ExpiresAt has not been reached. Lifetime mirrors the
+// server-side session_lifetime; a zero Lifetime falls back to
+// session.DefaultLifetime so the local view does not grow stale
+// faster than the server.
+//
+// UpdateLifetime mirrors session_update_lifetime=Y on the server: when
+// true, Heartbeat (called by api.Client after every successful call)
+// extends ExpiresAt to Now+Lifetime so the cache tracks the rolling
+// window the server applies.
 //
 // SessionTokenSource is safe for concurrent use.
 type SessionTokenSource struct {
-	Client *Client
+	Client         *Client
+	Store          *session.Store
+	Lifetime       time.Duration
+	UpdateLifetime bool
+	Now            func() time.Time
 
-	mu    sync.Mutex
-	token string
+	mu        sync.Mutex
+	loaded    bool
+	token     string
+	expiresAt time.Time
 }
 
 // NewSessionTokenSource returns a source that lazily fetches the token
-// on first use. The login it reports to api.Client is the one stored on
-// the underlying KasAuth client; the auth_type for KasApi calls is
-// always session, since the credential token is a session token.
+// on first use and does not persist it. Set Store, Lifetime, and
+// UpdateLifetime on the returned value to enable cross-invocation
+// caching.
 func NewSessionTokenSource(c *Client) *SessionTokenSource {
 	return &SessionTokenSource{Client: c}
 }
 
-// Credentials returns the cached token, fetching a new one if the
-// cache is empty.
+// Credentials returns the cached token. Order of preference:
+//  1. an in-memory token that has not expired,
+//  2. a persisted token loaded from Store that has not expired,
+//  3. a fresh token from KasAuth (also persisted when Store is set).
 func (s *SessionTokenSource) Credentials(ctx context.Context) (string, string, soap.AuthType, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if s.token == "" {
-		t, err := s.Client.GetCredentialToken(ctx)
-		if err != nil {
-			return "", "", "", err
+
+	if s.cachedValid() {
+		return s.Client.Login, s.token, soap.AuthSession, nil
+	}
+	if !s.loaded && s.Store != nil {
+		s.loaded = true
+		if e, err := s.Store.Load(s.Client.Login); err == nil && e != nil {
+			s.token = e.Token
+			s.expiresAt = e.ExpiresAt
+			if s.cachedValid() {
+				return s.Client.Login, s.token, soap.AuthSession, nil
+			}
+			s.token = ""
+			s.expiresAt = time.Time{}
 		}
-		s.token = t
+	}
+	t, err := s.Client.GetCredentialToken(ctx)
+	if err != nil {
+		return "", "", "", err
+	}
+	s.token = t
+	s.expiresAt = s.now().Add(s.lifetime())
+	if s.Store != nil {
+		entry := session.Entry{
+			Token:           t,
+			ExpiresAt:       s.expiresAt,
+			LifetimeSeconds: int(s.lifetime() / time.Second),
+			UpdateLifetime:  s.UpdateLifetime,
+		}
+		_ = s.Store.Save(s.Client.Login, entry)
 	}
 	return s.Client.Login, s.token, soap.AuthSession, nil
 }
 
-// Invalidate clears the cached token so the next Credentials call
-// re-authenticates against KasAuth.
+// Invalidate clears the cached token in memory and on disk so the next
+// Credentials call re-authenticates against KasAuth.
 func (s *SessionTokenSource) Invalidate() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.token = ""
+	s.expiresAt = time.Time{}
+	s.loaded = true
+	if s.Store != nil {
+		_ = s.Store.Delete(s.Client.Login)
+	}
+}
+
+// Heartbeat extends the cached expiry by Lifetime when UpdateLifetime
+// is true, mirroring the server's session_update_lifetime=Y rolling
+// window. It is a no-op when there is no cached token, when
+// UpdateLifetime is false, or when no Store is wired up. Called by
+// api.Client after every successful KasApi call.
+func (s *SessionTokenSource) Heartbeat() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if !s.UpdateLifetime || s.token == "" {
+		return
+	}
+	s.expiresAt = s.now().Add(s.lifetime())
+	if s.Store != nil {
+		entry := session.Entry{
+			Token:           s.token,
+			ExpiresAt:       s.expiresAt,
+			LifetimeSeconds: int(s.lifetime() / time.Second),
+			UpdateLifetime:  true,
+		}
+		_ = s.Store.Save(s.Client.Login, entry)
+	}
+}
+
+func (s *SessionTokenSource) cachedValid() bool {
+	if s.token == "" {
+		return false
+	}
+	if s.expiresAt.IsZero() {
+		return true
+	}
+	return s.now().Before(s.expiresAt)
+}
+
+func (s *SessionTokenSource) now() time.Time {
+	if s.Now != nil {
+		return s.Now()
+	}
+	return time.Now()
+}
+
+func (s *SessionTokenSource) lifetime() time.Duration {
+	if s.Lifetime > 0 {
+		return s.Lifetime
+	}
+	return session.DefaultLifetime
 }

--- a/internal/cli/wire.go
+++ b/internal/cli/wire.go
@@ -3,10 +3,12 @@ package cli
 import (
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/chmmou/kasapi-cli/internal/api"
 	"github.com/chmmou/kasapi-cli/internal/auth"
 	"github.com/chmmou/kasapi-cli/internal/config"
+	"github.com/chmmou/kasapi-cli/internal/session"
 	"github.com/chmmou/kasapi-cli/internal/soap"
 	"github.com/chmmou/kasapi-cli/internal/transport"
 )
@@ -90,7 +92,19 @@ func tokenSource(tr *transport.Client, creds config.Credentials, s sessionOpts) 
 			return nil, err
 		}
 		authClient := auth.New(tr, creds.Login, creds.AuthData, soap.AuthPlain, authOpts)
-		return auth.NewSessionTokenSource(authClient), nil
+		src := auth.NewSessionTokenSource(authClient)
+		store, serr := session.New("")
+		if serr != nil {
+			return nil, fmt.Errorf("session store: %w", serr)
+		}
+		src.Store = store
+		if s.Lifetime > 0 {
+			src.Lifetime = time.Duration(s.Lifetime) * time.Second
+		}
+		if authOpts.UpdateLifetime != nil && *authOpts.UpdateLifetime {
+			src.UpdateLifetime = true
+		}
+		return src, nil
 	default:
 		return nil, fmt.Errorf("config: unsupported auth_type %q", creds.AuthType)
 	}

--- a/internal/cli/wire.go
+++ b/internal/cli/wire.go
@@ -50,6 +50,7 @@ func BuildAPIClient(opts *RootOptions) (*api.Client, error) {
 
 	tr := transport.New()
 	ts, err := tokenSource(tr, creds, sessionOpts{
+		ConfigPath:     opts.ConfigPath,
 		OTP:            opts.OTP,
 		Lifetime:       opts.SessionLifetime,
 		UpdateLifetime: opts.SessionUpdateLifetime,
@@ -61,8 +62,11 @@ func BuildAPIClient(opts *RootOptions) (*api.Client, error) {
 }
 
 // sessionOpts groups the KasAuth-only flag values plumbed through to
-// auth.Options. All fields are optional; zero values mean "omit".
+// auth.Options plus the resolved --config path so the session store
+// can live next to a custom config file. All fields are optional;
+// zero values mean "omit" / "default location".
 type sessionOpts struct {
+	ConfigPath     string
 	OTP            string
 	Lifetime       int
 	UpdateLifetime string
@@ -93,7 +97,11 @@ func tokenSource(tr *transport.Client, creds config.Credentials, s sessionOpts) 
 		}
 		authClient := auth.New(tr, creds.Login, creds.AuthData, soap.AuthPlain, authOpts)
 		src := auth.NewSessionTokenSource(authClient)
-		store, serr := session.New("")
+		storePath, serr := session.PathFor(s.ConfigPath)
+		if serr != nil {
+			return nil, fmt.Errorf("session store: %w", serr)
+		}
+		store, serr := session.New(storePath)
 		if serr != nil {
 			return nil, fmt.Errorf("session store: %w", serr)
 		}

--- a/internal/session/helpers_test.go
+++ b/internal/session/helpers_test.go
@@ -1,0 +1,7 @@
+package session_test
+
+import "os"
+
+func statFile(path string) (os.FileInfo, error) {
+	return os.Stat(path)
+}

--- a/internal/session/store.go
+++ b/internal/session/store.go
@@ -78,6 +78,17 @@ func DefaultPath() (string, error) {
 	return filepath.Join(dir, "kasapi-cli", "sessions.toml"), nil
 }
 
+// PathFor returns the sessions file path that pairs with configPath.
+// Empty configPath resolves to DefaultPath. Otherwise the file lives
+// next to the config file as sessions.toml so a custom --config flag
+// keeps both halves of the on-disk state colocated.
+func PathFor(configPath string) (string, error) {
+	if configPath == "" {
+		return DefaultPath()
+	}
+	return filepath.Join(filepath.Dir(configPath), "sessions.toml"), nil
+}
+
 // Load returns the entry stored for login. nil is returned (without
 // error) when the file is absent, the login is not present, or the
 // entry has expired; expired entries are best-effort removed.

--- a/internal/session/store.go
+++ b/internal/session/store.go
@@ -1,0 +1,210 @@
+// Package session persists KasAuth credential tokens between CLI
+// invocations so a successful interactive login (including 2FA) does
+// not have to be repeated on every command for as long as the server
+// keeps the session alive.
+//
+// The store is a single TOML file (sessions.toml) keyed by login,
+// living next to the config file and written with mode 0600. Entries
+// expire client-side via ExpiresAt; the server's session_lifetime is
+// the source of truth, but mirroring it locally lets the CLI skip the
+// KasAuth round trip while a token is still good and refresh it
+// transparently once it is not.
+package session
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/BurntSushi/toml"
+)
+
+// DefaultLifetime is applied when an Entry is saved without a
+// LifetimeSeconds value. It matches the documented KasAuth default
+// (session_lifetime, 24 h) so a CLI invocation that did not pass
+// --session-lifetime still ends up with a sensible local expiry.
+const DefaultLifetime = 24 * time.Hour
+
+// Entry is one cached session token. The map key in the on-disk file
+// is the login, so Login is not encoded.
+type Entry struct {
+	Token           string    `toml:"token"`
+	ExpiresAt       time.Time `toml:"expires_at"`
+	LifetimeSeconds int       `toml:"lifetime_seconds"`
+	UpdateLifetime  bool      `toml:"update_lifetime"`
+}
+
+// Store reads and writes sessions to a TOML file. The zero value is
+// not usable; obtain one via New.
+type Store struct {
+	Path string
+	Now  func() time.Time
+}
+
+// fileFormat mirrors the on-disk schema:
+//
+//	[sessions.<login>]
+//	token = "..."
+//	expires_at = 2026-05-03T12:00:00Z
+//	lifetime_seconds = 3600
+//	update_lifetime = true
+type fileFormat struct {
+	Sessions map[string]Entry `toml:"sessions"`
+}
+
+// New returns a Store backed by path. Empty path resolves to
+// DefaultPath. The clock is wall-clock; tests override Now.
+func New(path string) (*Store, error) {
+	if path == "" {
+		var err error
+		path, err = DefaultPath()
+		if err != nil {
+			return nil, err
+		}
+	}
+	return &Store{Path: path, Now: time.Now}, nil
+}
+
+// DefaultPath returns the OS-specific default location of the
+// sessions file, alongside the config file.
+func DefaultPath() (string, error) {
+	dir, err := os.UserConfigDir()
+	if err != nil {
+		return "", fmt.Errorf("session: locate user config dir: %w", err)
+	}
+	return filepath.Join(dir, "kasapi-cli", "sessions.toml"), nil
+}
+
+// Load returns the entry stored for login. nil is returned (without
+// error) when the file is absent, the login is not present, or the
+// entry has expired; expired entries are best-effort removed.
+func (s *Store) Load(login string) (*Entry, error) {
+	if login == "" {
+		return nil, errors.New("session: Load requires login")
+	}
+	file, err := s.read()
+	if err != nil {
+		return nil, err
+	}
+	e, ok := file.Sessions[login]
+	if !ok {
+		return nil, nil
+	}
+	if !e.ExpiresAt.IsZero() && !s.now().Before(e.ExpiresAt) {
+		_ = s.Delete(login)
+		return nil, nil
+	}
+	return &e, nil
+}
+
+// Save writes e under login, replacing any existing entry. If
+// ExpiresAt is zero, it is computed as Now+LifetimeSeconds (or
+// Now+DefaultLifetime when LifetimeSeconds is 0).
+func (s *Store) Save(login string, e Entry) error {
+	if login == "" {
+		return errors.New("session: Save requires login")
+	}
+	if e.Token == "" {
+		return errors.New("session: Save requires token")
+	}
+	if e.ExpiresAt.IsZero() {
+		e.ExpiresAt = s.now().Add(s.lifetime(e))
+	}
+	file, err := s.read()
+	if err != nil {
+		return err
+	}
+	if file.Sessions == nil {
+		file.Sessions = map[string]Entry{}
+	}
+	file.Sessions[login] = e
+	return s.write(file)
+}
+
+// Delete removes the entry for login. Missing files and missing
+// entries are not errors. The file itself is removed when the last
+// entry is taken out so the on-disk state matches "no sessions".
+func (s *Store) Delete(login string) error {
+	if login == "" {
+		return errors.New("session: Delete requires login")
+	}
+	file, err := s.read()
+	if err != nil {
+		return err
+	}
+	if _, ok := file.Sessions[login]; !ok {
+		return nil
+	}
+	delete(file.Sessions, login)
+	if len(file.Sessions) == 0 {
+		if rerr := os.Remove(s.Path); rerr != nil && !errors.Is(rerr, os.ErrNotExist) {
+			return fmt.Errorf("session: remove %s: %w", s.Path, rerr)
+		}
+		return nil
+	}
+	return s.write(file)
+}
+
+func (s *Store) read() (fileFormat, error) {
+	var file fileFormat
+	if _, err := toml.DecodeFile(s.Path, &file); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return fileFormat{}, nil
+		}
+		return fileFormat{}, fmt.Errorf("session: parse %s: %w", s.Path, err)
+	}
+	return file, nil
+}
+
+func (s *Store) write(file fileFormat) error {
+	dir := filepath.Dir(s.Path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("session: create dir %s: %w", dir, err)
+	}
+	tmp, err := os.CreateTemp(dir, ".sessions-*.toml")
+	if err != nil {
+		return fmt.Errorf("session: create temp: %w", err)
+	}
+	tmpPath := tmp.Name()
+	cleanup := func() { _ = os.Remove(tmpPath) }
+	if cherr := tmp.Chmod(0o600); cherr != nil {
+		_ = tmp.Close()
+		cleanup()
+		return fmt.Errorf("session: chmod %s: %w", tmpPath, cherr)
+	}
+	if encErr := encode(tmp, file); encErr != nil {
+		_ = tmp.Close()
+		cleanup()
+		return fmt.Errorf("session: encode: %w", encErr)
+	}
+	if cerr := tmp.Close(); cerr != nil {
+		cleanup()
+		return fmt.Errorf("session: close temp: %w", cerr)
+	}
+	if rerr := os.Rename(tmpPath, s.Path); rerr != nil {
+		cleanup()
+		return fmt.Errorf("session: rename to %s: %w", s.Path, rerr)
+	}
+	return nil
+}
+
+func encode(w io.Writer, file fileFormat) error {
+	return toml.NewEncoder(w).Encode(file)
+}
+
+func (s *Store) now() time.Time {
+	if s.Now != nil {
+		return s.Now()
+	}
+	return time.Now()
+}
+
+func (s *Store) lifetime(e Entry) time.Duration {
+	if e.LifetimeSeconds > 0 {
+		return time.Duration(e.LifetimeSeconds) * time.Second
+	}
+	return DefaultLifetime
+}

--- a/internal/session/store_test.go
+++ b/internal/session/store_test.go
@@ -1,0 +1,168 @@
+package session_test
+
+import (
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/chmmou/kasapi-cli/internal/session"
+)
+
+func newStore(t *testing.T, now time.Time) *session.Store {
+	t.Helper()
+	s, err := session.New(filepath.Join(t.TempDir(), "sessions.toml"))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	s.Now = func() time.Time { return now }
+	return s
+}
+
+func TestSaveLoadRoundTrip(t *testing.T) {
+	now := time.Date(2026, 5, 3, 12, 0, 0, 0, time.UTC)
+	s := newStore(t, now)
+	want := session.Entry{
+		Token:           "tok-abc",
+		ExpiresAt:       now.Add(time.Hour),
+		LifetimeSeconds: 3600,
+		UpdateLifetime:  true,
+	}
+	if err := s.Save("w0000000", want); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	got, err := s.Load("w0000000")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got == nil {
+		t.Fatal("Load: nil entry")
+	}
+	if got.Token != want.Token || !got.ExpiresAt.Equal(want.ExpiresAt) ||
+		got.LifetimeSeconds != want.LifetimeSeconds || got.UpdateLifetime != want.UpdateLifetime {
+		t.Errorf("Load = %+v, want %+v", got, want)
+	}
+}
+
+func TestSaveComputesExpiresAtFromLifetime(t *testing.T) {
+	now := time.Date(2026, 5, 3, 12, 0, 0, 0, time.UTC)
+	s := newStore(t, now)
+	if err := s.Save("w0", session.Entry{Token: "t", LifetimeSeconds: 600}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	got, err := s.Load("w0")
+	if err != nil || got == nil {
+		t.Fatalf("Load: %v %v", got, err)
+	}
+	want := now.Add(10 * time.Minute)
+	if !got.ExpiresAt.Equal(want) {
+		t.Errorf("ExpiresAt = %v, want %v", got.ExpiresAt, want)
+	}
+}
+
+func TestSaveFallsBackToDefaultLifetime(t *testing.T) {
+	now := time.Date(2026, 5, 3, 12, 0, 0, 0, time.UTC)
+	s := newStore(t, now)
+	if err := s.Save("w0", session.Entry{Token: "t"}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	got, err := s.Load("w0")
+	if err != nil || got == nil {
+		t.Fatalf("Load: %v %v", got, err)
+	}
+	want := now.Add(session.DefaultLifetime)
+	if !got.ExpiresAt.Equal(want) {
+		t.Errorf("ExpiresAt = %v, want %v", got.ExpiresAt, want)
+	}
+}
+
+func TestLoadReturnsNilWhenFileMissing(t *testing.T) {
+	s := newStore(t, time.Now())
+	got, err := s.Load("anything")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got != nil {
+		t.Errorf("Load = %v, want nil", got)
+	}
+}
+
+func TestLoadReturnsNilWhenLoginAbsent(t *testing.T) {
+	s := newStore(t, time.Now())
+	if err := s.Save("w0", session.Entry{Token: "t", LifetimeSeconds: 60}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	got, err := s.Load("other")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got != nil {
+		t.Errorf("Load other = %v, want nil", got)
+	}
+}
+
+func TestLoadDropsExpiredEntry(t *testing.T) {
+	now := time.Date(2026, 5, 3, 12, 0, 0, 0, time.UTC)
+	s := newStore(t, now)
+	if err := s.Save("w0", session.Entry{
+		Token:     "t",
+		ExpiresAt: now.Add(-time.Second),
+	}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	got, err := s.Load("w0")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected expired Load to return nil, got %+v", got)
+	}
+	// File should be gone since it had only one entry.
+	if _, err := s.Load("w0"); err != nil {
+		t.Errorf("second Load on cleaned file: %v", err)
+	}
+}
+
+func TestDeleteRemovesEntryOnly(t *testing.T) {
+	now := time.Date(2026, 5, 3, 12, 0, 0, 0, time.UTC)
+	s := newStore(t, now)
+	if err := s.Save("a", session.Entry{Token: "1", LifetimeSeconds: 60}); err != nil {
+		t.Fatalf("Save a: %v", err)
+	}
+	if err := s.Save("b", session.Entry{Token: "2", LifetimeSeconds: 60}); err != nil {
+		t.Fatalf("Save b: %v", err)
+	}
+	if err := s.Delete("a"); err != nil {
+		t.Fatalf("Delete a: %v", err)
+	}
+	if got, _ := s.Load("a"); got != nil {
+		t.Errorf("a still present after Delete")
+	}
+	if got, _ := s.Load("b"); got == nil {
+		t.Errorf("b should still be present")
+	}
+}
+
+func TestDeleteMissingIsNoop(t *testing.T) {
+	s := newStore(t, time.Now())
+	if err := s.Delete("nope"); err != nil {
+		t.Errorf("Delete on missing file: %v", err)
+	}
+}
+
+func TestSaveWritesMode0600(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("file mode bits not meaningful on Windows")
+	}
+	s := newStore(t, time.Now())
+	if err := s.Save("w0", session.Entry{Token: "t", LifetimeSeconds: 60}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	info, err := statFile(s.Path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if mode := info.Mode().Perm(); mode != 0o600 {
+		t.Errorf("mode = %#o, want 0600", mode)
+	}
+}

--- a/internal/session/store_test.go
+++ b/internal/session/store_test.go
@@ -150,6 +150,31 @@ func TestDeleteMissingIsNoop(t *testing.T) {
 	}
 }
 
+func TestPathForCustomConfig(t *testing.T) {
+	got, err := session.PathFor("/tmp/custom/config.toml")
+	if err != nil {
+		t.Fatalf("PathFor: %v", err)
+	}
+	want := "/tmp/custom/sessions.toml"
+	if got != want {
+		t.Errorf("PathFor = %q, want %q", got, want)
+	}
+}
+
+func TestPathForEmptyFallsBackToDefault(t *testing.T) {
+	got, err := session.PathFor("")
+	if err != nil {
+		t.Fatalf("PathFor: %v", err)
+	}
+	def, err := session.DefaultPath()
+	if err != nil {
+		t.Fatalf("DefaultPath: %v", err)
+	}
+	if got != def {
+		t.Errorf("PathFor(\"\") = %q, want %q", got, def)
+	}
+}
+
 func TestSaveWritesMode0600(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("file mode bits not meaningful on Windows")


### PR DESCRIPTION
## Summary

A successful KasAuth login (including 2FA via `--otp`) is now cached on
disk and reused across CLI runs for as long as the session is alive,
so `--otp` no longer has to be re-entered on every command.

- New `internal/session` Store: TOML file `sessions.toml` next to the
  config file, mode `0600`, atomic temp+rename, keyed by login,
  expired entries are dropped on read.
- `auth.SessionTokenSource` loads the cached entry on first use,
  persists fresh KasAuth responses, deletes the entry on `Invalidate`.
  Lifetime defaults to 24 h (`session.DefaultLifetime`, matching the
  KasAuth `session_lifetime` default) when `--session-lifetime` was
  not set; otherwise mirrors the flag value.
- New optional `api.Heartbeater` hook: `api.Client.Call` invokes it
  after every successful call so a source configured with
  `--session-update-lifetime Y` rolls its local `expires_at` forward
  in lockstep with the server-side window.