### PR TITLE
fix: correct ddns_login filter name in docs/comment

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -60,7 +60,7 @@ The list is kept in sync with the code on `main`. To claim an unchecked item, pl
 - [ ] FTP user write paths (`add_ftpuser`, `update_ftpuser`, `delete_ftpuser`)
 - [x] `sambausers list` / `sambausers get <samba-login>` (`get_sambausers`, with `samba_login` filter)
 - [ ] Samba user write paths (`add_sambauser`, `update_sambauser`, `delete_sambauser`)
-- [x] `ddnsusers list` / `ddnsusers get <dyndns-login>` (`get_ddnsusers`, with `dyndns_login` filter)
+- [x] `ddnsusers list` / `ddnsusers get <dyndns-login>` (`get_ddnsusers`, with `ddns_login` filter)
 - [ ] DDNS user write paths (`add_ddnsuser`, `update_ddnsuser`, `delete_ddnsuser`)
 - [x] `cronjobs list` / `cronjobs get <cronjob-id>` (`get_cronjobs`, with `cronjob_id` filter)
 - [ ] Cronjob write paths (`add_cronjob`, `update_cronjob`, `delete_cronjob`)

--- a/internal/ddns/ddns.go
+++ b/internal/ddns/ddns.go
@@ -92,7 +92,7 @@ func (c *Client) List(ctx context.Context) (DDNSUserList, error) {
 	return list, nil
 }
 
-// Get calls get_ddnsusers with a dyndns_login filter and returns the
+// Get calls get_ddnsusers with a ddns_login filter and returns the
 // single matching DDNSUser. The KAS API still wraps the result in an
 // array; we unwrap it here so callers do not have to. A guard
 // against an unexpected empty array is included for parity with the


### PR DESCRIPTION
## Summary

The ddnsusers slice (PR #63) uses the filter parameter `ddns_login` (no `y`), but the ROADMAP entry and a doc comment on `ddns.Client.Get` listed the wrong name (`dyndns_login`). The wire-side asymmetry — action `get_ddnsusers`, filter `ddns_login`, response keys `dyndns_*` — is already documented correctly in the file-level doc on `DDNSUser`; this PR fixes the two stale spots.