### PR TITLE
feat: softwareinstalls get/list via get_softwareinstall (with software_id filter)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `internal/softwareinstall` read module and `kasapi-cli softwareinstalls
+  list|get` subcommand tree wrapping `get_softwareinstall` (note: the
+  KAS action name is singular for both variants). The list variant
+  decodes the Array of Maps into a typed `SoftwareInstallList`; `get
+  <software-id>` reuses the same endpoint with a `software_id` filter
+  and unwraps the single-entry result. The list view collapses the
+  PHP and database `{from, upto}` version pairs into one column each
+  ("8.4", "10.5..12.0"), prefixes the DB column with the engine name,
+  and renders the `0.0` "not applicable" sentinel as `—`. The base64
+  `image` data URI is kept on the struct for JSON/YAML round-trip
+  fidelity but stripped from both table views. Mapping tests run
+  against `testdata/softwareinstall/get_softwareinstalls_response_success.xml`
+  (22 entries) and `get_softwareinstall_response_success.xml`. Refs #11.
+
 - `internal/directoryprotection` read module and
   `kasapi-cli directoryprotection list [--path PATH]` subcommand
   wrapping `get_directoryprotection`. The KAS endpoint returns one

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -65,6 +65,7 @@ The list is kept in sync with the code on `main`. To claim an unchecked item, pl
 - [ ] Cronjob write paths (`add_cronjob`, `update_cronjob`, `delete_cronjob`)
 - [x] `directoryprotection list [--path PATH]` (`get_directoryprotection`, optional `directory_path` filter)
 - [ ] Directory protection write paths (`add_directoryprotection`, `update_directoryprotection`, `delete_directoryprotection`)
-- [ ] Software install entries (`get_softwareinstall`, `add_softwareinstall`, `delete_softwareinstall`)
+- [x] `softwareinstalls list` / `softwareinstalls get <software-id>` (`get_softwareinstall`, with `software_id` filter)
+- [ ] Software install write paths (`add_softwareinstall`, `delete_softwareinstall`)
 - [ ] SSL certificate management (`add_lets_encrypt_csr`, `update_ssl_certificate`, …)
 - [ ] Filesystem helpers (`chown`, `symlink`)

--- a/cmd/kasapi-cli/main.go
+++ b/cmd/kasapi-cli/main.go
@@ -27,6 +27,7 @@ func main() {
 		cli.NewSambaUsersCmd(opts),
 		cli.NewCronjobsCmd(opts),
 		cli.NewDirectoryProtectionCmd(opts),
+		cli.NewSoftwareInstallsCmd(opts),
 		cli.NewUsageCmd(opts),
 		cli.NewConfigCmd(opts),
 	)

--- a/internal/cli/softwareinstalls.go
+++ b/internal/cli/softwareinstalls.go
@@ -1,0 +1,67 @@
+package cli
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/chmmou/kasapi-cli/internal/softwareinstall"
+)
+
+// NewSoftwareInstallsCmd returns the "kasapi-cli softwareinstalls"
+// subcommand tree: list (get_softwareinstall, no filter) and get
+// <software-id> (get_softwareinstall with a software_id filter).
+// The KAS action is singular for both variants.
+func NewSoftwareInstallsCmd(opts *RootOptions) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "softwareinstalls",
+		Short: "Inspect installable software templates (get_softwareinstall)",
+	}
+	cmd.AddCommand(
+		newSoftwareInstallsListCmd(opts),
+		newSoftwareInstallsGetCmd(opts),
+	)
+	return cmd
+}
+
+func newSoftwareInstallsListCmd(opts *RootOptions) *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Short: "List all installable software templates (get_softwareinstall, no filter)",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			api, err := BuildAPIClient(opts)
+			if err != nil {
+				return err
+			}
+			list, err := softwareinstall.NewClient(api).List(cmd.Context())
+			if err != nil {
+				return APIError(err, "get_softwareinstall")
+			}
+			if err := Render(cmd.OutOrStdout(), opts.Output, list); err != nil {
+				return UserError(err, "render")
+			}
+			return nil
+		},
+	}
+}
+
+func newSoftwareInstallsGetCmd(opts *RootOptions) *cobra.Command {
+	return &cobra.Command{
+		Use:   "get <software-id>",
+		Short: "Show details for a single software template (get_softwareinstall with software_id)",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			api, err := BuildAPIClient(opts)
+			if err != nil {
+				return err
+			}
+			s, err := softwareinstall.NewClient(api).Get(cmd.Context(), args[0])
+			if err != nil {
+				return APIError(err, "get_softwareinstall")
+			}
+			if err := Render(cmd.OutOrStdout(), opts.Output, s); err != nil {
+				return UserError(err, "render")
+			}
+			return nil
+		},
+	}
+}

