### PR TITLE
fix: drop doubled action prefix in usage decoder errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `internal/usage`: drop the action name from `DecodeSpace` /
+  `DecodeSpaceUsage` / `DecodeTraffic` error strings. The Client
+  wrappers already prepend `usage: get_space:` / `usage: get_traffic:`
+  etc., so leaving the action in the decoder produced a doubled prefix
+  (`usage: get_space: usage: get_space: ReturnInfo[0] is not a Map`).
+  Decoders now use `"usage: …"` only, matching the established
+  `account` / `server` pattern.
+
 - `kasapi-cli config init`: rename the local `--profile` flag to
   `--name` so it no longer shadows the persistent root `--profile`
   flag. Previously `kasapi-cli --profile X config init` silently

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -151,7 +151,7 @@ func DecodeSpace(returnInfo soap.Value) (SpaceList, error) {
 	out := make(SpaceList, 0, len(returnInfo.Array))
 	for i, item := range returnInfo.Array {
 		if item.Kind != soap.KindMap {
-			return nil, fmt.Errorf("usage: get_space: ReturnInfo[%d] is not a Map", i)
+			return nil, fmt.Errorf("usage: ReturnInfo[%d] is not a Map", i)
 		}
 		out = append(out, Space{
 			AccountLogin:         getString(item, "account_login"),
@@ -176,7 +176,7 @@ func DecodeSpaceUsage(returnInfo soap.Value) (SpaceUsageList, error) {
 	out := make(SpaceUsageList, 0, len(returnInfo.Array))
 	for i, item := range returnInfo.Array {
 		if item.Kind != soap.KindMap {
-			return nil, fmt.Errorf("usage: get_space_usage: ReturnInfo[%d] is not a Map", i)
+			return nil, fmt.Errorf("usage: ReturnInfo[%d] is not a Map", i)
 		}
 		out = append(out, SpaceUsage{
 			Directory:       getString(item, "directory"),
@@ -200,7 +200,7 @@ func DecodeTraffic(returnInfo soap.Value) (TrafficList, error) {
 	out := make(TrafficList, 0, len(returnInfo.Map))
 	for _, kv := range returnInfo.Map {
 		if kv.Value.Kind != soap.KindMap {
-			return nil, fmt.Errorf("usage: get_traffic: entry %q is not a Map", kv.Key)
+			return nil, fmt.Errorf("usage: ReturnInfo entry %q is not a Map", kv.Key)
 		}
 		out = append(out, Traffic{
 			AccountLogin: getString(kv.Value, "account_login"),


### PR DESCRIPTION
## Summary

`DecodeSpace` / `DecodeSpaceUsage` / `DecodeTraffic` prefixed inner errors with the action name; the Client wrappers prepend the action layer too, producing `usage: get_space: usage: get_space: …`. Strip the action segment from decoder messages so they read `usage: …` only — same pattern as `account` / `server`.

Found during the post-merge review of #43.