### PR TITLE
fix: retry on kas_session_invalid; preserve wired session flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -233,6 +233,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Session re-authentication now triggers on `kas_session_invalid`.
+  `IsAuthFailure` previously covered only `no_auth`, `unknown_session`,
+  `kas_access_forbidden`, and `got_no_login_data`; KAS also returns
+  `kas_session_invalid` when a server-side session is no longer
+  accepted (e.g. it was created with `session_update_lifetime=N` and
+  the lifetime elapsed). Without this code the auto-retry path in
+  `*api.Client.Call` did not fire and the user saw the raw fault.
+
+- `internal/auth/source.go`: preserve the user-configured `Lifetime` /
+  `UpdateLifetime` across `Invalidate`. When a persisted session was
+  loaded its server-side properties are adopted for the duration of
+  that session's life (so Heartbeat stays consistent), but the wired
+  CLI-flag values are now snapshotted on first `Credentials` call and
+  restored by `Invalidate`. The fresh session created by the next
+  re-authentication therefore reflects the current run's flags rather
+  than the stale persisted properties — fixing the case where an
+  initial run without `--session-update-lifetime` would otherwise
+  pin the persisted entry to `update_lifetime=false` forever.
+
 - `internal/auth/source.go`: sharpen the `Heartbeat` doc comment.
   The previous wording claimed Heartbeat was a no-op "when no Store
   is wired up", but the in-memory rolling window is updated regardless

--- a/internal/api/doc.go
+++ b/internal/api/doc.go
@@ -8,9 +8,11 @@
 // IsSyntaxError, IsMaxReached, IsInProgress) are provided so callers can
 // branch on classes of errors without enumerating individual codes.
 //
-// On unknown_session or no_auth, Call invalidates the TokenSource and
-// retries once with fresh credentials. All other faults surface to the
-// caller without retry.
+// On any code classified as an auth failure by IsAuthFailure
+// (currently no_auth, unknown_session, kas_session_invalid,
+// kas_access_forbidden, got_no_login_data), Call invalidates the
+// TokenSource and retries once with fresh credentials. All other
+// faults surface to the caller without retry.
 //
 // See issue #6.
 package api

