### PR TITLE
fix: rename config init --profile to --name; canonical EOF idiom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `kasapi-cli config init`: rename the local `--profile` flag to
+  `--name` so it no longer shadows the persistent root `--profile`
+  flag. Previously `kasapi-cli --profile X config init` silently
+  reverted to the local default `main` instead of writing profile `X`.
+  The persistent `--profile` flag continues to select which profile is
+  *used* at runtime; `--name` selects which profile is *written*.
+- Replace the legacy direct `err == io.EOF` / `err != io.EOF`
+  comparisons in `internal/cli/confirm.go` and `internal/auth/codec.go`
+  with `errors.Is(err, io.EOF)` so wrapped EOF values are still
+  recognised.
+
 - `internal/transport`: drop the manual `Accept-Encoding: gzip`
   request header. `net/http` only decompresses gzip responses
   transparently when the caller has *not* set that header; the manual

--- a/internal/auth/codec.go
+++ b/internal/auth/codec.go
@@ -76,7 +76,7 @@ func DecodeResponse(r io.Reader) (string, error) {
 	dec := xml.NewDecoder(r)
 	for {
 		tok, err := dec.Token()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			return "", errors.New("auth: empty document")
 		}
 		if err != nil {

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -113,7 +113,7 @@ func newConfigInitCmd(opts *RootOptions) *cobra.Command {
 			return runConfigInit(opts.ConfigPath, profileName, force, cio)
 		},
 	}
-	cmd.Flags().StringVar(&profileName, "profile", "main", "profile name to write")
+	cmd.Flags().StringVar(&profileName, "name", "main", "profile name to write (the persistent --profile flag selects which profile is *used* at runtime)")
 	cmd.Flags().BoolVar(&force, "force", false, "overwrite an existing profile of the same name")
 	return cmd
 }
@@ -148,7 +148,7 @@ func runConfigInit(configPath, profileName string, force bool, cio configIO) err
 		return UserError(errors.New("kasapi-cli config init requires an interactive terminal (stdin is not a TTY)"), "")
 	}
 	if profileName == "" {
-		return UserError(errors.New("--profile must not be empty"), "")
+		return UserError(errors.New("--name must not be empty"), "")
 	}
 	path, err := resolveConfigPath(configPath)
 	if err != nil {

--- a/internal/cli/confirm.go
+++ b/internal/cli/confirm.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -20,7 +21,7 @@ func Confirm(in io.Reader, out io.Writer, prompt string) (bool, error) {
 	}
 	r := bufio.NewReader(in)
 	line, err := r.ReadString('\n')
-	if err != nil && err != io.EOF {
+	if err != nil && !errors.Is(err, io.EOF) {
 		return false, err
 	}
 	switch strings.ToLower(strings.TrimSpace(line)) {

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -101,6 +101,28 @@ func TestRootRejectsUnknownFlag(t *testing.T) {
 	}
 }
 
+// TestConfigInitDoesNotShadowRootProfile guards against the local
+// --profile flag on `config init` reappearing and silently overriding
+// the persistent root --profile. The local flag is now --name; the
+// root --profile must still bind to opts.Profile when the subcommand
+// runs.
+func TestConfigInitDoesNotShadowRootProfile(t *testing.T) {
+	t.Parallel()
+	root, opts := cli.NewRootCmd()
+	root.AddCommand(cli.NewConfigCmd(opts))
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&out)
+	// `config init` requires a TTY → it will exit with a user error before
+	// any prompt. We only need to assert that flag parsing succeeded and
+	// the root --profile reached opts.
+	root.SetArgs([]string{"--profile", "prod", "config", "init", "--name", "staging"})
+	_ = root.Execute()
+	if opts.Profile != "prod" {
+		t.Errorf("root --profile = %q, want prod (was the local --name flag shadowing it?)", opts.Profile)
+	}
+}
+
 func TestRootDefaultOutputIsTable(t *testing.T) {
 	t.Parallel()
 	root, opts := cli.NewRootCmd()


### PR DESCRIPTION
Two small code-review follow-ups:

- `config init`'s local `--profile` flag shadowed the persistent root `--profile` flag — `kasapi-cli --profile X config init` silently fell back to the local default "main". Renamed the local flag to `--name`. Persistent `--profile` selects which profile is *used*; `--name` selects which profile is *written*.
- Replaced the remaining `err == io.EOF` comparisons in `internal/cli/confirm.go` and `internal/auth/codec.go` with `errors.Is(err, io.EOF)` so wrapped EOF values still match and the codebase is internally consistent.