--- a/internal/cli/softwareinstalls_test.go
+++ b/internal/cli/softwareinstalls_test.go
@@ -1,0 +1,29 @@
+package cli_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/chmmou/kasapi-cli/internal/cli"
+)
+
+func TestSoftwareInstallsCmdHelpListsSubcommands(t *testing.T) {
+	t.Parallel()
+	root, opts := cli.NewRootCmd()
+	root.AddCommand(cli.NewSoftwareInstallsCmd(opts))
+
+	var buf bytes.Buffer
+	root.SetOut(&buf)
+	root.SetErr(&buf)
+	root.SetArgs([]string{"softwareinstalls", "--help"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{"list", "get"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("--help output missing %q\n%s", want, out)
+		}
+	}
+}

--- a/internal/softwareinstall/softwareinstall.go
+++ b/internal/softwareinstall/softwareinstall.go
@@ -1,0 +1,232 @@
+package softwareinstall
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/chmmou/kasapi-cli/internal/soap"
+)
+
+// Caller is the subset of *api.Client this package depends on. The
+// indirection keeps tests free of network setup: a fake Caller can
+// return a *soap.Response decoded from a fixture.
+type Caller interface {
+	Call(ctx context.Context, action string, params map[string]any) (*soap.Response, error)
+}
+
+// SoftwareInstall is one entry of get_softwareinstall (note: the KAS
+// action name is singular for both the list and the filtered variant).
+// Each entry describes one installable software package: ID, name,
+// version, runtime requirements (PHP/MySQL/MariaDB version bands),
+// and whether the current account can install it.
+//
+// The KAS API returns `image` as a base64-encoded data URI of the
+// software's logo; we keep it on the struct for JSON/YAML round-trip
+// fidelity but strip it from the table views since it would dwarf
+// every other column.
+type SoftwareInstall struct {
+	ID          string `json:"software_id" yaml:"software_id"`
+	Name        string `json:"software_name" yaml:"software_name"`
+	Category    string `json:"software_category" yaml:"software_category"`
+	Version     string `json:"software_version" yaml:"software_version"`
+	Licence     string `json:"software_licence" yaml:"software_licence"`
+	Description string `json:"description" yaml:"description"`
+	Image       string `json:"image" yaml:"image"`
+
+	HasExampleData string `json:"software_has_example_data" yaml:"software_has_example_data"`
+
+	// Version constraints. KAS sends them as strings ("8.4", "0.0",
+	// "10.5", …) where 0.0 effectively means "not applicable" — we
+	// preserve the wire form rather than parsing them.
+	PHPVersion         string `json:"software_version_php" yaml:"software_version_php"`
+	PHPVersionUpto     string `json:"software_version_php_upto" yaml:"software_version_php_upto"`
+	PHPHtaccess        string `json:"software_version_php_htaccess" yaml:"software_version_php_htaccess"`
+	PHPWantCGI         string `json:"software_version_php_want_cgi" yaml:"software_version_php_want_cgi"`
+	MySQLVersion       string `json:"software_version_mysql" yaml:"software_version_mysql"`
+	MySQLVersionUpto   string `json:"software_version_mysql_upto" yaml:"software_version_mysql_upto"`
+	MariaDBVersion     string `json:"software_version_mariadb" yaml:"software_version_mariadb"`
+	MariaDBVersionUpto string `json:"software_version_mariadb_upto" yaml:"software_version_mariadb_upto"`
+
+	CanBeInstalled string `json:"software_can_be_installed" yaml:"software_can_be_installed"`
+	CanBeMessage   string `json:"software_can_be_message" yaml:"software_can_be_message"`
+}
+
+// SoftwareInstallList is the typed payload of get_softwareinstall;
+// satisfies cli.Tabular.
+type SoftwareInstallList []SoftwareInstall
+
+// Client groups the read endpoint scoped to software-install
+// templates: get_softwareinstall (list and singular).
+type Client struct {
+	API Caller
+}
+
+// NewClient returns a Client backed by the given Caller.
+func NewClient(c Caller) *Client { return &Client{API: c} }
+
+// List calls get_softwareinstall without parameters and decodes the
+// response into a SoftwareInstallList covering every installable
+// software package visible to the login.
+func (c *Client) List(ctx context.Context) (SoftwareInstallList, error) {
+	resp, err := c.API.Call(ctx, "get_softwareinstall", nil)
+	if err != nil {
+		return nil, err
+	}
+	list, err := DecodeSoftwareInstalls(resp.Body.ReturnInfo)
+	if err != nil {
+		return nil, fmt.Errorf("softwareinstall: get_softwareinstall: %w", err)
+	}
+	return list, nil
+}
+
+// Get calls get_softwareinstall with a software_id filter and returns
+// the single matching SoftwareInstall. The KAS API still wraps the
+// result in an array; we unwrap it here so callers do not have to.
+// An empty array surfaces as a not-found error.
+func (c *Client) Get(ctx context.Context, id string) (SoftwareInstall, error) {
+	if id == "" {
+		return SoftwareInstall{}, fmt.Errorf("softwareinstall: id is required")
+	}
+	resp, err := c.API.Call(ctx, "get_softwareinstall", map[string]any{"software_id": id})
+	if err != nil {
+		return SoftwareInstall{}, err
+	}
+	list, err := DecodeSoftwareInstalls(resp.Body.ReturnInfo)
+	if err != nil {
+		return SoftwareInstall{}, fmt.Errorf("softwareinstall: get_softwareinstall: %w", err)
+	}
+	if len(list) == 0 {
+		return SoftwareInstall{}, fmt.Errorf("softwareinstall: %q not found", id)
+	}
+	return list[0], nil
+}
+
+// DecodeSoftwareInstalls maps the ReturnInfo of a get_softwareinstall
+// response (an Array of Maps) into the typed SoftwareInstallList.
+func DecodeSoftwareInstalls(returnInfo soap.Value) (SoftwareInstallList, error) {
+	if returnInfo.Kind != soap.KindArray {
+		return nil, fmt.Errorf("softwareinstall: expected ReturnInfo array, got kind %d", returnInfo.Kind)
+	}
+	out := make(SoftwareInstallList, 0, len(returnInfo.Array))
+	for i, item := range returnInfo.Array {
+		if item.Kind != soap.KindMap {
+			return nil, fmt.Errorf("softwareinstall: ReturnInfo[%d] is not a Map", i)
+		}
+		out = append(out, SoftwareInstall{
+			ID:                 getString(item, "software_id"),
+			Name:               getString(item, "software_name"),
+			Category:           getString(item, "software_category"),
+			Version:            getString(item, "software_version"),
+			Licence:            getString(item, "software_licence"),
+			Description:        getString(item, "description"),
+			Image:              getString(item, "image"),
+			HasExampleData:     getString(item, "software_has_example_data"),
+			PHPVersion:         getString(item, "software_version_php"),
+			PHPVersionUpto:     getString(item, "software_version_php_upto"),
+			PHPHtaccess:        getString(item, "software_version_php_htaccess"),
+			PHPWantCGI:         getString(item, "software_version_php_want_cgi"),
+			MySQLVersion:       getString(item, "software_version_mysql"),
+			MySQLVersionUpto:   getString(item, "software_version_mysql_upto"),
+			MariaDBVersion:     getString(item, "software_version_mariadb"),
+			MariaDBVersionUpto: getString(item, "software_version_mariadb_upto"),
+			CanBeInstalled:     getString(item, "software_can_be_installed"),
+			CanBeMessage:       getString(item, "software_can_be_message"),
+		})
+	}
+	return out, nil
+}
+
+func getString(m soap.Value, key string) string {
+	v, ok := m.Get(key)
+	if !ok {
+		return ""
+	}
+	return v.AsString()
+}
+
+// TableHeaders returns the columns used by --output=table for
+// SoftwareInstallList. The image and description fields are omitted
+// — the former because it is a multi-kB base64 blob, the latter
+// because it can wrap across many lines; both stay accessible via
+// --output=json|yaml.
+func (SoftwareInstallList) TableHeaders() []string {
+	return []string{"ID", "NAME", "CATEGORY", "VERSION", "PHP", "DB", "INSTALLABLE"}
+}
+
+// TableRows emits one row per SoftwareInstall entry. The PHP and DB
+// columns collapse the {min, upto} pair so the table stays narrow;
+// 0.0 sentinels are kept verbatim because they signal "not
+// applicable" on the wire.
+func (l SoftwareInstallList) TableRows() [][]string {
+	rows := make([][]string, 0, len(l))
+	for _, s := range l {
+		rows = append(rows, []string{
+			s.ID,
+			s.Name,
+			s.Category,
+			s.Version,
+			versionRange(s.PHPVersion, s.PHPVersionUpto),
+			dbRange(s.MariaDBVersion, s.MariaDBVersionUpto, s.MySQLVersion, s.MySQLVersionUpto),
+			s.CanBeInstalled,
+		})
+	}
+	return rows
+}
+
+// versionRange formats a {from, to} pair as "from..to" or just "from"
+// when the two coincide. An empty/zero from returns "—".
+func versionRange(from, to string) string {
+	if from == "" || from == "0.0" {
+		return "—"
+	}
+	if to == "" || to == from {
+		return from
+	}
+	return from + ".." + to
+}
+
+// dbRange picks MariaDB if it has a non-zero range (the common case
+// on All-Inkl) and falls back to MySQL otherwise. The leading prefix
+// makes it explicit which engine the version refers to.
+func dbRange(mariaFrom, mariaTo, mysqlFrom, mysqlTo string) string {
+	if r := versionRange(mariaFrom, mariaTo); r != "—" {
+		return "MariaDB " + r
+	}
+	if r := versionRange(mysqlFrom, mysqlTo); r != "—" {
+		return "MySQL " + r
+	}
+	return "—"
+}
+
+// TableHeaders for the singular SoftwareInstall view: a key/value
+// layout. The image data URI is intentionally omitted to keep the
+// output usable in a terminal — consumers that need the logo should
+// use --output=json|yaml.
+func (SoftwareInstall) TableHeaders() []string {
+	return []string{"FIELD", "VALUE"}
+}
+
+// TableRows emits the scalar fields. image is omitted (see
+// TableHeaders); software_can_be_message appears immediately after
+// software_can_be_installed because the message explains a "N" value.
+func (s SoftwareInstall) TableRows() [][]string {
+	return [][]string{
+		{"software_id", s.ID},
+		{"software_name", s.Name},
+		{"software_category", s.Category},
+		{"software_version", s.Version},
+		{"software_licence", s.Licence},
+		{"software_has_example_data", s.HasExampleData},
+		{"software_version_php", s.PHPVersion},
+		{"software_version_php_upto", s.PHPVersionUpto},
+		{"software_version_php_htaccess", s.PHPHtaccess},
+		{"software_version_php_want_cgi", s.PHPWantCGI},
+		{"software_version_mysql", s.MySQLVersion},
+		{"software_version_mysql_upto", s.MySQLVersionUpto},
+		{"software_version_mariadb", s.MariaDBVersion},
+		{"software_version_mariadb_upto", s.MariaDBVersionUpto},
+		{"software_can_be_installed", s.CanBeInstalled},
+		{"software_can_be_message", s.CanBeMessage},
+		{"description", s.Description},
+	}
+}

