### PR TITLE
chore: split kasapi-cli-git-workflow skill; extract code-review loop

### DIFF
--- a/.claude/skills/kasapi-cli-code-review/SKILL.md
+++ b/.claude/skills/kasapi-cli-code-review/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: kasapi-cli-code-review
+description: Code-review loop for kasapi-cli — classification of findings (Blocker/Should/Nice-to-have) and the re-review cycle that ends only when no Blocker or Should-finding remains. TRIGGER when the user asks for a code-review pass, before any larger new step, or after corrections have been merged. The git/PR mechanics (branch naming, signed FF-push, PR shape) live in the companion skill `kasapi-cli-git-workflow`.
+---
+
+# kasapi-cli Code-Review Loop
+
+Use this skill whenever the user asks for a review pass, before starting a larger new step, or directly after corrections have been merged. The git mechanics for landing the resulting fix branch (selective `git add`, signed commits, FF-push to `main`, branch cleanup) are **not** repeated here — defer to the companion skill **`kasapi-cli-git-workflow`** for those.
+
+## Stance
+
+Act in the role of code reviewer, not implementer. Read the diff or the affected code path with fresh eyes; resist the temptation to silently fix what you find while reading. Surface findings first, decide together what to address, then switch back to implementer mode on a dedicated branch.
+
+## Classification
+
+Every finding is one of:
+
+- **Blocker** — outright wrong: bug, undefined behavior, schema mismatch with the KAS API, security issue, broken invariant. Fix before the next step.
+- **Should** — consistency / readability / small footguns. Fix quickly if cheap; otherwise capture as a follow-up issue.
+- **Nice-to-have** — cosmetic, style, or speculative. Record (typically as a single grouped follow-up issue attached to the project) but do not block on it.
+
+When unsure between Blocker and Should, prefer Blocker — the cost of an extra fix PR is lower than the cost of shipping a wrong behavior.
+
+## Reporting Findings
+
+Group the report by classification, not by file. For each finding give:
+
+- file path with line number (`internal/api/client.go:43`),
+- one sentence on what is wrong,
+- one sentence on the suggested direction (not the full patch).
+
+Then ask the user which items to address now versus file as follow-ups. Do not start editing before the user has chosen.
+
+## Correction & Re-Review Cycle
+
+Corrections land on a dedicated `fix/<topic>` branch via a separate PR — see `kasapi-cli-git-workflow` for the branch/PR/merge mechanics. After the corrections merge, **re-review** the touched area, because fixes can introduce regressions. The loop ends only when no Blocker or Should-finding remains; Nice-to-haves are captured as a single grouped issue attached to the project board and explicitly out of scope for the current loop.
+
+## Follow-Up Issues
+
+When filing the Nice-to-have bundle as a GitHub issue:
+
+- one issue per review pass, not one per finding,
+- bullet list with the same `file:line` + one-sentence-each shape used in the report,
+- attach to the active project board so the item is tracked alongside feature work,
+- label `documentation` for doc/comment-only items, otherwise leave unlabeled and let triage decide.

--- a/.claude/skills/kasapi-cli-git-workflow/SKILL.md
+++ b/.claude/skills/kasapi-cli-git-workflow/SKILL.md
@@ -1,23 +1,11 @@
 ---
 name: kasapi-cli-git-workflow
-description: Git, commit, and PR workflow for kasapi-cli. TRIGGER on every `git commit` / `git push` / `gh pr create` / `gh pr merge`, when creating a feature or fix branch, on rebase/merge conflicts against `main`, or when the user asks for a code-review pass. Adapted from the libqasapi `qasapi-module` skill, reduced to what applies to a fresh greenfield project.
+description: Git, commit, branch, and PR/merge mechanics for kasapi-cli. TRIGGER on every `git commit` / `git push` / `gh pr create`, when creating a feature or fix branch, on rebase/merge conflicts against `main`, or on the signed-commit fast-forward merge to `main`. For the review-classification loop see the companion skill `kasapi-cli-code-review`.
 ---
 
 # kasapi-cli Git Workflow
 
