### PR TITLE
feat: add mail lists get subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,11 +112,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   not-found error. Mapping test runs against
   `testdata/account/get_account_response_success.xml`.
 
-- `internal/mailinglist` read module and `kasapi-cli mail lists list`
-  subcommand wrapping `get_mailinglists`. Decodes the Array of
-  `{mailinglist_name, mailinglist_admin, mailinglist_url, in_progress}`
-  Maps into a typed `MailingListList` so callers can inspect the
-  Mailman lists provisioned for the account. Closes #9.
+- `internal/mailinglist` read module and `kasapi-cli mail lists list|get`
+  subcommand tree wrapping `get_mailinglists`. The list variant decodes
+  the Array of `{mailinglist_name, mailinglist_admin, mailinglist_url,
+  in_progress}` Maps into a typed `MailingListList`; `get <name>` reuses
+  the same endpoint with a `mailinglist_name` filter (per the KAS docs
+  at `get-mailinglists-inc.html`) and unwraps the single-entry result,
+  mirroring the mail-forwards pattern. The singular view falls back to
+  a key/value table so the URL stays readable without truncation.
+  Mapping tests run against
+  `testdata/mailinglist/get_mailinglists_response_success.xml` and
+  `get_mailinglist_response_success.xml`. Closes #9.
 
 - `internal/mailfilter` read module and `kasapi-cli mail filters list`
   subcommand wrapping `get_mailstandardfilter`. Decodes the Array of

--- a/internal/cli/mail.go
+++ b/internal/cli/mail.go
@@ -31,7 +31,10 @@ func newMailListsCmd(opts *RootOptions) *cobra.Command {
 		Use:   "lists",
 		Short: "Inspect mailing lists (get_mailinglists)",
 	}
-	cmd.AddCommand(newMailListsListCmd(opts))
+	cmd.AddCommand(
+		newMailListsListCmd(opts),
+		newMailListsGetCmd(opts),
+	)
 	return cmd
 }
 