--- a/internal/api/errors.go
+++ b/internal/api/errors.go
@@ -18,6 +18,7 @@ const (
 	CodeUnknownAction    = "unkown_action"
 	CodeGotNoLoginData   = "got_no_login_data"
 	CodeUnknownSession   = "unknown_session"
+	CodeSessionInvalid   = "kas_session_invalid"
 	CodeFloodProtection  = "flood_protection"
 	CodeInProgress       = "in_progress"
 	CodeMissingParameter = "missing_parameter"
@@ -75,12 +76,12 @@ func IsCode(err error, code string) bool { return codeOf(err) == code }
 
 // IsAuthFailure reports whether err is an authentication failure that a
 // session-token client should respond to by re-authenticating. This
-// includes no_auth, unknown_session, kas_access_forbidden, and the
-// generic got_no_login_data envelope returned when the request lacked
-// kas_login.
+// includes no_auth, unknown_session, kas_session_invalid,
+// kas_access_forbidden, and the generic got_no_login_data envelope
+// returned when the request lacked kas_login.
 func IsAuthFailure(err error) bool {
 	switch codeOf(err) {
-	case CodeNoAuth, CodeUnknownSession, CodeAccessForbidden, CodeGotNoLoginData:
+	case CodeNoAuth, CodeUnknownSession, CodeSessionInvalid, CodeAccessForbidden, CodeGotNoLoginData:
 		return true
 	}
 	return false

--- a/internal/api/errors_test.go
+++ b/internal/api/errors_test.go
@@ -27,6 +27,7 @@ func TestPredicateClassesByCode(t *testing.T) {
 	}{
 		{code: "no_auth", auth: true},
 		{code: "unknown_session", auth: true},
+		{code: "kas_session_invalid", auth: true},
 		{code: "kas_access_forbidden", auth: true},
 		{code: "got_no_login_data", auth: true},
 		{code: "flood_protection", flood: true},

--- a/internal/auth/client_test.go
+++ b/internal/auth/client_test.go
@@ -326,6 +326,62 @@ func TestSessionTokenSourceAdoptsLifetimeFromCachedEntry(t *testing.T) {
 	}
 }
 
+// TestSessionTokenSourceInvalidateRestoresConfiguredAfterAdopt covers
+// the case the user reported as kas_session_invalid: an earlier run
+// persisted a session with UpdateLifetime=N, the current run wires the
+// source with --session-update-lifetime=Y, and the cached entry is
+// adopted (overwriting the wired flags). When the server later rejects
+// the adopted token, Invalidate must restore the wired flags so the
+// fresh session is persisted with the user's current intent.
+func TestSessionTokenSourceInvalidateRestoresConfiguredAfterAdopt(t *testing.T) {
+	body := loadFixture(t, "session/add_session_response_success.xml")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(body)
+	}))
+	defer srv.Close()
+
+	tNow := time.Date(2026, 5, 9, 12, 0, 0, 0, time.UTC)
+	store := newStore(t, tNow)
+	if err := store.Save("w0", session.Entry{
+		Token:           "stale-but-locally-valid",
+		ExpiresAt:       tNow.Add(30 * time.Minute),
+		LifetimeSeconds: 1800,
+		UpdateLifetime:  false,
+	}); err != nil {
+		t.Fatalf("seed Save: %v", err)
+	}
+
+	src := auth.NewSessionTokenSource(newAuthClient(srv, "w0", "secret", soap.AuthPlain, auth.Options{}))
+	src.Store = store
+	src.Lifetime = 2 * time.Hour
+	src.UpdateLifetime = true
+	src.Now = func() time.Time { return tNow }
+
+	// First Credentials call adopts the cached entry's lifetime / flag.
+	if _, _, _, err := src.Credentials(context.Background()); err != nil {
+		t.Fatalf("Credentials: %v", err)
+	}
+
+	// Simulate the server-side kas_session_invalid by invalidating, then
+	// fetching fresh credentials. The new entry must be persisted with
+	// the wired Lifetime+UpdateLifetime, not the adopted ones.
+	src.Invalidate()
+	if _, _, _, err := src.Credentials(context.Background()); err != nil {
+		t.Fatalf("Credentials after invalidate: %v", err)
+	}
+
+	got, _ := store.Load("w0")
+	if got == nil {
+		t.Fatal("expected fresh entry persisted after invalidate")
+	}
+	if got.LifetimeSeconds != int(2*time.Hour/time.Second) {
+		t.Errorf("LifetimeSeconds = %d, want %d (wired value)", got.LifetimeSeconds, int(2*time.Hour/time.Second))
+	}
+	if !got.UpdateLifetime {
+		t.Errorf("UpdateLifetime = false, want true (wired value)")
+	}
+}
+
 func TestSessionTokenSourceHeartbeatNoopWithoutUpdateLifetime(t *testing.T) {
 	body := loadFixture(t, "session/add_session_response_success.xml")
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/internal/auth/source.go
+++ b/internal/auth/source.go
@@ -36,6 +36,16 @@ type SessionTokenSource struct {
 	loaded    bool
 	token     string
 	expiresAt time.Time
+
+	// Snapshot of the user-configured Lifetime / UpdateLifetime captured
+	// on first Credentials call. Loading a persisted session adopts the
+	// values it was created with so Heartbeats stay consistent for the
+	// rest of that session's life. Invalidate then restores these
+	// snapshot values so the *next* fresh session honours the CLI flags
+	// of the current run, not the stale persisted properties.
+	configCaptured           bool
+	configuredLifetime       time.Duration
+	configuredUpdateLifetime bool
 }
 
 // NewSessionTokenSource returns a source that lazily fetches the token
@@ -53,6 +63,12 @@ func NewSessionTokenSource(c *Client) *SessionTokenSource {
 func (s *SessionTokenSource) Credentials(ctx context.Context) (string, string, soap.AuthType, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+
+	if !s.configCaptured {
+		s.configuredLifetime = s.Lifetime
+		s.configuredUpdateLifetime = s.UpdateLifetime
+		s.configCaptured = true
+	}
 
 	if s.cachedValid() {
 		return s.Client.Login, s.token, soap.AuthSession, nil
@@ -97,13 +113,21 @@ func (s *SessionTokenSource) Credentials(ctx context.Context) (string, string, s
 }
 
 // Invalidate clears the cached token in memory and on disk so the next
-// Credentials call re-authenticates against KasAuth.
+// Credentials call re-authenticates against KasAuth. If the source has
+// adopted a persisted session's Lifetime / UpdateLifetime, those are
+// reset to the user-configured values so the fresh session created by
+// the next Credentials call respects the current CLI flags rather than
+// the now-discarded session's properties.
 func (s *SessionTokenSource) Invalidate() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.token = ""
 	s.expiresAt = time.Time{}
 	s.loaded = true
+	if s.configCaptured {
+		s.Lifetime = s.configuredLifetime
+		s.UpdateLifetime = s.configuredUpdateLifetime
+	}
 	if s.Store != nil {
 		_ = s.Store.Delete(s.Client.Login)
 	}


### PR DESCRIPTION
## Summary

Two coupled fixes for a user-reported `kas_session_invalid` that the CLI did not transparently recover from:

- `internal/api/errors.go` — add `CodeSessionInvalid = "kas_session_invalid"` and include it in `IsAuthFailure`. The auto-retry path in `*api.Client.Call` now invalidates the `TokenSource` and retries on this fault, matching existing handling of `no_auth` / `unknown_session` / `kas_access_forbidden` / `got_no_login_data`.

- `internal/auth/source.go` — `SessionTokenSource` snapshots the wired `Lifetime` / `UpdateLifetime` on the first `Credentials` call and restores them in `Invalidate`. Adoption of a persisted session's properties is unchanged for the duration of that session's life (Heartbeat stays consistent), but the fresh session created after `Invalidate` now respects the current run's CLI flags rather than the discarded session's properties.

## Verification

Verified live against the production KAS endpoint with a stale `sessions.toml` entry (`update_lifetime=false`, `lifetime_seconds=86400` from an earlier `--otp`-only run):

- Pre-fix: `kasapi-cli ... --session-lifetime 7200 --session-update-lifetime Y --otp <code> databases list` returned `kas get_databases: kas_session_invalid` and exited with status 2.
- Post-fix: same invocation returns the databases table, and the rewritten `sessions.toml` carries the new token with `lifetime_seconds=7200` and `update_lifetime=true`.

New unit test `TestSessionTokenSourceInvalidateRestoresConfiguredAfterAdopt` covers the snapshot/restore path; an `IsAuthFailure` table-test row covers the new code.