### PR TITLE
fix: code-review follow-ups (doc/comment cleanup)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -221,6 +221,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `internal/auth/source.go`: sharpen the `Heartbeat` doc comment.
+  The previous wording claimed Heartbeat was a no-op "when no Store
+  is wired up", but the in-memory rolling window is updated regardless
+  of `Store`; the comment now describes the actual conditions
+  (`UpdateLifetime` false or no cached token). Closes #41.
+
+- `internal/api/client.go`: drop the stale "(issue #5)" reference from
+  the `StaticTokenSource` doc comment. Issue #5 was closed by PR #29
+  when the KasAuth client landed; the surrounding sentence is kept.
+
+- `internal/account/table.go`: document the `used_account_space`
+  unit conversion. The KAS phpdoc does not state the unit, but the
+  magnitudes and fractional digits in real responses are consistent
+  with KiB (`bytes/1024`); a one-line code comment records the
+  derivation so future readers do not rediscover it.
+
 - `internal/usage`: drop the action name from `DecodeSpace` /
   `DecodeSpaceUsage` / `DecodeTraffic` error strings. The Client
   wrappers already prepend `usage: get_space:` / `usage: get_traffic:`

--- a/internal/account/table.go
+++ b/internal/account/table.go
@@ -14,6 +14,10 @@ func (AccountList) TableHeaders() []string {
 }
 
 // TableRows returns one row per account, in the order returned by KAS.
+// KAS returns used_account_space in KiB (the phpdoc at
+// https://kasapi.kasserver.com/dokumentation/phpdoc/ does not state the
+// unit, but real responses have magnitudes and fractional digits
+// consistent with bytes/1024); /1024 yields MiB, displayed as MB.
 func (l AccountList) TableRows() [][]string {
 	rows := make([][]string, 0, len(l))
 	for _, a := range l {

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -39,8 +39,8 @@ type Heartbeater interface {
 
 // StaticTokenSource is a TokenSource that returns the same credentials
 // every call. Suitable for plain auth and for tests; session-token
-// callers should use the source provided by the auth package once the
-// KasAuth client (issue #5) is in place.
+// callers should use the source provided by the auth package, which
+// wraps the KasAuth client.
 type StaticTokenSource struct {
 	Login    string
 	AuthData string

--- a/internal/auth/source.go
+++ b/internal/auth/source.go
@@ -111,9 +111,10 @@ func (s *SessionTokenSource) Invalidate() {
 
 // Heartbeat extends the cached expiry by Lifetime when UpdateLifetime
 // is true, mirroring the server's session_update_lifetime=Y rolling
-// window. It is a no-op when there is no cached token, when
-// UpdateLifetime is false, or when no Store is wired up. Called by
-// api.Client after every successful KasApi call.
+// window. It is a no-op when UpdateLifetime is false or no token is
+// cached; when a Store is wired up the refreshed expiry is also
+// persisted, otherwise the rolling window stays in-memory only.
+// Called by api.Client after every successful KasApi call.
 func (s *SessionTokenSource) Heartbeat() {
 	s.mu.Lock()
 	defer s.mu.Unlock()


### PR DESCRIPTION
## Summary

Three small doc/comment clean-ups bundled from the 2026-05-03 code review:

- `internal/auth/source.go` — Heartbeat doc-vs-behavior mismatch fixed: the in-memory rolling window is updated regardless of `Store`, so the comment now lists the actual no-op conditions (`UpdateLifetime` false or no cached token) and clarifies that the persisted-vs-in-memory split is orthogonal.
- `internal/api/client.go` — drop the stale "(issue #5)" reference from the `StaticTokenSource` doc; #5 was closed by PR #29.
- `internal/account/table.go` — record the `used_account_space` unit derivation inline. The KAS phpdoc does not state the unit, but the magnitudes and fractional digits in real responses (`testdata/account/get_accounts_response_success.xml`) are consistent with KiB (`bytes/1024`), so `/1024` yields MiB, displayed as MB.

Closes #41.