@@ -50,6 +53,28 @@ func newMailListsListCmd(opts *RootOptions) *cobra.Command {
 				return APIError(err, "get_mailinglists")
 			}
 			if err := Render(cmd.OutOrStdout(), opts.Output, list); err != nil {
+				return UserError(err, "render")
+			}
+			return nil
+		},
+	}
+}
+
+func newMailListsGetCmd(opts *RootOptions) *cobra.Command {
+	return &cobra.Command{
+		Use:   "get <name>",
+		Short: "Show details for a single mailing list (get_mailinglists with mailinglist_name)",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			api, err := BuildAPIClient(opts)
+			if err != nil {
+				return err
+			}
+			m, err := mailinglist.NewClient(api).Get(cmd.Context(), args[0])
+			if err != nil {
+				return APIError(err, "get_mailinglists")
+			}
+			if err := Render(cmd.OutOrStdout(), opts.Output, m); err != nil {
 				return UserError(err, "render")
 			}
 			return nil

--- a/internal/mailinglist/doc.go
+++ b/internal/mailinglist/doc.go
@@ -1,4 +1,7 @@
 // Package mailinglist holds the domain types and use cases for the KAS
-// mailinglist endpoints (get_mailinglists, add_mailinglist,
-// update_mailinglist, delete_mailinglist). See issues #9 and #13.
+// mailinglist endpoints (get_mailinglists in list and singular form,
+// add_mailinglist, update_mailinglist, delete_mailinglist). The
+// singular form is get_mailinglists with a mailinglist_name filter;
+// the response is still an array, which Client.Get unwraps to a single
+// MailingList. See issues #9 and #13.
 package mailinglist

--- a/internal/mailinglist/mailinglist.go
+++ b/internal/mailinglist/mailinglist.go
@@ -13,8 +13,9 @@ type Caller interface {
 	Call(ctx context.Context, action string, params map[string]any) (*soap.Response, error)
 }
 
-// MailingList is one entry of get_mailinglists, describing a Mailman
-// list provisioned for the account.
+// MailingList is one entry of get_mailinglists. The list and singular
+// views (the latter being get_mailinglists called with a mailinglist_name
+// filter) return the same Map shape, so a single struct covers both.
 type MailingList struct {
 	Name       string `json:"mailinglist_name" yaml:"mailinglist_name"`
 	Admin      string `json:"mailinglist_admin" yaml:"mailinglist_admin"`
@@ -26,7 +27,8 @@ type MailingList struct {
 // cli.Tabular.
 type MailingListList []MailingList
 
-// Client groups the read endpoint scoped to mailing lists.
+// Client groups the read endpoints scoped to mailing lists:
+// get_mailinglists (list and singular).
 type Client struct {
 	API Caller
 }
@@ -34,9 +36,9 @@ type Client struct {
 // NewClient returns a Client backed by the given Caller.
 func NewClient(c Caller) *Client { return &Client{API: c} }
 
-// List calls get_mailinglists and decodes the response into a
-// MailingListList covering every mailing list visible to the login.
-// The endpoint takes no parameters.
+// List calls get_mailinglists without parameters and decodes the
+// response into a MailingListList covering every mailing list visible
+// to the login.
 func (c *Client) List(ctx context.Context) (MailingListList, error) {
 	resp, err := c.API.Call(ctx, "get_mailinglists", nil)
 	if err != nil {
@@ -47,6 +49,28 @@ func (c *Client) List(ctx context.Context) (MailingListList, error) {
 		return nil, fmt.Errorf("mailinglist: get_mailinglists: %w", err)
 	}
 	return list, nil
+}
+
+// Get calls get_mailinglists with a mailinglist_name filter and returns
+// the single matching MailingList. The KAS API still wraps the result
+// in an array; we unwrap it so callers do not have to. An empty array
+// surfaces as a not-found error.
+func (c *Client) Get(ctx context.Context, name string) (MailingList, error) {
+	if name == "" {
+		return MailingList{}, fmt.Errorf("mailinglist: name is required")
+	}
+	resp, err := c.API.Call(ctx, "get_mailinglists", map[string]any{"mailinglist_name": name})
+	if err != nil {
+		return MailingList{}, err
+	}
+	list, err := DecodeMailingLists(resp.Body.ReturnInfo)
+	if err != nil {
+		return MailingList{}, fmt.Errorf("mailinglist: get_mailinglists: %w", err)
+	}
+	if len(list) == 0 {
+		return MailingList{}, fmt.Errorf("mailinglist: %q not found", name)
+	}
+	return list[0], nil
 }
 
 // DecodeMailingLists maps the ReturnInfo of a get_mailinglists response
@@ -88,4 +112,20 @@ func (l MailingListList) TableRows() [][]string {
 		})
 	}
 	return rows
+}
+
+// TableHeaders for the singular MailingList view: a key/value layout
+// keeps the URL readable without truncation.
+func (MailingList) TableHeaders() []string {
+	return []string{"FIELD", "VALUE"}
+}
+
+// TableRows emits the scalar fields of a single MailingList.
+func (m MailingList) TableRows() [][]string {
+	return [][]string{
+		{"mailinglist_name", m.Name},
+		{"mailinglist_admin", m.Admin},
+		{"mailinglist_url", m.URL},
+		{"in_progress", m.InProgress},
+	}
 }

--- a/internal/mailinglist/mailinglist_test.go
+++ b/internal/mailinglist/mailinglist_test.go
@@ -82,6 +82,21 @@ func TestDecodeMailingLists(t *testing.T) {
 	}
 }
 
+func TestDecodeMailingListSingular(t *testing.T) {
+	t.Parallel()
+	resp := decodeFixture(t, "get_mailinglist_response_success.xml")
+	got, err := mailinglist.DecodeMailingLists(resp.Body.ReturnInfo)
+	if err != nil {
+		t.Fatalf("DecodeMailingLists: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("len = %d, want 1", len(got))
+	}
+	if got[0].Name != "announce@example.com" {
+		t.Errorf("Name = %q", got[0].Name)
+	}
+}
+
 func TestClientList(t *testing.T) {
 	t.Parallel()
 	resp := decodeFixture(t, "get_mailinglists_response_success.xml")
@@ -101,12 +116,51 @@ func TestClientList(t *testing.T) {
 	}
 }
 
+func TestClientGet(t *testing.T) {
+	t.Parallel()
+	resp := decodeFixture(t, "get_mailinglist_response_success.xml")
+	fc := &fakeCaller{resp: resp}
+	m, err := mailinglist.NewClient(fc).Get(context.Background(), "announce@example.com")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if fc.gotAction != "get_mailinglists" {
+		t.Errorf("action = %q, want get_mailinglists", fc.gotAction)
+	}
+	if got, _ := fc.gotParams["mailinglist_name"].(string); got != "announce@example.com" {
+		t.Errorf("params[mailinglist_name] = %v, want announce@example.com", fc.gotParams["mailinglist_name"])
+	}
+	if m.Name != "announce@example.com" {
+		t.Errorf("Name = %q", m.Name)
+	}
+}
+
+func TestClientGetEmptyName(t *testing.T) {
+	t.Parallel()
+	c := mailinglist.NewClient(&fakeCaller{})
+	if _, err := c.Get(context.Background(), ""); err == nil {
+		t.Errorf("Get(\"\") err = nil, want validation error")
+	}
+}
+
+func TestClientGetNotFound(t *testing.T) {
+	t.Parallel()
+	resp := &soap.Response{Body: soap.ResponseBody{ReturnInfo: soap.Value{Kind: soap.KindArray}}}
+	c := mailinglist.NewClient(&fakeCaller{resp: resp})
+	if _, err := c.Get(context.Background(), "missing@example.com"); err == nil {
+		t.Errorf("Get on empty result err = nil, want not-found")
+	}
+}
+
 func TestClientPropagatesError(t *testing.T) {
 	t.Parallel()
 	want := errors.New("boom")
 	c := mailinglist.NewClient(&fakeCaller{err: want})
 	if _, err := c.List(context.Background()); !errors.Is(err, want) {
 		t.Errorf("List err = %v, want %v wrapped", err, want)
+	}
+	if _, err := c.Get(context.Background(), "announce@example.com"); !errors.Is(err, want) {
+		t.Errorf("Get err = %v, want %v wrapped", err, want)
 	}
 }
 
@@ -120,5 +174,33 @@ func TestMailingListListTabular(t *testing.T) {
 	}
 	if rows[0][0] != "announce@example.com" {
 		t.Errorf("rows[0][0] = %q", rows[0][0])
+	}
+}
+
+func TestMailingListSingularTabular(t *testing.T) {
+	t.Parallel()
+	resp := decodeFixture(t, "get_mailinglist_response_success.xml")
+	list, _ := mailinglist.DecodeMailingLists(resp.Body.ReturnInfo)
+	if len(list) != 1 {
+		t.Fatalf("len = %d, want 1", len(list))
+	}
+	rows := list[0].TableRows()
+	if len(rows) != 4 {
+		t.Fatalf("rows = %d, want 4", len(rows))
+	}
+	wantPairs := map[string]string{
+		"mailinglist_name":  "announce@example.com",
+		"mailinglist_admin": "admin@example.com",
+		"mailinglist_url":   "https://lists.example.com/mailman/listinfo/announce",
+		"in_progress":       "FALSE",
+	}
+	for _, r := range rows {
+		if want, ok := wantPairs[r[0]]; !ok || r[1] != want {
+			t.Errorf("row %v not in expected map", r)
+		}
+	}
+	hdr := (mailinglist.MailingList{}).TableHeaders()
+	if len(hdr) != 2 || hdr[0] != "FIELD" || hdr[1] != "VALUE" {
+		t.Errorf("headers = %v, want [FIELD VALUE]", hdr)
 	}
 }

--- a/testdata/mailinglist/get_mailinglist_request.xml
+++ b/testdata/mailinglist/get_mailinglist_request.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:tns="https://kasserver.com/">
+    <soapenv:Body>
+        <tns:KasApi>
+            <Params>
+            {
+                "KasRequestParams": {
+                    "mailinglist_name": "announce@example.com"
+                },
+                "kas_action": "get_mailinglists",
+                "kas_auth_data": "REDACTED",
+                "kas_auth_type": "session",
+                "kas_login": "w0000000"
+            }
+            </Params>
+        </tns:KasApi>
+    </soapenv:Body>
+</soapenv:Envelope>

--- a/testdata/mailinglist/get_mailinglist_response_success.xml
+++ b/testdata/mailinglist/get_mailinglist_response_success.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="https://kasapi.kasserver.com/soap/KasApi.php" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/" xmlns:ns2="http://xml.apache.org/xml-soap" SOAP-ENV:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+    <SOAP-ENV:Body>
+        <ns1:KasApiResponse>
+            <return xsi:type="ns2:Map">
+                <item>
+                    <key xsi:type="xsd:string">Request</key>
+                    <value xsi:type="ns2:Map">
+                        <item>
+                            <key xsi:type="xsd:string">KasRequestTime</key>
+                            <value xsi:type="xsd:int">1777746000</value>
+                        </item>
+                        <item>
+                            <key xsi:type="xsd:string">KasRequestType</key>
+                            <value xsi:type="xsd:string">get_mailinglists</value>
+                        </item>
+                        <item>
+                            <key xsi:type="xsd:string">KasRequestParams</key>
+                            <value xsi:type="ns2:Map">
+                                <item>
+                                    <key xsi:type="xsd:string">mailinglist_name</key>
+                                    <value xsi:type="xsd:string">announce@example.com</value>
+                                </item>
+                            </value>
+                        </item>
+                    </value>
+                </item>
+                <item>
+                    <key xsi:type="xsd:string">Response</key>
+                    <value xsi:type="ns2:Map">
+                        <item>
+                            <key xsi:type="xsd:string">KasFloodDelay</key>
+                            <value xsi:type="xsd:float">0.5</value>
+                        </item>
+                        <item>
+                            <key xsi:type="xsd:string">ReturnString</key>
+                            <value xsi:type="xsd:string">TRUE</value>
+                        </item>
+                        <item>
+                            <key xsi:type="xsd:string">ReturnInfo</key>
+                            <value SOAP-ENC:arrayType="ns2:Map[1]" xsi:type="SOAP-ENC:Array">
+                                <item xsi:type="ns2:Map">
+                                    <item>
+                                        <key xsi:type="xsd:string">mailinglist_name</key>
+                                        <value xsi:type="xsd:string">announce@example.com</value>
+                                    </item>
+                                    <item>
+                                        <key xsi:type="xsd:string">mailinglist_admin</key>
+                                        <value xsi:type="xsd:string">admin@example.com</value>
+                                    </item>
+                                    <item>
+                                        <key xsi:type="xsd:string">mailinglist_url</key>
+                                        <value xsi:type="xsd:string">https://lists.example.com/mailman/listinfo/announce</value>
+                                    </item>
+                                    <item>
+                                        <key xsi:type="xsd:string">in_progress</key>
+                                        <value xsi:type="xsd:string">FALSE</value>
+                                    </item>
+                                </item>
+                            </value>
+                        </item>
+                    </value>
+                </item>
+            </return>
+        </ns1:KasApiResponse>
+    </SOAP-ENV:Body>
+</SOAP-ENV:Envelope>


### PR DESCRIPTION
## Summary

Adds the singular `kasapi-cli mail lists get <name>` variant: the KAS
`get_mailinglists` endpoint accepts an optional `mailinglist_name`
filter, the response is still array-shaped, and `Client.Get` unwraps
the single-entry result (empty array → not-found), mirroring
`mailforward.Client.Get`.

Live-verified against the production KAS endpoint with both an empty
account (server returns `[]` → typed not-found) and a real list
(`olbaflinx-chm-projects-de`).

Closes #9.