-Mandatory workflow for branches, commits, PRs, and review rounds. Applies only to git actions — the domain-specific module slicing from the libqasapi original is **not** carried over.
-
-## Precondition
-
-The repo is currently **not a git repository**. Before the first commit:
-
-```bash
-git init -b main
-git add <selective: only the files you want in the initial commit>
-git commit -m "chore: initial commit"
-```
-
-Only after that do the branch/PR rules below apply. The `gh` steps additionally require a configured GitHub remote (`gh repo create …`) — clarify owner / visibility with the user, do not assume.
+Mandatory mechanics for branches, commits, PRs, and the merge to `main`. The review-loop side of the workflow (Blocker/Should/Nice classification, re-review after corrections) lives in the companion skill **`kasapi-cli-code-review`** — invoke that one when the user asks for a review pass or you are about to start a larger new step.
 
 ## Golden Rule
 
@@ -85,16 +73,6 @@ git push origin --delete <branch>
 - **`--force-push` is blocked** by default; same authorization pattern. Never bypass with `-c` overrides or `--no-verify`.
 - **Do not skip hooks.** No `--no-verify`, no `--no-gpg-sign`. On hook failure, fix the underlying cause and create a **new** commit — do not `--amend`.
 - **Branch protection on `main`** (settings: `required_signatures`, `enforce_admins`, `required_linear_history`, `allow_force_pushes` kept on for retroactive history fixes, `allow_deletions` off). Pushes to `main` of unsigned commits will be rejected by GitHub.
-
-## Code-Review Loop
-
-Before any larger new step and after every correction, review the existing code — acting in the role of code reviewer, not implementer. Classify findings:
-
-- **Blocker:** outright wrong (bug, UB, schema mismatch, security) → fix before the next step.
-- **Should:** consistency / readability → fix quickly if cheap.
-- **Nice-to-have:** cosmetic → record but do not block on it.
-
-Corrected findings are committed on a dedicated `fix/<topic>` branch and merged via a separate PR. After merged corrections, **re-review**, because fixes can introduce regressions — the loop ends only when no blocker or should-findings remain.
 
 ## Post-Merge
 

--- a/README.md
+++ b/README.md
@@ -60,12 +60,13 @@ go test ./...
 - `internal/` — domain types, transport, mappers (planned).
 - `testdata/` — recorded KAS-API SOAP responses; the source of truth for response shape, used by offline parser tests.
 - `docs/go/` — Go style, architecture, patterns, and linting reference for this repo.
-- `.claude/skills/kasapi-cli-git-workflow/` — git/PR workflow skill enforced for this project.
+- `.claude/skills/kasapi-cli-git-workflow/` — git/PR/merge mechanics enforced for this project.
+- `.claude/skills/kasapi-cli-code-review/` — code-review loop (Blocker/Should/Nice classification, re-review cycle).
 - `AGENTS.md`, `CLAUDE.md` — agent guidance.
 
 ## Contributing
 
-Read `AGENTS.md` and `docs/go/ARCHITECTURE.md` before opening a PR. The git workflow (branch naming, commit style, PR shape, CI gate) is captured in `.claude/skills/kasapi-cli-git-workflow/SKILL.md`.
+Read `AGENTS.md` and `docs/go/ARCHITECTURE.md` before opening a PR. The git workflow (branch naming, commit style, PR shape, CI gate, signed FF-merge) is captured in `.claude/skills/kasapi-cli-git-workflow/SKILL.md`; the review-loop conventions (finding classification, re-review cycle) live next to it in `.claude/skills/kasapi-cli-code-review/SKILL.md`.
 
 ## License
 


### PR DESCRIPTION
Split the bundled skill into two so each fires on its own trigger:

- `kasapi-cli-git-workflow` — git/commit/branch/PR/merge mechanics. Drops the obsolete `Precondition` (repo-init) section.
- `kasapi-cli-code-review` (new) — review stance, Blocker/Should/Nice classification, reporting format, re-review cycle, follow-up-issue conventions. Defers branch/PR mechanics back to the workflow skill.
- `README.md` — references both skills.