### PR TITLE
docs+test: re-review follow-ups for PR #68

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -231,6 +231,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `[2000, currentYear+1]`) and `--month` (must be `1..12`) instead of
   forwarding obvious typos to KAS. Closes #45.
 
+### Changed
+
+- `internal/api/doc.go`: stop enumerating the auth-failure code list
+  inline; point to `IsAuthFailure` as the single source of truth so a
+  future code addition only has to update one place.
+
+- `internal/auth/source.go`: extend the `SessionTokenSource`
+  type-level doc to describe the snapshot/restore semantics applied
+  during `Invalidate`, so readers see the full lifecycle without
+  having to drill into the field block.
+
+- `internal/api`: add `testdata/response_failed_kas_session_invalid.xml`
+  and `TestCallRetriesOnSessionInvalid` to pin the full Client + retry
+  composition for the new code; complements the IsAuthFailure
+  table-test row.
+
 ### Fixed
 
 - Session re-authentication now triggers on `kas_session_invalid`.

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -193,6 +193,39 @@ func TestCallRetriesOnAuthFailure(t *testing.T) {
 	}
 }
 
+// TestCallRetriesOnSessionInvalid is the kas_session_invalid analogue
+// of TestCallRetriesOnAuthFailure: it pins the integration so a future
+// edit that drops kas_session_invalid from IsAuthFailure surfaces here
+// rather than only in TestPredicateClassesByCode.
+func TestCallRetriesOnSessionInvalid(t *testing.T) {
+	authBody := loadFixture(t, "response_failed_kas_session_invalid.xml")
+	okBody := loadFixture(t, "account/get_accounts_response_success.xml")
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if calls.Add(1) == 1 {
+			_, _ = w.Write(authBody)
+			return
+		}
+		_, _ = w.Write(okBody)
+	}))
+	defer srv.Close()
+
+	ts := &countingTokens{login: "w0", data: "tok-1", typ: soap.AuthSession, refresh: "tok-2"}
+	c := newAPIClient(srv, ts)
+	if _, err := c.Call(context.Background(), "get_accounts", nil); err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	if calls.Load() != 2 {
+		t.Errorf("server calls = %d, want 2", calls.Load())
+	}
+	if ts.invalidations != 1 {
+		t.Errorf("invalidations = %d, want 1", ts.invalidations)
+	}
+	if ts.lastData != "tok-2" {
+		t.Errorf("retry used data = %q, want tok-2", ts.lastData)
+	}
+}
+
 func TestCallNoRetryOnNonAuthFault(t *testing.T) {
 	body := loadFixture(t, "account/add_account_response_failed_max_account_reached.xml")
 	var calls atomic.Int32

--- a/internal/api/doc.go
+++ b/internal/api/doc.go
@@ -8,11 +8,9 @@
 // IsSyntaxError, IsMaxReached, IsInProgress) are provided so callers can
 // branch on classes of errors without enumerating individual codes.
 //
-// On any code classified as an auth failure by IsAuthFailure
-// (currently no_auth, unknown_session, kas_session_invalid,
-// kas_access_forbidden, got_no_login_data), Call invalidates the
-// TokenSource and retries once with fresh credentials. All other
-// faults surface to the caller without retry.
+// On any code classified as an auth failure by IsAuthFailure, Call
+// invalidates the TokenSource and retries once with fresh credentials.
+// All other faults surface to the caller without retry.
 //
 // See issue #6.
 package api

--- a/internal/auth/source.go
+++ b/internal/auth/source.go
@@ -24,6 +24,13 @@ import (
 // extends ExpiresAt to Now+Lifetime so the cache tracks the rolling
 // window the server applies.
 //
+// Loading a persisted entry temporarily overrides Lifetime and
+// UpdateLifetime with the values the session was created with so
+// Heartbeats stay consistent. The user-supplied values are snapshotted
+// on first Credentials call and restored by Invalidate so the next
+// fresh session honours the current run's CLI flags rather than the
+// discarded session's properties.
+//
 // SessionTokenSource is safe for concurrent use.
 type SessionTokenSource struct {
 	Client         *Client

--- a/testdata/response_failed_kas_session_invalid.xml
+++ b/testdata/response_failed_kas_session_invalid.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Body>
+        <SOAP-ENV:Fault>
+            <faultcode>SOAP-ENV:Server</faultcode>
+            <faultstring>kas_session_invalid</faultstring>
+            <faultactor>KasApi</faultactor>
+            <detail>session token is no longer accepted</detail>
+        </SOAP-ENV:Fault>
+    </SOAP-ENV:Body>
+</SOAP-ENV:Envelope>


### PR DESCRIPTION
## Summary

Three follow-ups from the post-merge re-review of PR #68:

- `internal/api/doc.go` — drop the inline enumeration of auth-failure codes; point to `IsAuthFailure` as the single source of truth. Reduces the drift surface from three places to two.
- `internal/auth/source.go` — extend the `SessionTokenSource` type-level doc to describe the snapshot/restore semantics applied during `Invalidate`, so the full lifecycle is visible without drilling into the field block.
- `internal/api` — add `testdata/response_failed_kas_session_invalid.xml` and `TestCallRetriesOnSessionInvalid`, pinning the full Client + retry composition for `kas_session_invalid` (complements the `TestPredicateClassesByCode` row).