### PR TITLE
refactor: consolidate getString/getFloat/getInt into soap.Value methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -198,6 +198,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `internal/soap`: extend `Value` with typed Map accessors (`MapString`,
+  `MapInt`, `MapInt64`, `MapFloat`) and a generic `AsInt` coercion so
+  every read module can drop its private `getString` / `getInt` /
+  `getInt64` / `getFloat` helper. Migrated 17 read packages to the new
+  accessors (~28 helper copies removed; net –195 lines). Behaviour is
+  unchanged — the new methods replicate the existing nil-safe coercion
+  rules and are pinned by `TestValueMapAccessors` in
+  `internal/soap/soap_test.go` against missing-key, cross-kind, and
+  unparseable inputs. The package-local `getBool` / `getYN` in
+  `internal/account/decode.go` are intentionally left in place; they
+  are only used by one decoder and cover boolean/Y-N coercion that is
+  out of scope for #56. Closes #56.
+
 - `kasapi-cli accounts get` was renamed to `kasapi-cli accounts
   settings`; the old name now wraps `get_accounts` with the
   `account_login` filter (see Added), matching the `mail accounts

--- a/internal/account/decode.go
+++ b/internal/account/decode.go
@@ -2,7 +2,6 @@ package account
 
 import (
 	"fmt"
-	"strconv"
 	"strings"
 
 	"github.com/chmmou/kasapi-cli/internal/soap"
@@ -81,77 +80,77 @@ func DecodeAccountResources(returnInfo soap.Value) (AccountResources, error) {
 
 func decodeAccount(m soap.Value) Account {
 	return Account{
-		Login:                       getString(m, "account_login"),
-		Password:                    getString(m, "account_password"),
-		MaxAccount:                  getInt(m, "max_account"),
-		MaxDomain:                   getInt(m, "max_domain"),
-		MaxSubdomain:                getInt(m, "max_subdomain"),
-		MaxWebspace:                 getInt(m, "max_webspace"),
-		MaxMailAccount:              getInt(m, "max_mail_account"),
-		MaxMailForward:              getInt(m, "max_mail_forward"),
-		MaxMailList:                 getInt(m, "max_mail_list"),
-		MaxDatabases:                getInt(m, "max_databases"),
-		MaxFTPUser:                  getInt(m, "max_ftpuser"),
-		MaxSambaUser:                getInt(m, "max_sambauser"),
-		MaxCronjobs:                 getInt(m, "max_cronjobs"),
-		MaxWBK:                      getInt(m, "max_wbk"),
-		InstHtaccess:                getString(m, "inst_htaccess"),
-		InstFPSE:                    getString(m, "inst_fpse"),
-		InstSoftware:                getString(m, "inst_software"),
-		KASAccessForbid:             getString(m, "kas_access_forbidden"),
-		Logging:                     getString(m, "logging"),
-		Statistic:                   getString(m, "statistic"),
-		Logage:                      getInt(m, "logage"),
-		ShowPassword:                getString(m, "show_password"),
-		DNSSettings:                 getString(m, "dns_settings"),
-		ShowDirectLinks:             getInt(m, "show_direct_links"),
-		SSHAccess:                   getString(m, "ssh_access"),
-		UsedAccountSpace:            getFloat(m, "used_account_space"),
-		Account2FA:                  getString(m, "account_2fa"),
-		Account2FAInherited:         getString(m, "account_2fa_inherited"),
-		ShowDirectLinksWBK:          getString(m, "show_direct_links_wbk"),
-		ShowDirectLinksSambausers:   getString(m, "show_direct_links_sambausers"),
-		ShowDirectLinksAccounts:     getString(m, "show_direct_links_accounts"),
-		ShowDirectLinksMailaccounts: getString(m, "show_direct_links_mailaccounts"),
-		ShowDirectLinksFTPUser:      getString(m, "show_direct_links_ftpuser"),
-		ShowDirectLinksDatabases:    getString(m, "show_direct_links_databases"),
-		AccountComment:              getString(m, "account_comment"),
-		AccountContactMail:          getString(m, "account_contact_mail"),
-		InProgress:                  getString(m, "in_progress"),
+		Login:                       m.MapString("account_login"),
+		Password:                    m.MapString("account_password"),
+		MaxAccount:                  m.MapInt("max_account"),
+		MaxDomain:                   m.MapInt("max_domain"),
+		MaxSubdomain:                m.MapInt("max_subdomain"),
+		MaxWebspace:                 m.MapInt("max_webspace"),
+		MaxMailAccount:              m.MapInt("max_mail_account"),
+		MaxMailForward:              m.MapInt("max_mail_forward"),
+		MaxMailList:                 m.MapInt("max_mail_list"),
+		MaxDatabases:                m.MapInt("max_databases"),
+		MaxFTPUser:                  m.MapInt("max_ftpuser"),
+		MaxSambaUser:                m.MapInt("max_sambauser"),
+		MaxCronjobs:                 m.MapInt("max_cronjobs"),
+		MaxWBK:                      m.MapInt("max_wbk"),
+		InstHtaccess:                m.MapString("inst_htaccess"),
+		InstFPSE:                    m.MapString("inst_fpse"),
+		InstSoftware:                m.MapString("inst_software"),
+		KASAccessForbid:             m.MapString("kas_access_forbidden"),
+		Logging:                     m.MapString("logging"),
+		Statistic:                   m.MapString("statistic"),
+		Logage:                      m.MapInt("logage"),
+		ShowPassword:                m.MapString("show_password"),
+		DNSSettings:                 m.MapString("dns_settings"),
+		ShowDirectLinks:             m.MapInt("show_direct_links"),
+		SSHAccess:                   m.MapString("ssh_access"),
+		UsedAccountSpace:            m.MapFloat("used_account_space"),
+		Account2FA:                  m.MapString("account_2fa"),
+		Account2FAInherited:         m.MapString("account_2fa_inherited"),
+		ShowDirectLinksWBK:          m.MapString("show_direct_links_wbk"),
+		ShowDirectLinksSambausers:   m.MapString("show_direct_links_sambausers"),
+		ShowDirectLinksAccounts:     m.MapString("show_direct_links_accounts"),
+		ShowDirectLinksMailaccounts: m.MapString("show_direct_links_mailaccounts"),
+		ShowDirectLinksFTPUser:      m.MapString("show_direct_links_ftpuser"),
+		ShowDirectLinksDatabases:    m.MapString("show_direct_links_databases"),
+		AccountComment:              m.MapString("account_comment"),
+		AccountContactMail:          m.MapString("account_contact_mail"),
+		InProgress:                  m.MapString("in_progress"),
 	}
 }
 
 func decodeSettings(m soap.Value) AccountSettings {
 	return AccountSettings{
-		Login:              getString(m, "account_login"),
-		AccountComment:     getString(m, "account_comment"),
-		AccountContactMail: getString(m, "account_contact_mail"),
-		IsSuperuser:        getString(m, "is_superuser"),
-		AccountPassword:    getString(m, "account_password"),
-		ShowPassword:       getString(m, "show_password"),
-		Logging:            getString(m, "logging"),
-		Logage:             getInt(m, "logage"),
-		Statistic:          getString(m, "statistic"),
-		DNSSettings:        getString(m, "dns_settings"),
-		InstHtaccess:       getString(m, "inst_htaccess"),
-		InstFPSE:           getString(m, "inst_fpse"),
-		InstSoftware:       getString(m, "inst_software"),
-		SSHAccess:          getString(m, "ssh_access"),
-		SSHKeys:            getString(m, "ssh_keys"),
+		Login:              m.MapString("account_login"),
+		AccountComment:     m.MapString("account_comment"),
+		AccountContactMail: m.MapString("account_contact_mail"),
+		IsSuperuser:        m.MapString("is_superuser"),
+		AccountPassword:    m.MapString("account_password"),
+		ShowPassword:       m.MapString("show_password"),
+		Logging:            m.MapString("logging"),
+		Logage:             m.MapInt("logage"),
+		Statistic:          m.MapString("statistic"),
+		DNSSettings:        m.MapString("dns_settings"),
+		InstHtaccess:       m.MapString("inst_htaccess"),
+		InstFPSE:           m.MapString("inst_fpse"),
+		InstSoftware:       m.MapString("inst_software"),
+		SSHAccess:          m.MapString("ssh_access"),
+		SSHKeys:            m.MapString("ssh_keys"),
 		SSHFingerprints:    decodeFingerprints(m),
-		SSHPHPVersion:      getString(m, "ssh_php_version"),
-		Server:             getString(m, "server"),
-		InProgress:         getString(m, "in_progress"),
+		SSHPHPVersion:      m.MapString("ssh_php_version"),
+		Server:             m.MapString("server"),
+		InProgress:         m.MapString("in_progress"),
 		ShowDirectLinks: DirectLinkPrefs{
-			WBK:          getString(m, "show_direct_links_wbk"),
-			Sambausers:   getString(m, "show_direct_links_sambausers"),
-			Accounts:     getString(m, "show_direct_links_accounts"),
-			Mailaccounts: getString(m, "show_direct_links_mailaccounts"),
-			FTPUser:      getString(m, "show_direct_links_ftpuser"),
-			Databases:    getString(m, "show_direct_links_databases"),
+			WBK:          m.MapString("show_direct_links_wbk"),
+			Sambausers:   m.MapString("show_direct_links_sambausers"),
+			Accounts:     m.MapString("show_direct_links_accounts"),
+			Mailaccounts: m.MapString("show_direct_links_mailaccounts"),
+			FTPUser:      m.MapString("show_direct_links_ftpuser"),
+			Databases:    m.MapString("show_direct_links_databases"),
 		},
-		Account2FA:        getString(m, "account_2fa"),
-		Account2FAInherit: getString(m, "account_2fa_inherited"),
+		Account2FA:        m.MapString("account_2fa"),
+		Account2FAInherit: m.MapString("account_2fa_inherited"),
 		UserPrefs:         decodeUserPrefs(m),
 	}
 }
@@ -164,8 +163,8 @@ func decodeFingerprints(settings soap.Value) map[string]Fingerprint {
 	out := make(map[string]Fingerprint, len(fp.Map))
 	for _, kv := range fp.Map {
 		out[kv.Key] = Fingerprint{
-			MD5:    getString(kv.Value, "MD5:"),
-			SHA256: getString(kv.Value, "SHA256:"),
+			MD5:    kv.Value.MapString("MD5:"),
+			SHA256: kv.Value.MapString("SHA256:"),
 		}
 	}
 	return out
@@ -177,7 +176,7 @@ func decodeUserPrefs(settings soap.Value) UserPrefs {
 		return UserPrefs{}
 	}
 	out := UserPrefs{
-		PerPage: getInt(up, "per_page"),
+		PerPage: up.MapInt("per_page"),
 	}
 	if exp, ok := up.Get("expandableTables"); ok && exp.Kind == soap.KindMap {
 		out.ExpandableTables = mapOfStringSlices(exp)
@@ -210,53 +209,13 @@ func decodeQuota(v soap.Value) ResourceQuota {
 		return ResourceQuota{}
 	}
 	return ResourceQuota{
-		Max:      getInt(v, "max"),
+		Max:      v.MapInt("max"),
 		Exceeded: getBool(v, "exceeded"),
-		Reserved: getInt(v, "reserved"),
-		Created:  getInt(v, "created"),
-		Used:     getInt(v, "used"),
-		Free:     getInt(v, "free"),
+		Reserved: v.MapInt("reserved"),
+		Created:  v.MapInt("created"),
+		Used:     v.MapInt("used"),
+		Free:     v.MapInt("free"),
 	}
-}
-
-func getString(m soap.Value, key string) string {
-	v, ok := m.Get(key)
-	if !ok {
-		return ""
-	}
-	return v.AsString()
-}
-
-func getInt(m soap.Value, key string) int {
-	v, ok := m.Get(key)
-	if !ok {
-		return 0
-	}
-	switch v.Kind {
-	case soap.KindInt:
-		return int(v.Int)
-	case soap.KindFloat:
-		return int(v.Float)
-	case soap.KindString:
-		s := strings.TrimSpace(v.String)
-		if s == "" {
-			return 0
-		}
-		n, err := strconv.Atoi(s)
-		if err != nil {
-			return 0
-		}
-		return n
-	}
-	return 0
-}
-
-func getFloat(m soap.Value, key string) float64 {
-	v, ok := m.Get(key)
-	if !ok {
-		return 0
-	}
-	return v.AsFloat()
 }
 
 func getBool(m soap.Value, key string) bool {

--- a/internal/cronjob/cronjob.go
+++ b/internal/cronjob/cronjob.go
@@ -138,58 +138,26 @@ func DecodeCronjobs(returnInfo soap.Value) (CronjobList, error) {
 			return nil, fmt.Errorf("cronjob: ReturnInfo[%d] is not a Map", i)
 		}
 		out = append(out, Cronjob{
-			ID:            getString(item, "cronjob_id"),
-			Comment:       getString(item, "cronjob_comment"),
-			ShellCommand:  getString(item, "shell_command"),
-			Timeout:       getInt(item, "timeout"),
-			Protocol:      getString(item, "protocol"),
-			HTTPURL:       getString(item, "http_url"),
-			HTTPUser:      getString(item, "http_user"),
-			HTTPPassword:  getString(item, "http_password"),
-			Minute:        getString(item, "minute"),
-			Hour:          getString(item, "hour"),
-			DayOfMonth:    getString(item, "day_of_month"),
-			Month:         getString(item, "month"),
-			DayOfWeek:     getString(item, "day_of_week"),
-			MailAdress:    getString(item, "mail_adress"),
-			MailCondition: getString(item, "mail_condition"),
-			MailSubject:   getString(item, "mail_subject"),
-			IsActive:      getString(item, "is_active"),
+			ID:            item.MapString("cronjob_id"),
+			Comment:       item.MapString("cronjob_comment"),
+			ShellCommand:  item.MapString("shell_command"),
+			Timeout:       item.MapInt("timeout"),
+			Protocol:      item.MapString("protocol"),
+			HTTPURL:       item.MapString("http_url"),
+			HTTPUser:      item.MapString("http_user"),
+			HTTPPassword:  item.MapString("http_password"),
+			Minute:        item.MapString("minute"),
+			Hour:          item.MapString("hour"),
+			DayOfMonth:    item.MapString("day_of_month"),
+			Month:         item.MapString("month"),
+			DayOfWeek:     item.MapString("day_of_week"),
+			MailAdress:    item.MapString("mail_adress"),
+			MailCondition: item.MapString("mail_condition"),
+			MailSubject:   item.MapString("mail_subject"),
+			IsActive:      item.MapString("is_active"),
 		})
 	}
 	return out, nil
-}
-
-func getString(m soap.Value, key string) string {
-	v, ok := m.Get(key)
-	if !ok {
-		return ""
-	}
-	return v.AsString()
-}
-
-func getInt(m soap.Value, key string) int {
-	v, ok := m.Get(key)
-	if !ok {
-		return 0
-	}
-	switch v.Kind {
-	case soap.KindInt:
-		return int(v.Int)
-	case soap.KindFloat:
-		return int(v.Float)
-	case soap.KindString:
-		s := strings.TrimSpace(v.String)
-		if s == "" {
-			return 0
-		}
-		n, err := strconv.Atoi(s)
-		if err != nil {
-			return 0
-		}
-		return n
-	}
-	return 0
 }
 
 // TableHeaders returns the columns used by --output=table for

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -88,31 +88,15 @@ func DecodeDatabases(returnInfo soap.Value) (DatabaseList, error) {
 			return nil, fmt.Errorf("database: ReturnInfo[%d] is not a Map", i)
 		}
 		out = append(out, Database{
-			Name:              getString(item, "database_name"),
-			Login:             getString(item, "database_login"),
-			Password:          getString(item, "database_password"),
-			Comment:           getString(item, "database_comment"),
-			AllowedHosts:      getString(item, "database_allowed_hosts"),
-			UsedDatabaseSpace: getFloat(item, "used_database_space"),
+			Name:              item.MapString("database_name"),
+			Login:             item.MapString("database_login"),
+			Password:          item.MapString("database_password"),
+			Comment:           item.MapString("database_comment"),
+			AllowedHosts:      item.MapString("database_allowed_hosts"),
+			UsedDatabaseSpace: item.MapFloat("used_database_space"),
 		})
 	}
 	return out, nil
-}
-
-func getString(m soap.Value, key string) string {
-	v, ok := m.Get(key)
-	if !ok {
-		return ""
-	}
-	return v.AsString()
-}
-
-func getFloat(m soap.Value, key string) float64 {
-	v, ok := m.Get(key)
-	if !ok {
-		return 0
-	}
-	return v.AsFloat()
 }
 
 // TableHeaders returns the columns used by --output=table for

--- a/internal/ddns/ddns.go
+++ b/internal/ddns/ddns.go
@@ -128,27 +128,19 @@ func DecodeDDNSUsers(returnInfo soap.Value) (DDNSUserList, error) {
 			return nil, fmt.Errorf("ddns: ReturnInfo[%d] is not a Map", i)
 		}
 		out = append(out, DDNSUser{
-			Login:      getString(item, "dyndns_login"),
-			Password:   getString(item, "dyndns_password"),
-			Zone:       getString(item, "dyndns_zone"),
-			Label:      getString(item, "dyndns_label"),
-			TargetIP:   getString(item, "dyndns_target_ip"),
-			TargetIPv4: getString(item, "dyndns_target_ipv4"),
-			TargetIPv6: getString(item, "dyndns_target_ipv6"),
-			DualStack:  getString(item, "dyndns_dual_stack"),
-			Comment:    getString(item, "dyndns_comment"),
-			InProgress: getString(item, "in_progress"),
+			Login:      item.MapString("dyndns_login"),
+			Password:   item.MapString("dyndns_password"),
+			Zone:       item.MapString("dyndns_zone"),
+			Label:      item.MapString("dyndns_label"),
+			TargetIP:   item.MapString("dyndns_target_ip"),
+			TargetIPv4: item.MapString("dyndns_target_ipv4"),
+			TargetIPv6: item.MapString("dyndns_target_ipv6"),
+			DualStack:  item.MapString("dyndns_dual_stack"),
+			Comment:    item.MapString("dyndns_comment"),
+			InProgress: item.MapString("in_progress"),
 		})
 	}
 	return out, nil
-}
-
-func getString(m soap.Value, key string) string {
-	v, ok := m.Get(key)
-	if !ok {
-		return ""
-	}
-	return v.AsString()
 }
 
 // TableHeaders returns the columns used by --output=table for

--- a/internal/directoryprotection/directoryprotection.go
+++ b/internal/directoryprotection/directoryprotection.go
@@ -78,22 +78,14 @@ func DecodeDirectoryProtections(returnInfo soap.Value) (DirectoryProtectionList,
 			return nil, fmt.Errorf("directoryprotection: ReturnInfo[%d] is not a Map", i)
 		}
 		out = append(out, DirectoryProtection{
-			User:       getString(item, "directory_user"),
-			Path:       getString(item, "directory_path"),
-			AuthName:   getString(item, "directory_authname"),
-			Password:   getString(item, "directory_password"),
-			InProgress: getString(item, "in_progress"),
+			User:       item.MapString("directory_user"),
+			Path:       item.MapString("directory_path"),
+			AuthName:   item.MapString("directory_authname"),
+			Password:   item.MapString("directory_password"),
+			InProgress: item.MapString("in_progress"),
 		})
 	}
 	return out, nil
-}
-
-func getString(m soap.Value, key string) string {
-	v, ok := m.Get(key)
-	if !ok {
-		return ""
-	}
-	return v.AsString()
 }
 
 // TableHeaders returns the columns used by --output=table for

--- a/internal/dns/dns.go
+++ b/internal/dns/dns.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"strconv"
-	"strings"
 
 	"github.com/chmmou/kasapi-cli/internal/soap"
 )
@@ -79,49 +78,17 @@ func DecodeRecords(returnInfo soap.Value) (RecordList, error) {
 			return nil, fmt.Errorf("dns: ReturnInfo[%d] is not a Map", i)
 		}
 		out = append(out, Record{
-			Zone:       getString(item, "record_zone"),
-			Name:       getString(item, "record_name"),
-			Type:       getString(item, "record_type"),
-			Data:       getString(item, "record_data"),
-			Aux:        getInt(item, "record_aux"),
-			ID:         getString(item, "record_id"),
-			Changeable: getString(item, "record_changeable"),
-			Deleteable: getString(item, "record_deleteable"),
+			Zone:       item.MapString("record_zone"),
+			Name:       item.MapString("record_name"),
+			Type:       item.MapString("record_type"),
+			Data:       item.MapString("record_data"),
+			Aux:        item.MapInt("record_aux"),
+			ID:         item.MapString("record_id"),
+			Changeable: item.MapString("record_changeable"),
+			Deleteable: item.MapString("record_deleteable"),
 		})
 	}
 	return out, nil
-}
-
-func getString(m soap.Value, key string) string {
-	v, ok := m.Get(key)
-	if !ok {
-		return ""
-	}
-	return v.AsString()
-}
-
-func getInt(m soap.Value, key string) int {
-	v, ok := m.Get(key)
-	if !ok {
-		return 0
-	}
-	switch v.Kind {
-	case soap.KindInt:
-		return int(v.Int)
-	case soap.KindFloat:
-		return int(v.Float)
-	case soap.KindString:
-		s := strings.TrimSpace(v.String)
-		if s == "" {
-			return 0
-		}
-		n, err := strconv.Atoi(s)
-		if err != nil {
-			return 0
-		}
-		return n
-	}
-	return 0
 }
 
 // TableHeaders returns the columns used by --output=table for

--- a/internal/domain/domain.go
+++ b/internal/domain/domain.go
@@ -163,9 +163,9 @@ func DecodeTLDs(returnInfo soap.Value) (TLDList, error) {
 			return nil, fmt.Errorf("domain: ReturnInfo[%d] is not a Map", i)
 		}
 		out = append(out, TLD{
-			Name:   getString(item, "tld_name"),
-			MinLen: getInt(item, "tld_minlen"),
-			MaxLen: getInt(item, "tld_maxlen"),
+			Name:   item.MapString("tld_name"),
+			MinLen: item.MapInt("tld_minlen"),
+			MaxLen: item.MapInt("tld_maxlen"),
 		})
 	}
 	return out, nil
@@ -173,71 +173,39 @@ func DecodeTLDs(returnInfo soap.Value) (TLDList, error) {
 
 func decodeDomain(m soap.Value) Domain {
 	return Domain{
-		Name:           getString(m, "domain_name"),
-		TLD:            getString(m, "domain_tld"),
-		RedirectStatus: getInt(m, "domain_redirect_status"),
-		Path:           getString(m, "domain_path"),
-		Account:        getString(m, "domain_account"),
-		Server:         getString(m, "domain_server"),
+		Name:           m.MapString("domain_name"),
+		TLD:            m.MapString("domain_tld"),
+		RedirectStatus: m.MapInt("domain_redirect_status"),
+		Path:           m.MapString("domain_path"),
+		Account:        m.MapString("domain_account"),
+		Server:         m.MapString("domain_server"),
 
-		DummyHost:     getString(m, "dummy_host"),
-		DKIMSelector:  getString(m, "dkim_selector"),
-		FPSEActive:    getString(m, "fpse_active"),
-		PHPVersion:    getString(m, "php_version"),
-		PHPDeprecated: getString(m, "php_deprecated"),
-		IsActive:      getString(m, "is_active"),
-		InProgress:    getString(m, "in_progress"),
+		DummyHost:     m.MapString("dummy_host"),
+		DKIMSelector:  m.MapString("dkim_selector"),
+		FPSEActive:    m.MapString("fpse_active"),
+		PHPVersion:    m.MapString("php_version"),
+		PHPDeprecated: m.MapString("php_deprecated"),
+		IsActive:      m.MapString("is_active"),
+		InProgress:    m.MapString("in_progress"),
 
-		StatisticVersion:  getInt(m, "statistic_version"),
-		StatisticLanguage: getString(m, "statistic_language"),
+		StatisticVersion:  m.MapInt("statistic_version"),
+		StatisticLanguage: m.MapString("statistic_language"),
 
 		SSL: SSL{
-			Proxy:         getString(m, "ssl_proxy"),
-			CertificateIP: getString(m, "ssl_certificate_ip"),
-			SNI:           getString(m, "ssl_certificate_sni"),
-			SNIIsActive:   getString(m, "ssl_certificate_sni_is_active"),
-			SNICSR:        getString(m, "ssl_certificate_sni_csr"),
-			SNIKey:        getString(m, "ssl_certificate_sni_key"),
-			SNICRT:        getString(m, "ssl_certificate_sni_crt"),
-			SNIBundle:     getString(m, "ssl_certificate_sni_bundle"),
-			SNIChainfile:  getString(m, "ssl_certificate_sni_chainfile"),
-			SNIType:       getString(m, "ssl_certificate_sni_type"),
-			SNIForceHTTPS: getString(m, "ssl_certificate_sni_force_https"),
-			SNIHSTSMaxAge: getString(m, "ssl_certificate_sni_hsts_max_age"),
+			Proxy:         m.MapString("ssl_proxy"),
+			CertificateIP: m.MapString("ssl_certificate_ip"),
+			SNI:           m.MapString("ssl_certificate_sni"),
+			SNIIsActive:   m.MapString("ssl_certificate_sni_is_active"),
+			SNICSR:        m.MapString("ssl_certificate_sni_csr"),
+			SNIKey:        m.MapString("ssl_certificate_sni_key"),
+			SNICRT:        m.MapString("ssl_certificate_sni_crt"),
+			SNIBundle:     m.MapString("ssl_certificate_sni_bundle"),
+			SNIChainfile:  m.MapString("ssl_certificate_sni_chainfile"),
+			SNIType:       m.MapString("ssl_certificate_sni_type"),
+			SNIForceHTTPS: m.MapString("ssl_certificate_sni_force_https"),
+			SNIHSTSMaxAge: m.MapString("ssl_certificate_sni_hsts_max_age"),
 		},
 	}
-}
-
-func getString(m soap.Value, key string) string {
-	v, ok := m.Get(key)
-	if !ok {
-		return ""
-	}
-	return v.AsString()
-}
-
-func getInt(m soap.Value, key string) int {
-	v, ok := m.Get(key)
-	if !ok {
-		return 0
-	}
-	switch v.Kind {
-	case soap.KindInt:
-		return int(v.Int)
-	case soap.KindFloat:
-		return int(v.Float)
-	case soap.KindString:
-		s := strings.TrimSpace(v.String)
-		if s == "" {
-			return 0
-		}
-		n, err := strconv.Atoi(s)
-		if err != nil {
-			return 0
-		}
-		return n
-	}
-	return 0
 }
 
 // TableHeaders returns the columns used by --output=table for

--- a/internal/ftpuser/ftpuser.go
+++ b/internal/ftpuser/ftpuser.go
@@ -100,28 +100,20 @@ func DecodeFTPUsers(returnInfo soap.Value) (FTPUserList, error) {
 			return nil, fmt.Errorf("ftpuser: ReturnInfo[%d] is not a Map", i)
 		}
 		out = append(out, FTPUser{
-			Login:           getString(item, "ftp_login"),
-			Password:        getString(item, "ftp_password"),
-			Passwort:        getString(item, "ftp_passwort"),
-			Path:            getString(item, "ftp_path"),
-			Comment:         getString(item, "ftp_comment"),
-			IsMainUser:      getString(item, "ftp_is_main_user"),
-			PermissionList:  getString(item, "ftp_permission_list"),
-			PermissionRead:  getString(item, "ftp_permission_read"),
-			PermissionWrite: getString(item, "ftp_permission_write"),
-			VirusClamAV:     getString(item, "ftp_virus_clamav"),
-			InProgress:      getString(item, "in_progress"),
+			Login:           item.MapString("ftp_login"),
+			Password:        item.MapString("ftp_password"),
+			Passwort:        item.MapString("ftp_passwort"),
+			Path:            item.MapString("ftp_path"),
+			Comment:         item.MapString("ftp_comment"),
+			IsMainUser:      item.MapString("ftp_is_main_user"),
+			PermissionList:  item.MapString("ftp_permission_list"),
+			PermissionRead:  item.MapString("ftp_permission_read"),
+			PermissionWrite: item.MapString("ftp_permission_write"),
+			VirusClamAV:     item.MapString("ftp_virus_clamav"),
+			InProgress:      item.MapString("in_progress"),
 		})
 	}
 	return out, nil
-}
-
-func getString(m soap.Value, key string) string {
-	v, ok := m.Get(key)
-	if !ok {
-		return ""
-	}
-	return v.AsString()
 }
 
 // TableHeaders returns the columns used by --output=table for

--- a/internal/mailaccount/mailaccount.go
+++ b/internal/mailaccount/mailaccount.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"strconv"
-	"strings"
 
 	"github.com/chmmou/kasapi-cli/internal/soap"
 )
@@ -124,76 +123,36 @@ func DecodeMailAccounts(returnInfo soap.Value) (MailAccountList, error) {
 			return nil, fmt.Errorf("mailaccount: ReturnInfo[%d] is not a Map", i)
 		}
 		out = append(out, MailAccount{
-			Login:                getString(item, "mail_login"),
-			Password:             getString(item, "mail_password"),
-			Adresses:             getString(item, "mail_adresses"),
-			Addresses:            getString(item, "mail_addresses"),
-			Comment:              getString(item, "mail_comment"),
-			Responder:            getString(item, "mail_responder"),
-			ResponderText:        getString(item, "mail_responder_text"),
-			ResponderDisplayName: getString(item, "mail_responder_displayname"),
-			ResponderContentType: getString(item, "mail_responder_content_type"),
-			CopyAdress:           getString(item, "mail_copy_adress"),
-			CopyAddress:          getString(item, "mail_copy_address"),
-			SenderAlias:          getString(item, "mail_sender_alias"),
-			Spamfilter:           getString(item, "mail_spamfilter"),
-			InProgress:           getString(item, "in_progress"),
-			XListEnabled:         getString(item, "mail_xlist_enabled"),
-			XListSent:            getString(item, "mail_xlist_sent"),
-			XListDrafts:          getString(item, "mail_xlist_drafts"),
-			XListTrash:           getString(item, "mail_xlist_trash"),
-			XListSpam:            getString(item, "mail_xlist_spam"),
-			XListArchiv:          getString(item, "mail_xlist_archiv"),
-			UsedSpace:            getFloat(item, "used_mailaccount_space"),
-			IsActive:             getString(item, "mail_is_active"),
-			ShowPassword:         getString(item, "show_password"),
-			AllowNets:            getString(item, "mail_allow_nets"),
-			TwoFA:                getString(item, "mail_2fa"),
-			QuotaRule:            getInt(item, "quota_rule"),
-			WebmailAutologin:     getString(item, "webmail_autologin"),
+			Login:                item.MapString("mail_login"),
+			Password:             item.MapString("mail_password"),
+			Adresses:             item.MapString("mail_adresses"),
+			Addresses:            item.MapString("mail_addresses"),
+			Comment:              item.MapString("mail_comment"),
+			Responder:            item.MapString("mail_responder"),
+			ResponderText:        item.MapString("mail_responder_text"),
+			ResponderDisplayName: item.MapString("mail_responder_displayname"),
+			ResponderContentType: item.MapString("mail_responder_content_type"),
+			CopyAdress:           item.MapString("mail_copy_adress"),
+			CopyAddress:          item.MapString("mail_copy_address"),
+			SenderAlias:          item.MapString("mail_sender_alias"),
+			Spamfilter:           item.MapString("mail_spamfilter"),
+			InProgress:           item.MapString("in_progress"),
+			XListEnabled:         item.MapString("mail_xlist_enabled"),
+			XListSent:            item.MapString("mail_xlist_sent"),
+			XListDrafts:          item.MapString("mail_xlist_drafts"),
+			XListTrash:           item.MapString("mail_xlist_trash"),
+			XListSpam:            item.MapString("mail_xlist_spam"),
+			XListArchiv:          item.MapString("mail_xlist_archiv"),
+			UsedSpace:            item.MapFloat("used_mailaccount_space"),
+			IsActive:             item.MapString("mail_is_active"),
+			ShowPassword:         item.MapString("show_password"),
+			AllowNets:            item.MapString("mail_allow_nets"),
+			TwoFA:                item.MapString("mail_2fa"),
+			QuotaRule:            item.MapInt("quota_rule"),
+			WebmailAutologin:     item.MapString("webmail_autologin"),
 		})
 	}
 	return out, nil
-}
-
-func getString(m soap.Value, key string) string {
-	v, ok := m.Get(key)
-	if !ok {
-		return ""
-	}
-	return v.AsString()
-}
-
-func getInt(m soap.Value, key string) int {
-	v, ok := m.Get(key)
-	if !ok {
-		return 0
-	}
-	switch v.Kind {
-	case soap.KindInt:
-		return int(v.Int)
-	case soap.KindFloat:
-		return int(v.Float)
-	case soap.KindString:
-		s := strings.TrimSpace(v.String)
-		if s == "" {
-			return 0
-		}
-		n, err := strconv.Atoi(s)
-		if err != nil {
-			return 0
-		}
-		return n
-	}
-	return 0
-}
-
-func getFloat(m soap.Value, key string) float64 {
-	v, ok := m.Get(key)
-	if !ok {
-		return 0
-	}
-	return v.AsFloat()
 }
 
 // TableHeaders returns the columns used by --output=table for

--- a/internal/mailfilter/mailfilter.go
+++ b/internal/mailfilter/mailfilter.go
@@ -61,21 +61,13 @@ func DecodeStandardFilters(returnInfo soap.Value) (StandardFilterList, error) {
 			return nil, fmt.Errorf("mailfilter: ReturnInfo[%d] is not a Map", i)
 		}
 		out = append(out, StandardFilter{
-			Filter:      getString(item, "filter"),
-			Type:        getString(item, "type"),
-			Title:       getString(item, "title"),
-			Recommended: getString(item, "recommended"),
+			Filter:      item.MapString("filter"),
+			Type:        item.MapString("type"),
+			Title:       item.MapString("title"),
+			Recommended: item.MapString("recommended"),
 		})
 	}
 	return out, nil
-}
-
-func getString(m soap.Value, key string) string {
-	v, ok := m.Get(key)
-	if !ok {
-		return ""
-	}
-	return v.AsString()
 }
 
 // TableHeaders returns the columns used by --output=table for

--- a/internal/mailforward/mailforward.go
+++ b/internal/mailforward/mailforward.go
@@ -92,23 +92,15 @@ func DecodeMailForwards(returnInfo soap.Value) (MailForwardList, error) {
 			return nil, fmt.Errorf("mailforward: ReturnInfo[%d] is not a Map", i)
 		}
 		out = append(out, MailForward{
-			Adress:     getString(item, "mail_forward_adress"),
-			Address:    getString(item, "mail_forward_address"),
-			Comment:    getString(item, "mail_forward_comment"),
-			Targets:    getString(item, "mail_forward_targets"),
-			Spamfilter: getString(item, "mail_forward_spamfilter"),
-			InProgress: getString(item, "in_progress"),
+			Adress:     item.MapString("mail_forward_adress"),
+			Address:    item.MapString("mail_forward_address"),
+			Comment:    item.MapString("mail_forward_comment"),
+			Targets:    item.MapString("mail_forward_targets"),
+			Spamfilter: item.MapString("mail_forward_spamfilter"),
+			InProgress: item.MapString("in_progress"),
 		})
 	}
 	return out, nil
-}
-
-func getString(m soap.Value, key string) string {
-	v, ok := m.Get(key)
-	if !ok {
-		return ""
-	}
-	return v.AsString()
 }
 
 // TableHeaders returns the columns used by --output=table for

--- a/internal/mailinglist/mailinglist.go
+++ b/internal/mailinglist/mailinglist.go
@@ -61,21 +61,13 @@ func DecodeMailingLists(returnInfo soap.Value) (MailingListList, error) {
 			return nil, fmt.Errorf("mailinglist: ReturnInfo[%d] is not a Map", i)
 		}
 		out = append(out, MailingList{
-			Name:       getString(item, "mailinglist_name"),
-			Admin:      getString(item, "mailinglist_admin"),
-			URL:        getString(item, "mailinglist_url"),
-			InProgress: getString(item, "in_progress"),
+			Name:       item.MapString("mailinglist_name"),
+			Admin:      item.MapString("mailinglist_admin"),
+			URL:        item.MapString("mailinglist_url"),
+			InProgress: item.MapString("in_progress"),
 		})
 	}
 	return out, nil
-}
-
-func getString(m soap.Value, key string) string {
-	v, ok := m.Get(key)
-	if !ok {
-		return ""
-	}
-	return v.AsString()
 }
 
 // TableHeaders returns the columns used by --output=table for

--- a/internal/sambauser/sambauser.go
+++ b/internal/sambauser/sambauser.go
@@ -89,22 +89,14 @@ func DecodeSambaUsers(returnInfo soap.Value) (SambaUserList, error) {
 			return nil, fmt.Errorf("sambauser: ReturnInfo[%d] is not a Map", i)
 		}
 		out = append(out, SambaUser{
-			Login:      getString(item, "samba_login"),
-			Password:   getString(item, "samba_password"),
-			Path:       getString(item, "samba_path"),
-			Comment:    getString(item, "samba_comment"),
-			InProgress: getString(item, "in_progress"),
+			Login:      item.MapString("samba_login"),
+			Password:   item.MapString("samba_password"),
+			Path:       item.MapString("samba_path"),
+			Comment:    item.MapString("samba_comment"),
+			InProgress: item.MapString("in_progress"),
 		})
 	}
 	return out, nil
-}
-
-func getString(m soap.Value, key string) string {
-	v, ok := m.Get(key)
-	if !ok {
-		return ""
-	}
-	return v.AsString()
 }
 
 // TableHeaders returns the columns used by --output=table for

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -64,23 +64,15 @@ func DecodeServices(returnInfo soap.Value) (ServiceList, error) {
 			return nil, fmt.Errorf("server: ReturnInfo[%d] is not a Map", i)
 		}
 		out = append(out, Service{
-			Service:       getString(item, "service"),
-			Version:       getString(item, "version"),
-			VersionType:   getString(item, "version_type"),
-			Interface:     getString(item, "interface"),
-			FileExtension: getString(item, "file_extension"),
-			Distribution:  getString(item, "distribution"),
+			Service:       item.MapString("service"),
+			Version:       item.MapString("version"),
+			VersionType:   item.MapString("version_type"),
+			Interface:     item.MapString("interface"),
+			FileExtension: item.MapString("file_extension"),
+			Distribution:  item.MapString("distribution"),
 		})
 	}
 	return out, nil
-}
-
-func getString(m soap.Value, key string) string {
-	v, ok := m.Get(key)
-	if !ok {
-		return ""
-	}
-	return v.AsString()
 }
 
 // TableHeaders returns the columns used by --output=table.

--- a/internal/soap/soap_test.go
+++ b/internal/soap/soap_test.go
@@ -220,6 +220,85 @@ func TestEncodeRequestRoundtrip(t *testing.T) {
 	}
 }
 
+// TestValueMapAccessors covers the typed Map accessors (MapString /
+// MapInt / MapInt64 / MapFloat) used by every read module. The cases
+// here pin coercion across nil, missing-key, cross-kind, and
+// unparseable inputs so a future mistake in a single accessor cannot
+// silently corrupt every decoder that depends on it.
+func TestValueMapAccessors(t *testing.T) {
+	m := soap.Value{Kind: soap.KindMap, Map: []soap.KV{
+		{Key: "name", Value: soap.Value{Kind: soap.KindString, String: "demo"}},
+		{Key: "count", Value: soap.Value{Kind: soap.KindInt, Int: 42}},
+		{Key: "ratio", Value: soap.Value{Kind: soap.KindFloat, Float: 1.5}},
+		{Key: "stringy_int", Value: soap.Value{Kind: soap.KindString, String: " 7 "}},
+		{Key: "stringy_float", Value: soap.Value{Kind: soap.KindString, String: "3.25"}},
+		{Key: "blank", Value: soap.Value{Kind: soap.KindString, String: ""}},
+		{Key: "garbage", Value: soap.Value{Kind: soap.KindString, String: "abc"}},
+		{Key: "nil_field", Value: soap.Value{Kind: soap.KindNil}},
+	}}
+
+	if got, want := m.MapString("name"), "demo"; got != want {
+		t.Errorf("MapString(name) = %q, want %q", got, want)
+	}
+	if got, want := m.MapString("count"), "42"; got != want {
+		t.Errorf("MapString(count) = %q, want %q", got, want)
+	}
+	if got := m.MapString("missing"); got != "" {
+		t.Errorf("MapString(missing) = %q, want empty", got)
+	}
+	if got := m.MapString("nil_field"); got != "" {
+		t.Errorf("MapString(nil_field) = %q, want empty", got)
+	}
+
+	if got, want := m.MapInt("count"), 42; got != want {
+		t.Errorf("MapInt(count) = %d, want %d", got, want)
+	}
+	if got, want := m.MapInt("ratio"), 1; got != want {
+		t.Errorf("MapInt(ratio) = %d, want %d (truncated)", got, want)
+	}
+	if got, want := m.MapInt("stringy_int"), 7; got != want {
+		t.Errorf("MapInt(stringy_int) = %d, want %d", got, want)
+	}
+	if got := m.MapInt("garbage"); got != 0 {
+		t.Errorf("MapInt(garbage) = %d, want 0", got)
+	}
+	if got := m.MapInt("blank"); got != 0 {
+		t.Errorf("MapInt(blank) = %d, want 0", got)
+	}
+	if got := m.MapInt("missing"); got != 0 {
+		t.Errorf("MapInt(missing) = %d, want 0", got)
+	}
+
+	if got, want := m.MapInt64("count"), int64(42); got != want {
+		t.Errorf("MapInt64(count) = %d, want %d", got, want)
+	}
+
+	if got, want := m.MapFloat("ratio"), 1.5; got != want {
+		t.Errorf("MapFloat(ratio) = %v, want %v", got, want)
+	}
+	if got, want := m.MapFloat("stringy_float"), 3.25; got != want {
+		t.Errorf("MapFloat(stringy_float) = %v, want %v", got, want)
+	}
+	if got := m.MapFloat("garbage"); got != 0 {
+		t.Errorf("MapFloat(garbage) = %v, want 0", got)
+	}
+
+	// Non-Map receiver: every accessor must return zero without panic.
+	scalar := soap.Value{Kind: soap.KindString, String: "x"}
+	if got := scalar.MapString("anything"); got != "" {
+		t.Errorf("scalar.MapString = %q, want empty", got)
+	}
+	if got := scalar.MapInt("anything"); got != 0 {
+		t.Errorf("scalar.MapInt = %d, want 0", got)
+	}
+	if got := scalar.MapInt64("anything"); got != 0 {
+		t.Errorf("scalar.MapInt64 = %d, want 0", got)
+	}
+	if got := scalar.MapFloat("anything"); got != 0 {
+		t.Errorf("scalar.MapFloat = %v, want 0", got)
+	}
+}
+
 // TestEncodeRequestRequiresFields verifies that EncodeRequest rejects
 // malformed input rather than silently producing an unauthenticated call.
 func TestEncodeRequestRequiresFields(t *testing.T) {

--- a/internal/soap/value.go
+++ b/internal/soap/value.go
@@ -308,3 +308,64 @@ func (v Value) AsFloat() float64 {
 	}
 	return 0
 }
+
+// AsInt coerces numeric kinds to int64. Strings are parsed when they
+// represent a valid integer; floats truncate toward zero; everything
+// else returns 0.
+func (v Value) AsInt() int64 {
+	switch v.Kind {
+	case KindInt:
+		return v.Int
+	case KindFloat:
+		return int64(v.Float)
+	case KindString:
+		s := strings.TrimSpace(v.String)
+		if s == "" {
+			return 0
+		}
+		n, err := strconv.ParseInt(s, 10, 64)
+		if err != nil {
+			return 0
+		}
+		return n
+	}
+	return 0
+}
+
+// MapString looks up key in a Map Value and returns the entry coerced
+// to its textual form via AsString. Missing keys, non-Map receivers,
+// and xsi:nil values yield "". This is the canonical accessor read
+// modules use to extract scalar string fields from a KAS response Map.
+func (v Value) MapString(key string) string {
+	inner, ok := v.Get(key)
+	if !ok {
+		return ""
+	}
+	return inner.AsString()
+}
+
+// MapInt looks up key in a Map Value and returns the entry coerced to
+// int via AsInt. Missing keys and unparseable values yield 0.
+func (v Value) MapInt(key string) int {
+	return int(v.MapInt64(key))
+}
+
+// MapInt64 is the int64 form of MapInt for fields whose magnitude
+// would not fit a 32-bit int on all targets (counters, byte sizes).
+func (v Value) MapInt64(key string) int64 {
+	inner, ok := v.Get(key)
+	if !ok {
+		return 0
+	}
+	return inner.AsInt()
+}
+
+// MapFloat looks up key in a Map Value and returns the entry coerced
+// to float64 via AsFloat. Missing keys yield 0.
+func (v Value) MapFloat(key string) float64 {
+	inner, ok := v.Get(key)
+	if !ok {
+		return 0
+	}
+	return inner.AsFloat()
+}

--- a/internal/softwareinstall/softwareinstall.go
+++ b/internal/softwareinstall/softwareinstall.go
@@ -113,35 +113,27 @@ func DecodeSoftwareInstalls(returnInfo soap.Value) (SoftwareInstallList, error) 
 			return nil, fmt.Errorf("softwareinstall: ReturnInfo[%d] is not a Map", i)
 		}
 		out = append(out, SoftwareInstall{
-			ID:                 getString(item, "software_id"),
-			Name:               getString(item, "software_name"),
-			Category:           getString(item, "software_category"),
-			Version:            getString(item, "software_version"),
-			Licence:            getString(item, "software_licence"),
-			Description:        getString(item, "description"),
-			Image:              getString(item, "image"),
-			HasExampleData:     getString(item, "software_has_example_data"),
-			PHPVersion:         getString(item, "software_version_php"),
-			PHPVersionUpto:     getString(item, "software_version_php_upto"),
-			PHPHtaccess:        getString(item, "software_version_php_htaccess"),
-			PHPWantCGI:         getString(item, "software_version_php_want_cgi"),
-			MySQLVersion:       getString(item, "software_version_mysql"),
-			MySQLVersionUpto:   getString(item, "software_version_mysql_upto"),
-			MariaDBVersion:     getString(item, "software_version_mariadb"),
-			MariaDBVersionUpto: getString(item, "software_version_mariadb_upto"),
-			CanBeInstalled:     getString(item, "software_can_be_installed"),
-			CanBeMessage:       getString(item, "software_can_be_message"),
+			ID:                 item.MapString("software_id"),
+			Name:               item.MapString("software_name"),
+			Category:           item.MapString("software_category"),
+			Version:            item.MapString("software_version"),
+			Licence:            item.MapString("software_licence"),
+			Description:        item.MapString("description"),
+			Image:              item.MapString("image"),
+			HasExampleData:     item.MapString("software_has_example_data"),
+			PHPVersion:         item.MapString("software_version_php"),
+			PHPVersionUpto:     item.MapString("software_version_php_upto"),
+			PHPHtaccess:        item.MapString("software_version_php_htaccess"),
+			PHPWantCGI:         item.MapString("software_version_php_want_cgi"),
+			MySQLVersion:       item.MapString("software_version_mysql"),
+			MySQLVersionUpto:   item.MapString("software_version_mysql_upto"),
+			MariaDBVersion:     item.MapString("software_version_mariadb"),
+			MariaDBVersionUpto: item.MapString("software_version_mariadb_upto"),
+			CanBeInstalled:     item.MapString("software_can_be_installed"),
+			CanBeMessage:       item.MapString("software_can_be_message"),
 		})
 	}
 	return out, nil
-}
-
-func getString(m soap.Value, key string) string {
-	v, ok := m.Get(key)
-	if !ok {
-		return ""
-	}
-	return v.AsString()
 }
 
 // TableHeaders returns the columns used by --output=table for

--- a/internal/subdomain/subdomain.go
+++ b/internal/subdomain/subdomain.go
@@ -121,70 +121,38 @@ func DecodeSubdomains(returnInfo soap.Value) (SubdomainList, error) {
 			return nil, fmt.Errorf("subdomain: ReturnInfo[%d] is not a Map", i)
 		}
 		out = append(out, Subdomain{
-			Name:           getString(item, "subdomain_name"),
-			RedirectStatus: getInt(item, "subdomain_redirect_status"),
-			Path:           getString(item, "subdomain_path"),
-			Account:        getString(item, "subdomain_account"),
-			Server:         getString(item, "subdomain_server"),
+			Name:           item.MapString("subdomain_name"),
+			RedirectStatus: item.MapInt("subdomain_redirect_status"),
+			Path:           item.MapString("subdomain_path"),
+			Account:        item.MapString("subdomain_account"),
+			Server:         item.MapString("subdomain_server"),
 
-			FPSEActive:    getString(item, "fpse_active"),
-			PHPVersion:    getString(item, "php_version"),
-			PHPDeprecated: getString(item, "php_deprecated"),
-			IsActive:      getString(item, "is_active"),
-			InProgress:    getString(item, "in_progress"),
+			FPSEActive:    item.MapString("fpse_active"),
+			PHPVersion:    item.MapString("php_version"),
+			PHPDeprecated: item.MapString("php_deprecated"),
+			IsActive:      item.MapString("is_active"),
+			InProgress:    item.MapString("in_progress"),
 
-			StatisticVersion:  getInt(item, "statistic_version"),
-			StatisticLanguage: getString(item, "statistic_language"),
+			StatisticVersion:  item.MapInt("statistic_version"),
+			StatisticLanguage: item.MapString("statistic_language"),
 
 			SSL: SSL{
-				Proxy:         getString(item, "ssl_proxy"),
-				CertificateIP: getString(item, "ssl_certificate_ip"),
-				SNI:           getString(item, "ssl_certificate_sni"),
-				SNIIsActive:   getString(item, "ssl_certificate_sni_is_active"),
-				SNICSR:        getString(item, "ssl_certificate_sni_csr"),
-				SNIKey:        getString(item, "ssl_certificate_sni_key"),
-				SNICRT:        getString(item, "ssl_certificate_sni_crt"),
-				SNIBundle:     getString(item, "ssl_certificate_sni_bundle"),
-				SNIChainfile:  getString(item, "ssl_certificate_sni_chainfile"),
-				SNIType:       getString(item, "ssl_certificate_sni_type"),
-				SNIForceHTTPS: getString(item, "ssl_certificate_sni_force_https"),
-				SNIHSTSMaxAge: getString(item, "ssl_certificate_sni_hsts_max_age"),
+				Proxy:         item.MapString("ssl_proxy"),
+				CertificateIP: item.MapString("ssl_certificate_ip"),
+				SNI:           item.MapString("ssl_certificate_sni"),
+				SNIIsActive:   item.MapString("ssl_certificate_sni_is_active"),
+				SNICSR:        item.MapString("ssl_certificate_sni_csr"),
+				SNIKey:        item.MapString("ssl_certificate_sni_key"),
+				SNICRT:        item.MapString("ssl_certificate_sni_crt"),
+				SNIBundle:     item.MapString("ssl_certificate_sni_bundle"),
+				SNIChainfile:  item.MapString("ssl_certificate_sni_chainfile"),
+				SNIType:       item.MapString("ssl_certificate_sni_type"),
+				SNIForceHTTPS: item.MapString("ssl_certificate_sni_force_https"),
+				SNIHSTSMaxAge: item.MapString("ssl_certificate_sni_hsts_max_age"),
 			},
 		})
 	}
 	return out, nil
-}
-
-func getString(m soap.Value, key string) string {
-	v, ok := m.Get(key)
-	if !ok {
-		return ""
-	}
-	return v.AsString()
-}
-
-func getInt(m soap.Value, key string) int {
-	v, ok := m.Get(key)
-	if !ok {
-		return 0
-	}
-	switch v.Kind {
-	case soap.KindInt:
-		return int(v.Int)
-	case soap.KindFloat:
-		return int(v.Float)
-	case soap.KindString:
-		s := strings.TrimSpace(v.String)
-		if s == "" {
-			return 0
-		}
-		n, err := strconv.Atoi(s)
-		if err != nil {
-			return 0
-		}
-		return n
-	}
-	return 0
 }
 
 // TableHeaders returns the columns used by --output=table for

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -154,14 +154,14 @@ func DecodeSpace(returnInfo soap.Value) (SpaceList, error) {
 			return nil, fmt.Errorf("usage: ReturnInfo[%d] is not a Map", i)
 		}
 		out = append(out, Space{
-			AccountLogin:         getString(item, "account_login"),
-			LastCalculation:      getInt64(item, "last_calculation"),
-			UsedHTDocsSpace:      getInt64(item, "used_htdocs_space"),
-			UsedChrootSpace:      getInt64(item, "used_chroot_space"),
-			UsedDatabaseSpace:    getInt64(item, "used_database_space"),
-			UsedMailaccountSpace: getInt64(item, "used_mailaccount_space"),
-			UsedWebspace:         getInt64(item, "used_webspace"),
-			MaxWebspace:          getInt64(item, "max_webspace"),
+			AccountLogin:         item.MapString("account_login"),
+			LastCalculation:      item.MapInt64("last_calculation"),
+			UsedHTDocsSpace:      item.MapInt64("used_htdocs_space"),
+			UsedChrootSpace:      item.MapInt64("used_chroot_space"),
+			UsedDatabaseSpace:    item.MapInt64("used_database_space"),
+			UsedMailaccountSpace: item.MapInt64("used_mailaccount_space"),
+			UsedWebspace:         item.MapInt64("used_webspace"),
+			MaxWebspace:          item.MapInt64("max_webspace"),
 		})
 	}
 	return out, nil
@@ -179,10 +179,10 @@ func DecodeSpaceUsage(returnInfo soap.Value) (SpaceUsageList, error) {
 			return nil, fmt.Errorf("usage: ReturnInfo[%d] is not a Map", i)
 		}
 		out = append(out, SpaceUsage{
-			Directory:       getString(item, "directory"),
-			Count:           getInt64(item, "count"),
-			Bytes:           getInt64(item, "bytes"),
-			LastCalculation: getInt64(item, "last_calculation"),
+			Directory:       item.MapString("directory"),
+			Count:           item.MapInt64("count"),
+			Bytes:           item.MapInt64("bytes"),
+			LastCalculation: item.MapInt64("last_calculation"),
 			HasSubDirs:      getYN(item, "has_sub_dirs"),
 		})
 	}
@@ -203,54 +203,18 @@ func DecodeTraffic(returnInfo soap.Value) (TrafficList, error) {
 			return nil, fmt.Errorf("usage: ReturnInfo entry %q is not a Map", kv.Key)
 		}
 		out = append(out, Traffic{
-			AccountLogin: getString(kv.Value, "account_login"),
-			Year:         getInt(kv.Value, "year"),
-			Month:        getInt(kv.Value, "month"),
-			Day:          getInt(kv.Value, "day"),
-			HTTPTraffic:  getInt64(kv.Value, "http_traffic"),
-			FTPTraffic:   getInt64(kv.Value, "ftp_traffic"),
-			HTTPHits:     getInt64(kv.Value, "http_hits"),
-			FTPHits:      getInt64(kv.Value, "ftp_hits"),
-			Comment:      getString(kv.Value, "comment"),
+			AccountLogin: kv.Value.MapString("account_login"),
+			Year:         kv.Value.MapInt("year"),
+			Month:        kv.Value.MapInt("month"),
+			Day:          kv.Value.MapInt("day"),
+			HTTPTraffic:  kv.Value.MapInt64("http_traffic"),
+			FTPTraffic:   kv.Value.MapInt64("ftp_traffic"),
+			HTTPHits:     kv.Value.MapInt64("http_hits"),
+			FTPHits:      kv.Value.MapInt64("ftp_hits"),
+			Comment:      kv.Value.MapString("comment"),
 		})
 	}
 	return out, nil
-}
-
-func getString(m soap.Value, key string) string {
-	v, ok := m.Get(key)
-	if !ok {
-		return ""
-	}
-	return v.AsString()
-}
-
-func getInt(m soap.Value, key string) int {
-	return int(getInt64(m, key))
-}
-
-func getInt64(m soap.Value, key string) int64 {
-	v, ok := m.Get(key)
-	if !ok {
-		return 0
-	}
-	switch v.Kind {
-	case soap.KindInt:
-		return v.Int
-	case soap.KindFloat:
-		return int64(v.Float)
-	case soap.KindString:
-		s := strings.TrimSpace(v.String)
-		if s == "" {
-			return 0
-		}
-		n, err := strconv.ParseInt(s, 10, 64)
-		if err != nil {
-			return 0
-		}
-		return n
-	}
-	return 0
 }
 
 func getYN(m soap.Value, key string) bool {


### PR DESCRIPTION
## Summary

Every read module defined its own copy of `getString` / `getInt` / `getInt64` / `getFloat` around `soap.Value.Get` (#56 catalogued ~28 copies across 17 packages). Promote the canonical forms to typed accessors on `soap.Value` and migrate every read module to call them directly.

- New API on `soap.Value`: `MapString`, `MapInt`, `MapInt64`, `MapFloat`, plus a generic `AsInt` coercion (counterpart to the existing `AsString` / `AsFloat`).
- Migrated 17 read packages: account, cronjob, database, ddns, directoryprotection, dns, domain, ftpuser, mailaccount, mailfilter, mailforward, mailinglist, sambauser, server, softwareinstall, subdomain, usage.
- Behaviour-preserving: `TestValueMapAccessors` pins coercion across nil, missing-key, cross-kind, and unparseable inputs against the rules the per-package helpers used.
- Out of scope: package-local `getBool` / `getYN` in `internal/account/decode.go` (only used by one decoder, covers boolean/Y-N coercion not listed in #56).

Net: −195 LOC.

Closes #56.