### PR TITLE
fix: code-review follow-ups (PR #70)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -204,6 +204,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `kasapi-cli mail lists get` argument placeholder renamed from
+  `<name>` to `<mailinglist-name>` so the help text matches the
+  KAS wire parameter and the placeholder convention used by every
+  other `get` subcommand (`<address>`, `<mail-login>`, `<dyndns-login>`,
+  `<domain>`, `<software-id>`, …). `TestMailingListSingularTabular`
+  was tightened from a map-lookup over rows (order-insensitive) to
+  an indexed comparison so a future refactor reordering `TableRows`
+  cannot slip past the test silently.
+
 - `internal/soap`: extend `Value` with typed Map accessors (`MapString`,
   `MapInt`, `MapInt64`, `MapFloat`) and a generic `AsInt` coercion so
   every read module can drop its private `getString` / `getInt` /

--- a/internal/cli/mail.go
+++ b/internal/cli/mail.go
@@ -62,7 +62,7 @@ func newMailListsListCmd(opts *RootOptions) *cobra.Command {
 
 func newMailListsGetCmd(opts *RootOptions) *cobra.Command {
 	return &cobra.Command{
-		Use:   "get <name>",
+		Use:   "get <mailinglist-name>",
 		Short: "Show details for a single mailing list (get_mailinglists with mailinglist_name)",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/mailinglist/mailinglist_test.go
+++ b/internal/mailinglist/mailinglist_test.go
@@ -184,19 +184,23 @@ func TestMailingListSingularTabular(t *testing.T) {
 	if len(list) != 1 {
 		t.Fatalf("len = %d, want 1", len(list))
 	}
+	// The order is part of the user-visible table contract: identity
+	// (name, admin, url) before lifecycle state (in_progress). Pin it
+	// by index so a refactor reordering the slice does not slip
+	// through silently.
+	want := [][]string{
+		{"mailinglist_name", "announce@example.com"},
+		{"mailinglist_admin", "admin@example.com"},
+		{"mailinglist_url", "https://lists.example.com/mailman/listinfo/announce"},
+		{"in_progress", "FALSE"},
+	}
 	rows := list[0].TableRows()
-	if len(rows) != 4 {
-		t.Fatalf("rows = %d, want 4", len(rows))
+	if len(rows) != len(want) {
+		t.Fatalf("rows = %d, want %d", len(rows), len(want))
 	}
-	wantPairs := map[string]string{
-		"mailinglist_name":  "announce@example.com",
-		"mailinglist_admin": "admin@example.com",
-		"mailinglist_url":   "https://lists.example.com/mailman/listinfo/announce",
-		"in_progress":       "FALSE",
-	}
-	for _, r := range rows {
-		if want, ok := wantPairs[r[0]]; !ok || r[1] != want {
-			t.Errorf("row %v not in expected map", r)
+	for i, r := range rows {
+		if r[0] != want[i][0] || r[1] != want[i][1] {
+			t.Errorf("row[%d] = %v, want %v", i, r, want[i])
 		}
 	}
 	hdr := (mailinglist.MailingList{}).TableHeaders()


### PR DESCRIPTION
## Summary

Two review findings from the PR #70 re-read:

- **Should:** `mail lists get` was the only get subcommand using a
  generic `<name>` placeholder; renamed to `<mailinglist-name>` to
  match the KAS wire parameter and the convention used by every
  other get sibling.
- **Nice-to-have:** `TestMailingListSingularTabular` checked row
  content with a map lookup (order-insensitive); now indexed so a
  refactor reordering `TableRows` cannot pass silently.