--- a/internal/softwareinstall/softwareinstall_test.go
+++ b/internal/softwareinstall/softwareinstall_test.go
@@ -1,0 +1,240 @@
+package softwareinstall_test
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/chmmou/kasapi-cli/internal/soap"
+	"github.com/chmmou/kasapi-cli/internal/softwareinstall"
+)
+
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	dir := filepath.Dir(file)
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatalf("repo root not found from %q", file)
+		}
+		dir = parent
+	}
+}
+
+func decodeFixture(t *testing.T, name string) *soap.Response {
+	t.Helper()
+	path := filepath.Join(repoRoot(t), "testdata", "softwareinstall", name)
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open %s: %v", name, err)
+	}
+	defer func() { _ = f.Close() }()
+	resp, err := soap.Decode(f)
+	if err != nil {
+		t.Fatalf("decode %s: %v", name, err)
+	}
+	return resp
+}
+
+type fakeCaller struct {
+	resp *soap.Response
+	err  error
+
+	gotAction string
+	gotParams map[string]any
+}
+
+func (f *fakeCaller) Call(_ context.Context, action string, params map[string]any) (*soap.Response, error) {
+	f.gotAction = action
+	f.gotParams = params
+	return f.resp, f.err
+}
+
+func TestDecodeSoftwareInstalls(t *testing.T) {
+	t.Parallel()
+	resp := decodeFixture(t, "get_softwareinstalls_response_success.xml")
+	got, err := softwareinstall.DecodeSoftwareInstalls(resp.Body.ReturnInfo)
+	if err != nil {
+		t.Fatalf("DecodeSoftwareInstalls: %v", err)
+	}
+	if len(got) != 22 {
+		t.Fatalf("len = %d, want 22", len(got))
+	}
+	// Verify a few entries can be located by ID and that the
+	// runtime-version fields are preserved verbatim, including the
+	// 0.0 sentinel for "not applicable".
+	byID := map[string]softwareinstall.SoftwareInstall{}
+	for _, s := range got {
+		byID[s.ID] = s
+	}
+	joomla, ok := byID["joomla_v6.1.0"]
+	if !ok {
+		t.Fatalf("joomla_v6.1.0 not in list")
+	}
+	if joomla.Name != "Joomla!" {
+		t.Errorf("Name = %q, want Joomla!", joomla.Name)
+	}
+	if joomla.Category != "CMS" {
+		t.Errorf("Category = %q", joomla.Category)
+	}
+	if joomla.PHPVersion != "8.4" {
+		t.Errorf("PHPVersion = %q", joomla.PHPVersion)
+	}
+	if joomla.MySQLVersion != "0.0" {
+		t.Errorf("MySQLVersion = %q, want 0.0 (sentinel preserved)", joomla.MySQLVersion)
+	}
+	if joomla.MariaDBVersion != "10.5" {
+		t.Errorf("MariaDBVersion = %q", joomla.MariaDBVersion)
+	}
+	if joomla.CanBeInstalled != "Y" {
+		t.Errorf("CanBeInstalled = %q", joomla.CanBeInstalled)
+	}
+}
+
+func TestDecodeSoftwareInstallSingular(t *testing.T) {
+	t.Parallel()
+	resp := decodeFixture(t, "get_softwareinstall_response_success.xml")
+	got, err := softwareinstall.DecodeSoftwareInstalls(resp.Body.ReturnInfo)
+	if err != nil {
+		t.Fatalf("DecodeSoftwareInstalls: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("len = %d, want 1", len(got))
+	}
+	s := got[0]
+	if s.ID != "joomla_v6.1.0" {
+		t.Errorf("ID = %q", s.ID)
+	}
+	if s.Description == "" {
+		t.Error("Description not populated")
+	}
+	if s.Image == "" {
+		t.Error("Image not populated (expected base64 data URI)")
+	}
+}
+
+func TestClientList(t *testing.T) {
+	t.Parallel()
+	resp := decodeFixture(t, "get_softwareinstalls_response_success.xml")
+	fc := &fakeCaller{resp: resp}
+	list, err := softwareinstall.NewClient(fc).List(context.Background())
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if fc.gotAction != "get_softwareinstall" {
+		t.Errorf("action = %q, want get_softwareinstall (singular for both)", fc.gotAction)
+	}
+	if fc.gotParams != nil {
+		t.Errorf("params = %v, want nil", fc.gotParams)
+	}
+	if len(list) != 22 {
+		t.Errorf("len = %d, want 22", len(list))
+	}
+}
+
+func TestClientGet(t *testing.T) {
+	t.Parallel()
+	resp := decodeFixture(t, "get_softwareinstall_response_success.xml")
+	fc := &fakeCaller{resp: resp}
+	s, err := softwareinstall.NewClient(fc).Get(context.Background(), "joomla_v6.1.0")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if fc.gotAction != "get_softwareinstall" {
+		t.Errorf("action = %q", fc.gotAction)
+	}
+	if got, _ := fc.gotParams["software_id"].(string); got != "joomla_v6.1.0" {
+		t.Errorf("params[software_id] = %v", fc.gotParams["software_id"])
+	}
+	if s.ID != "joomla_v6.1.0" {
+		t.Errorf("ID = %q", s.ID)
+	}
+}
+
+func TestClientGetEmptyID(t *testing.T) {
+	t.Parallel()
+	c := softwareinstall.NewClient(&fakeCaller{})
+	if _, err := c.Get(context.Background(), ""); err == nil {
+		t.Errorf("Get(\"\") err = nil, want validation error")
+	}
+}
+
+func TestClientGetNotFound(t *testing.T) {
+	t.Parallel()
+	resp := &soap.Response{Body: soap.ResponseBody{ReturnInfo: soap.Value{Kind: soap.KindArray}}}
+	c := softwareinstall.NewClient(&fakeCaller{resp: resp})
+	if _, err := c.Get(context.Background(), "nope_v0.0"); err == nil {
+		t.Errorf("Get on empty result err = nil, want not-found")
+	}
+}
+
+func TestClientPropagatesError(t *testing.T) {
+	t.Parallel()
+	want := errors.New("boom")
+	c := softwareinstall.NewClient(&fakeCaller{err: want})
+	if _, err := c.List(context.Background()); !errors.Is(err, want) {
+		t.Errorf("List err = %v, want %v wrapped", err, want)
+	}
+	if _, err := c.Get(context.Background(), "joomla_v6.1.0"); !errors.Is(err, want) {
+		t.Errorf("Get err = %v, want %v wrapped", err, want)
+	}
+}
+
+func TestSoftwareInstallListTabular(t *testing.T) {
+	t.Parallel()
+	resp := decodeFixture(t, "get_softwareinstalls_response_success.xml")
+	list, _ := softwareinstall.DecodeSoftwareInstalls(resp.Body.ReturnInfo)
+	headers := list.TableHeaders()
+	if headers[0] != "ID" {
+		t.Errorf("headers[0] = %q, want ID", headers[0])
+	}
+	rows := list.TableRows()
+	if len(rows) != 22 {
+		t.Fatalf("rows = %d, want 22", len(rows))
+	}
+	// PHP / DB columns must collapse the {from, upto} pair.
+	for _, row := range rows {
+		if row[0] == "joomla_v6.1.0" {
+			if row[4] != "8.4" {
+				t.Errorf("PHP column for joomla = %q, want 8.4 (from==upto collapses)", row[4])
+			}
+			if row[5] != "MariaDB 10.5..12.0" {
+				t.Errorf("DB column for joomla = %q, want 'MariaDB 10.5..12.0'", row[5])
+			}
+		}
+	}
+}
+
+func TestSoftwareInstallTabular(t *testing.T) {
+	t.Parallel()
+	resp := decodeFixture(t, "get_softwareinstall_response_success.xml")
+	list, _ := softwareinstall.DecodeSoftwareInstalls(resp.Body.ReturnInfo)
+	if len(list) != 1 {
+		t.Fatalf("len = %d, want 1", len(list))
+	}
+	s := list[0]
+	headers := s.TableHeaders()
+	if headers[0] != "FIELD" || headers[1] != "VALUE" {
+		t.Errorf("headers = %v, want [FIELD VALUE]", headers)
+	}
+	rows := s.TableRows()
+	if rows[0][0] != "software_id" || rows[0][1] != "joomla_v6.1.0" {
+		t.Errorf("rows[0] = %v, want [software_id joomla_v6.1.0]", rows[0])
+	}
+	// image must NOT appear in the K/V table.
+	for _, row := range rows {
+		if row[0] == "image" {
+			t.Errorf("image leaked into table view: %v", row)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Adds `internal/softwareinstall` read module and the `kasapi-cli softwareinstalls list|get` subcommand tree wrapping `get_softwareinstall` (the KAS action name is singular for both variants). The `get` form reuses the same endpoint with a `software_id` filter and unwraps the single-entry array.

The list view collapses the PHP and database `{from, upto}` version pairs into one column each ("8.4", "10.5..12.0"), prefixes the DB column with the engine name, and renders the `0.0` "not applicable" sentinel as `—`. The base64 `image` data URI is kept on the struct for JSON/YAML fidelity but stripped from both table views.

Refs #11.