### PR TITLE
chore: add GitHub issue and pull request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,83 @@
+name: Bug report
+description: Report incorrect behavior in kasapi-cli (wrong CLI output, decoder mismatch, transport bug, …).
+title: "bug: <short summary>"
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug.
+
+        > [!WARNING]
+        > **Do not paste credentials, KAS auth tokens, session tokens, full account IDs, or unredacted API responses.** Strip / replace those before submitting.
+
+  - type: input
+    id: version
+    attributes:
+      label: kasapi-cli version
+      description: Output of `kasapi-cli --version` (or commit SHA if built from source).
+      placeholder: "v0.x.y or commit abc1234"
+    validations:
+      required: true
+
+  - type: input
+    id: kas_action
+    attributes:
+      label: KAS-API action involved
+      description: The `kas_action` this bug relates to, if any.
+      placeholder: "e.g. get_domains, get_dns_settings, KasAuth"
+
+  - type: textarea
+    id: command
+    attributes:
+      label: Command used
+      description: The exact `kasapi-cli` invocation (with secrets redacted).
+      render: shell
+      placeholder: "kasapi-cli domains get example.com --output=json"
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: What actually happened? Include the error message and, if relevant, the redacted CLI output.
+      render: text
+    validations:
+      required: true
+
+  - type: textarea
+    id: fixture
+    attributes:
+      label: Captured response (optional)
+      description: |
+        If the bug is a decoder / mapping mismatch, attach the redacted SOAP response that triggers it. This will become a `testdata/` fixture once the fix lands.
+      render: xml
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: OS, Go version (if built from source), terminal, anything else relevant.
+      placeholder: |
+        - OS: Linux 7.x
+        - Go: 1.23.x
+        - Shell: fish
+
+  - type: checkboxes
+    id: sanity
+    attributes:
+      label: Sanity check
+      options:
+        - label: I redacted credentials, session tokens, and personally identifying account data from every snippet above.
+          required: true
+        - label: I searched existing issues and did not find a duplicate.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/chmmou/kasapi-cli/blob/main/CONTRIBUTING.md#reporting-security-issues
+    about: Please do not file public issues for vulnerabilities — see CONTRIBUTING for the private channel.
+  - name: KAS-API documentation
+    url: https://kasapi.kasserver.com/dokumentation/phpdoc/
+    about: Endpoint contracts and parameter shapes (the source of truth for request/response form).
+  - name: Roadmap
+    url: https://github.com/chmmou/kasapi-cli/blob/main/ROADMAP.md
+    about: Check whether the endpoint you want is already tracked before opening a feature request.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,57 @@
+name: Feature request
+description: Propose a new KAS-API endpoint, CLI subcommand, or quality-of-life improvement.
+title: "feat: <short summary>"
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Before opening: please skim [ROADMAP.md](https://github.com/chmmou/kasapi-cli/blob/main/ROADMAP.md). If the endpoint is already tracked there, comment on the existing issue (or open one referencing the roadmap entry) instead of duplicating it.
+
+  - type: input
+    id: kas_action
+    attributes:
+      label: KAS-API action(s)
+      description: The `kas_action` name(s) from the official documentation that this request would wrap.
+      placeholder: "e.g. add_dns_settings, get_mailaccounts"
+
+  - type: input
+    id: doc_link
+    attributes:
+      label: Link to KAS-API docs
+      description: The page on `kasapi.kasserver.com/dokumentation/phpdoc/` describing the endpoint.
+      placeholder: "https://kasapi.kasserver.com/dokumentation/phpdoc/files/<page>.html"
+
+  - type: textarea
+    id: cli_shape
+    attributes:
+      label: Proposed CLI shape
+      description: How would you invoke this from the command line? Subcommand, flags, expected output.
+      render: shell
+      placeholder: |
+        kasapi-cli dns add --domain example.com --type A --name www --data 1.2.3.4
+    validations:
+      required: true
+
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation / use case
+      description: What problem does this solve? Concrete scenarios are more useful than abstract requirements.
+    validations:
+      required: true
+
+  - type: textarea
+    id: shape_notes
+    attributes:
+      label: Request / response shape notes
+      description: |
+        Anything noteworthy about the wire format — required vs. optional params, list-vs-singular variants, fields that arrive as `xsi:nil`, etc. A redacted captured response helps a lot.
+
+  - type: checkboxes
+    id: claim
+    attributes:
+      label: Are you offering to implement this?
+      options:
+        - label: Yes — I plan to open a PR following the vertical-slice pattern in CONTRIBUTING.md.
+        - label: No — request only.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,36 @@
+<!--
+PR title: use Conventional Commits — feat:/fix:/docs:/chore:/refactor:/test:.
+Keep this body short. Summary block describing *what*, not *how*.
+No "Test plan" section. No generated-by footer. No Co-Authored-By trailer.
+-->
+
+## Summary
+
+<!-- One or two sentences. What changed. -->
+
+Closes #
+
+## KAS-API surface (if applicable)
+
+<!-- Which kas_action(s) does this PR cover? Skip if N/A (docs / chore / infra). -->
+
+- Action(s):
+- Doc page:
+
+## Vertical-slice checklist
+
+<!-- For new endpoints. Tick what applies; remove the section for pure docs/chore PRs. See CONTRIBUTING.md. -->
+
+- [ ] Type & decoder in `internal/<domain>/<name>.go`
+- [ ] Client method on the package's `*Client`
+- [ ] Fixture-backed test in `internal/<domain>/<name>_test.go`
+- [ ] Captured response under `testdata/<domain>/<kas_action>_response_*.xml` (redacted)
+- [ ] CLI subcommand wired into `cmd/kasapi-cli/main.go`
+- [ ] CHANGELOG entry under `## [Unreleased]`
+- [ ] [ROADMAP.md](../ROADMAP.md) updated (`- [ ]` → `- [x]`)
+
+## Author confirmation
+
+- [ ] Commits are signed and follow Conventional Commits (`feat:`, `fix:`, …).
+- [ ] No credentials, session tokens, or unredacted account data in any fixture, log line, or test.
+- [ ] `go fmt`, `go vet`, `golangci-lint`, and `go test` (with `-race` where applicable) pass locally.


### PR DESCRIPTION
Issue Forms for bug and feature reports plus a `config.yml` (blank issues disabled; security / KAS docs / roadmap as contact links). PR template encodes the vertical-slice checklist from CONTRIBUTING.md.