### PR TITLE
refactor: extract shared test helpers into internal/testutil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -204,6 +204,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `internal/testutil`: extract the `repoRoot` / `decodeFixture` /
+  `fakeCaller` helpers that every per-module `*_test.go` carried as
+  a private copy into a single shared package, and migrate all 20
+  test files (17 module test suites + `internal/{soap,auth,api}`'s
+  own root-discovery helpers) to use it. `DecodeFixture` now takes a
+  forward-slash-separated path rooted at `testdata/` (e.g.
+  `"mailinglist/get_mailinglists_response_success.xml"`) so the fixture
+  layout is visible at the call site instead of being hidden inside
+  per-module `decodeFixture(t, name)` wrappers. The `FakeCaller` stub
+  is exported with `Resp` / `Err` / `GotAction` / `GotParams` fields
+  so cross-module test code can construct it directly. Net effect:
+  ~910 lines of word-for-word boilerplate removed; behaviour
+  unchanged (the loop ends only after `go test -race ./...` and
+  `golangci-lint run` are clean against the migrated suite).
+
 - `kasapi-cli mail lists get` argument placeholder renamed from
   `<name>` to `<mailinglist-name>` so the help text matches the
   KAS wire parameter and the placeholder convention used by every

--- a/internal/account/account_test.go
+++ b/internal/account/account_test.go
@@ -3,52 +3,15 @@ package account_test
 import (
 	"context"
 	"errors"
-	"os"
-	"path/filepath"
-	"runtime"
 	"testing"
 
 	"github.com/chmmou/kasapi-cli/internal/account"
-	"github.com/chmmou/kasapi-cli/internal/soap"
+	"github.com/chmmou/kasapi-cli/internal/testutil"
 )
-
-func repoRoot(t *testing.T) string {
-	t.Helper()
-	_, file, _, ok := runtime.Caller(0)
-	if !ok {
-		t.Fatal("runtime.Caller failed")
-	}
-	dir := filepath.Dir(file)
-	for {
-		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
-			return dir
-		}
-		parent := filepath.Dir(dir)
-		if parent == dir {
-			t.Fatalf("repo root not found from %q", file)
-		}
-		dir = parent
-	}
-}
-
-func decodeFixture(t *testing.T, name string) *soap.Response {
-	t.Helper()
-	path := filepath.Join(repoRoot(t), "testdata", "account", name)
-	f, err := os.Open(path)
-	if err != nil {
-		t.Fatalf("open %s: %v", path, err)
-	}
-	defer func() { _ = f.Close() }()
-	resp, err := soap.Decode(f)
-	if err != nil {
-		t.Fatalf("decode %s: %v", path, err)
-	}
-	return resp
-}
 
 func TestDecodeAccounts(t *testing.T) {
 	t.Parallel()
-	resp := decodeFixture(t, "get_accounts_response_success.xml")
+	resp := testutil.DecodeFixture(t, "account/get_accounts_response_success.xml")
 	got, err := account.DecodeAccounts(resp.Body.ReturnInfo)
 	if err != nil {
 		t.Fatalf("DecodeAccounts: %v", err)
@@ -87,7 +50,7 @@ func TestDecodeAccounts(t *testing.T) {
 
 func TestDecodeAccountSettings(t *testing.T) {
 	t.Parallel()
-	resp := decodeFixture(t, "get_accountsettings_response_success.xml")
+	resp := testutil.DecodeFixture(t, "account/get_accountsettings_response_success.xml")
 	got, err := account.DecodeAccountSettings(resp.Body.ReturnInfo)
 	if err != nil {
 		t.Fatalf("DecodeAccountSettings: %v", err)
@@ -119,7 +82,7 @@ func TestDecodeAccountSettings(t *testing.T) {
 
 func TestDecodeAccountResources(t *testing.T) {
 	t.Parallel()
-	resp := decodeFixture(t, "get_accountresources_response_success.xml")
+	resp := testutil.DecodeFixture(t, "account/get_accountresources_response_success.xml")
 	got, err := account.DecodeAccountResources(resp.Body.ReturnInfo)
 	if err != nil {
 		t.Fatalf("DecodeAccountResources: %v", err)
@@ -148,33 +111,19 @@ func TestDecodeAccountResources(t *testing.T) {
 // the action / params it was called with. This is enough to exercise
 // Client.List / Get / Settings / Resources without a network
 // roundtrip.
-type fakeCaller struct {
-	resp *soap.Response
-	err  error
-
-	gotAction string
-	gotParams map[string]any
-}
-
-func (f *fakeCaller) Call(_ context.Context, action string, params map[string]any) (*soap.Response, error) {
-	f.gotAction = action
-	f.gotParams = params
-	return f.resp, f.err
-}
-
 func TestClientList(t *testing.T) {
 	t.Parallel()
-	resp := decodeFixture(t, "get_accounts_response_success.xml")
-	fc := &fakeCaller{resp: resp}
+	resp := testutil.DecodeFixture(t, "account/get_accounts_response_success.xml")
+	fc := &testutil.FakeCaller{Resp: resp}
 	got, err := account.NewClient(fc).List(context.Background())
 	if err != nil {
 		t.Fatalf("List: %v", err)
 	}
-	if fc.gotAction != "get_accounts" {
-		t.Errorf("action = %q, want get_accounts", fc.gotAction)
+	if fc.GotAction != "get_accounts" {
+		t.Errorf("action = %q, want get_accounts", fc.GotAction)
 	}
-	if fc.gotParams != nil {
-		t.Errorf("params = %v, want nil", fc.gotParams)
+	if fc.GotParams != nil {
+		t.Errorf("params = %v, want nil", fc.GotParams)
 	}
 	if len(got) != 4 {
 		t.Errorf("len = %d, want 4", len(got))
@@ -183,16 +132,16 @@ func TestClientList(t *testing.T) {
 
 func TestClientGet(t *testing.T) {
 	t.Parallel()
-	resp := decodeFixture(t, "get_account_response_success.xml")
-	fc := &fakeCaller{resp: resp}
+	resp := testutil.DecodeFixture(t, "account/get_account_response_success.xml")
+	fc := &testutil.FakeCaller{Resp: resp}
 	got, err := account.NewClient(fc).Get(context.Background(), "w0000001")
 	if err != nil {
 		t.Fatalf("Get: %v", err)
 	}
-	if fc.gotAction != "get_accounts" {
-		t.Errorf("action = %q, want get_accounts", fc.gotAction)
+	if fc.GotAction != "get_accounts" {
+		t.Errorf("action = %q, want get_accounts", fc.GotAction)
 	}
-	if v, ok := fc.gotParams["account_login"]; !ok || v != "w0000001" {
+	if v, ok := fc.GotParams["account_login"]; !ok || v != "w0000001" {
 		t.Errorf("account_login param = %v (ok=%v), want w0000001", v, ok)
 	}
 	if got.Login != "w0000001" {
@@ -205,7 +154,7 @@ func TestClientGet(t *testing.T) {
 
 func TestClientGetEmptyLogin(t *testing.T) {
 	t.Parallel()
-	c := account.NewClient(&fakeCaller{})
+	c := account.NewClient(&testutil.FakeCaller{})
 	if _, err := c.Get(context.Background(), ""); err == nil {
 		t.Error("Get(\"\") returned nil, want error")
 	}
@@ -215,9 +164,9 @@ func TestClientGetNotFound(t *testing.T) {
 	t.Parallel()
 	// Synthesise an empty array response by reusing the singular
 	// fixture but with the array stripped to zero entries.
-	emptyResp := decodeFixture(t, "get_account_response_success.xml")
+	emptyResp := testutil.DecodeFixture(t, "account/get_account_response_success.xml")
 	emptyResp.Body.ReturnInfo.Array = nil
-	c := account.NewClient(&fakeCaller{resp: emptyResp})
+	c := account.NewClient(&testutil.FakeCaller{Resp: emptyResp})
 	if _, err := c.Get(context.Background(), "wXXXXXXX"); err == nil {
 		t.Error("Get on empty array returned nil, want not-found error")
 	}
@@ -226,7 +175,7 @@ func TestClientGetNotFound(t *testing.T) {
 func TestClientPropagatesError(t *testing.T) {
 	t.Parallel()
 	want := errors.New("boom")
-	c := account.NewClient(&fakeCaller{err: want})
+	c := account.NewClient(&testutil.FakeCaller{Err: want})
 	if _, err := c.List(context.Background()); !errors.Is(err, want) {
 		t.Errorf("List err = %v, want %v wrapped", err, want)
 	}
@@ -237,7 +186,7 @@ func TestClientPropagatesError(t *testing.T) {
 
 func TestAccountListTabular(t *testing.T) {
 	t.Parallel()
-	resp := decodeFixture(t, "get_accounts_response_success.xml")
+	resp := testutil.DecodeFixture(t, "account/get_accounts_response_success.xml")
 	accs, _ := account.DecodeAccounts(resp.Body.ReturnInfo)
 	list := account.AccountList(accs)
 	headers := list.TableHeaders()
@@ -255,7 +204,7 @@ func TestAccountListTabular(t *testing.T) {
 
 func TestAccountTabular(t *testing.T) {
 	t.Parallel()
-	resp := decodeFixture(t, "get_account_response_success.xml")
+	resp := testutil.DecodeFixture(t, "account/get_account_response_success.xml")
 	accs, _ := account.DecodeAccounts(resp.Body.ReturnInfo)
 	if len(accs) != 1 {
 		t.Fatalf("len = %d, want 1", len(accs))
@@ -273,7 +222,7 @@ func TestAccountTabular(t *testing.T) {
 
 func TestAccountResourcesTabular(t *testing.T) {
 	t.Parallel()
-	resp := decodeFixture(t, "get_accountresources_response_success.xml")
+	resp := testutil.DecodeFixture(t, "account/get_accountresources_response_success.xml")
 	r, _ := account.DecodeAccountResources(resp.Body.ReturnInfo)
 	rows := r.TableRows()
 	if len(rows) != 12 {

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -8,7 +8,6 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -16,31 +15,13 @@ import (
 
 	"github.com/chmmou/kasapi-cli/internal/api"
 	"github.com/chmmou/kasapi-cli/internal/soap"
+	"github.com/chmmou/kasapi-cli/internal/testutil"
 	"github.com/chmmou/kasapi-cli/internal/transport"
 )
 
-func repoRoot(t *testing.T) string {
-	t.Helper()
-	_, file, _, ok := runtime.Caller(0)
-	if !ok {
-		t.Fatal("runtime.Caller failed")
-	}
-	dir := filepath.Dir(file)
-	for {
-		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
-			return dir
-		}
-		parent := filepath.Dir(dir)
-		if parent == dir {
-			t.Fatalf("repo root not found from %q", file)
-		}
-		dir = parent
-	}
-}
-
 func loadFixture(t *testing.T, rel string) []byte {
 	t.Helper()
-	b, err := os.ReadFile(filepath.Join(repoRoot(t), "testdata", rel))
+	b, err := os.ReadFile(filepath.Join(testutil.RepoRoot(t), "testdata", rel))
 	if err != nil {
 		t.Fatalf("load %s: %v", rel, err)
 	}

--- a/internal/auth/codec_test.go
+++ b/internal/auth/codec_test.go
@@ -6,36 +6,17 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
 
 	"github.com/chmmou/kasapi-cli/internal/auth"
 	"github.com/chmmou/kasapi-cli/internal/soap"
+	"github.com/chmmou/kasapi-cli/internal/testutil"
 )
-
-func repoRoot(t *testing.T) string {
-	t.Helper()
-	_, file, _, ok := runtime.Caller(0)
-	if !ok {
-		t.Fatal("runtime.Caller failed")
-	}
-	dir := filepath.Dir(file)
-	for {
-		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
-			return dir
-		}
-		parent := filepath.Dir(dir)
-		if parent == dir {
-			t.Fatalf("repo root not found from %q", file)
-		}
-		dir = parent
-	}
-}
 
 func loadFixture(t *testing.T, rel string) []byte {
 	t.Helper()
-	b, err := os.ReadFile(filepath.Join(repoRoot(t), "testdata", rel))
+	b, err := os.ReadFile(filepath.Join(testutil.RepoRoot(t), "testdata", rel))
 	if err != nil {
 		t.Fatalf("load %s: %v", rel, err)
 	}

--- a/internal/cronjob/cronjob_test.go
+++ b/internal/cronjob/cronjob_test.go
@@ -3,66 +3,16 @@ package cronjob_test
 import (
 	"context"
 	"errors"
-	"os"
-	"path/filepath"
-	"runtime"
 	"testing"
 
 	"github.com/chmmou/kasapi-cli/internal/cronjob"
 	"github.com/chmmou/kasapi-cli/internal/soap"
+	"github.com/chmmou/kasapi-cli/internal/testutil"
 )
-
-func repoRoot(t *testing.T) string {
-	t.Helper()
-	_, file, _, ok := runtime.Caller(0)
-	if !ok {
-		t.Fatal("runtime.Caller failed")
-	}
-	dir := filepath.Dir(file)
-	for {
-		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
-			return dir
-		}
-		parent := filepath.Dir(dir)
-		if parent == dir {
-			t.Fatalf("repo root not found from %q", file)
-		}
-		dir = parent
-	}
-}
-
-func decodeFixture(t *testing.T, name string) *soap.Response {
-	t.Helper()
-	path := filepath.Join(repoRoot(t), "testdata", "cronjob", name)
-	f, err := os.Open(path)
-	if err != nil {
-		t.Fatalf("open %s: %v", name, err)
-	}
-	defer func() { _ = f.Close() }()
-	resp, err := soap.Decode(f)
-	if err != nil {
-		t.Fatalf("decode %s: %v", name, err)
-	}
-	return resp
-}
-
-type fakeCaller struct {
-	resp *soap.Response
-	err  error
-
-	gotAction string
-	gotParams map[string]any
-}
-
-func (f *fakeCaller) Call(_ context.Context, action string, params map[string]any) (*soap.Response, error) {
-	f.gotAction = action
-	f.gotParams = params
-	return f.resp, f.err
-}
 
 func TestDecodeCronjobs(t *testing.T) {
 	t.Parallel()
-	resp := decodeFixture(t, "get_cronjobs_response_success.xml")
+	resp := testutil.DecodeFixture(t, "cronjob/get_cronjobs_response_success.xml")
 	got, err := cronjob.DecodeCronjobs(resp.Body.ReturnInfo)
 	if err != nil {
 		t.Fatalf("DecodeCronjobs: %v", err)
@@ -110,7 +60,7 @@ func TestDecodeCronjobs(t *testing.T) {
 
 func TestDecodeCronjobSingular(t *testing.T) {
 	t.Parallel()
-	resp := decodeFixture(t, "get_cronjob_response_success.xml")
+	resp := testutil.DecodeFixture(t, "cronjob/get_cronjob_response_success.xml")
 	got, err := cronjob.DecodeCronjobs(resp.Body.ReturnInfo)
 	if err != nil {
 		t.Fatalf("DecodeCronjobs: %v", err)
@@ -166,17 +116,17 @@ func TestCronjobTarget(t *testing.T) {
 
 func TestClientList(t *testing.T) {
 	t.Parallel()
-	resp := decodeFixture(t, "get_cronjobs_response_success.xml")
-	fc := &fakeCaller{resp: resp}
+	resp := testutil.DecodeFixture(t, "cronjob/get_cronjobs_response_success.xml")
+	fc := &testutil.FakeCaller{Resp: resp}
 	list, err := cronjob.NewClient(fc).List(context.Background())
 	if err != nil {
 		t.Fatalf("List: %v", err)
 	}
-	if fc.gotAction != "get_cronjobs" {
-		t.Errorf("action = %q, want get_cronjobs", fc.gotAction)
+	if fc.GotAction != "get_cronjobs" {
+		t.Errorf("action = %q, want get_cronjobs", fc.GotAction)
 	}
-	if fc.gotParams != nil {
-		t.Errorf("params = %v, want nil", fc.gotParams)
+	if fc.GotParams != nil {
+		t.Errorf("params = %v, want nil", fc.GotParams)
 	}
 	if len(list) != 2 {
 		t.Errorf("len = %d, want 2", len(list))
@@ -185,17 +135,17 @@ func TestClientList(t *testing.T) {
 
 func TestClientGet(t *testing.T) {
 	t.Parallel()
-	resp := decodeFixture(t, "get_cronjob_response_success.xml")
-	fc := &fakeCaller{resp: resp}
+	resp := testutil.DecodeFixture(t, "cronjob/get_cronjob_response_success.xml")
+	fc := &testutil.FakeCaller{Resp: resp}
 	c, err := cronjob.NewClient(fc).Get(context.Background(), "325208")
 	if err != nil {
 		t.Fatalf("Get: %v", err)
 	}
-	if fc.gotAction != "get_cronjobs" {
-		t.Errorf("action = %q, want get_cronjobs", fc.gotAction)
+	if fc.GotAction != "get_cronjobs" {
+		t.Errorf("action = %q, want get_cronjobs", fc.GotAction)
 	}
-	if got, _ := fc.gotParams["cronjob_id"].(string); got != "325208" {
-		t.Errorf("params[cronjob_id] = %v, want 325208", fc.gotParams["cronjob_id"])
+	if got, _ := fc.GotParams["cronjob_id"].(string); got != "325208" {
+		t.Errorf("params[cronjob_id] = %v, want 325208", fc.GotParams["cronjob_id"])
 	}
 	if c.ID != "325208" {
 		t.Errorf("ID = %q, want 325208", c.ID)
@@ -204,7 +154,7 @@ func TestClientGet(t *testing.T) {
 
 func TestClientGetEmptyID(t *testing.T) {
 	t.Parallel()
-	c := cronjob.NewClient(&fakeCaller{})
+	c := cronjob.NewClient(&testutil.FakeCaller{})
 	if _, err := c.Get(context.Background(), ""); err == nil {
 		t.Errorf("Get(\"\") err = nil, want validation error")
 	}
@@ -213,7 +163,7 @@ func TestClientGetEmptyID(t *testing.T) {
 func TestClientGetNotFound(t *testing.T) {
 	t.Parallel()
 	resp := &soap.Response{Body: soap.ResponseBody{ReturnInfo: soap.Value{Kind: soap.KindArray}}}
-	c := cronjob.NewClient(&fakeCaller{resp: resp})
+	c := cronjob.NewClient(&testutil.FakeCaller{Resp: resp})
 	if _, err := c.Get(context.Background(), "999999"); err == nil {
 		t.Errorf("Get on empty result err = nil, want not-found")
 	}
@@ -222,7 +172,7 @@ func TestClientGetNotFound(t *testing.T) {
 func TestClientPropagatesError(t *testing.T) {
 	t.Parallel()
 	want := errors.New("boom")
-	c := cronjob.NewClient(&fakeCaller{err: want})
+	c := cronjob.NewClient(&testutil.FakeCaller{Err: want})
 	if _, err := c.List(context.Background()); !errors.Is(err, want) {
 		t.Errorf("List err = %v, want %v wrapped", err, want)
 	}
@@ -233,7 +183,7 @@ func TestClientPropagatesError(t *testing.T) {
 
 func TestCronjobListTabular(t *testing.T) {
 	t.Parallel()
-	resp := decodeFixture(t, "get_cronjobs_response_success.xml")
+	resp := testutil.DecodeFixture(t, "cronjob/get_cronjobs_response_success.xml")
 	list, _ := cronjob.DecodeCronjobs(resp.Body.ReturnInfo)
 	headers := list.TableHeaders()
 	if headers[0] != "ID" {
@@ -256,7 +206,7 @@ func TestCronjobListTabular(t *testing.T) {
 
 func TestCronjobTabular(t *testing.T) {
 	t.Parallel()
-	resp := decodeFixture(t, "get_cronjob_response_success.xml")
+	resp := testutil.DecodeFixture(t, "cronjob/get_cronjob_response_success.xml")
 	list, _ := cronjob.DecodeCronjobs(resp.Body.ReturnInfo)
 	if len(list) != 1 {
 		t.Fatalf("len = %d, want 1", len(list))

--- a/internal/database/database_test.go
+++ b/internal/database/database_test.go
@@ -3,66 +3,16 @@ package database_test
 import (
 	"context"
 	"errors"
-	"os"
-	"path/filepath"
-	"runtime"
 	"testing"
 
 	"github.com/chmmou/kasapi-cli/internal/database"
 	"github.com/chmmou/kasapi-cli/internal/soap"
+	"github.com/chmmou/kasapi-cli/internal/testutil"
 )
-
-func repoRoot(t *testing.T) string {
-	t.Helper()
-	_, file, _, ok := runtime.Caller(0)
-	if !ok {
-		t.Fatal("runtime.Caller failed")
-	}
-	dir := filepath.Dir(file)
-	for {
-		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
-			return dir
-		}
-		parent := filepath.Dir(dir)
-		if parent == dir {
-			t.Fatalf("repo root not found from %q", file)
-		}
-		dir = parent
-	}
-}
-
-func decodeFixture(t *testing.T, name string) *soap.Response {
-	t.Helper()
-	path := filepath.Join(repoRoot(t), "testdata", "database", name)
-	f, err := os.Open(path)
-	if err != nil {
-		t.Fatalf("open %s: %v", name, err)
-	}
-	defer func() { _ = f.Close() }()
-	resp, err := soap.Decode(f)
-	if err != nil {
-		t.Fatalf("decode %s: %v", name, err)
-	}
-	return resp
-}
-
-type fakeCaller struct {
-	resp *soap.Response
-	err  error
-
-	gotAction string
-	gotParams map[string]any
-}
-
-func (f *fakeCaller) Call(_ context.Context, action string, params map[string]any) (*soap.Response, error) {
-	f.gotAction = action
-	f.gotParams = params
-	return f.resp, f.err
-}
 
 func TestDecodeDatabases(t *testing.T) {
 	t.Parallel()
-	resp := decodeFixture(t, "get_databases_response_success.xml")
+	resp := testutil.DecodeFixture(t, "database/get_databases_response_success.xml")
 	got, err := database.DecodeDatabases(resp.Body.ReturnInfo)
 	if err != nil {
 		t.Fatalf("DecodeDatabases: %v", err)
@@ -95,7 +45,7 @@ func TestDecodeDatabases(t *testing.T) {
 
 func TestDecodeDatabaseSingular(t *testing.T) {
 	t.Parallel()
-	resp := decodeFixture(t, "get_database_response_success.xml")
+	resp := testutil.DecodeFixture(t, "database/get_database_response_success.xml")
 	got, err := database.DecodeDatabases(resp.Body.ReturnInfo)
 	if err != nil {
 		t.Fatalf("DecodeDatabases: %v", err)
@@ -114,17 +64,17 @@ func TestDecodeDatabaseSingular(t *testing.T) {
 
 func TestClientList(t *testing.T) {
 	t.Parallel()
-	resp := decodeFixture(t, "get_databases_response_success.xml")
-	fc := &fakeCaller{resp: resp}
+	resp := testutil.DecodeFixture(t, "database/get_databases_response_success.xml")
+	fc := &testutil.FakeCaller{Resp: resp}
 	list, err := database.NewClient(fc).List(context.Background())
 	if err != nil {
 		t.Fatalf("List: %v", err)
 	}
-	if fc.gotAction != "get_databases" {
-		t.Errorf("action = %q, want get_databases", fc.gotAction)
+	if fc.GotAction != "get_databases" {
+		t.Errorf("action = %q, want get_databases", fc.GotAction)
 	}
-	if fc.gotParams != nil {
-		t.Errorf("params = %v, want nil", fc.gotParams)
+	if fc.GotParams != nil {
+		t.Errorf("params = %v, want nil", fc.GotParams)
 	}
 	if len(list) != 4 {
 		t.Errorf("len = %d, want 4", len(list))
@@ -133,17 +83,17 @@ func TestClientList(t *testing.T) {
 
 func TestClientGet(t *testing.T) {
 	t.Parallel()
-	resp := decodeFixture(t, "get_database_response_success.xml")
-	fc := &fakeCaller{resp: resp}
+	resp := testutil.DecodeFixture(t, "database/get_database_response_success.xml")
+	fc := &testutil.FakeCaller{Resp: resp}
 	d, err := database.NewClient(fc).Get(context.Background(), "d0123452")
 	if err != nil {
 		t.Fatalf("Get: %v", err)
 	}
-	if fc.gotAction != "get_databases" {
-		t.Errorf("action = %q, want get_databases", fc.gotAction)
+	if fc.GotAction != "get_databases" {
+		t.Errorf("action = %q, want get_databases", fc.GotAction)
 	}
-	if got, _ := fc.gotParams["database_login"].(string); got != "d0123452" {
-		t.Errorf("params[database_login] = %v, want d0123452", fc.gotParams["database_login"])
+	if got, _ := fc.GotParams["database_login"].(string); got != "d0123452" {
+		t.Errorf("params[database_login] = %v, want d0123452", fc.GotParams["database_login"])
 	}
 	if d.Login != "d0123452" {
 		t.Errorf("Login = %q, want d0123452", d.Login)
@@ -152,7 +102,7 @@ func TestClientGet(t *testing.T) {
 
 func TestClientGetEmptyLogin(t *testing.T) {
 	t.Parallel()
-	c := database.NewClient(&fakeCaller{})
+	c := database.NewClient(&testutil.FakeCaller{})
 	if _, err := c.Get(context.Background(), ""); err == nil {
 		t.Errorf("Get(\"\") err = nil, want validation error")
 	}
@@ -161,7 +111,7 @@ func TestClientGetEmptyLogin(t *testing.T) {
 func TestClientGetNotFound(t *testing.T) {
 	t.Parallel()
 	resp := &soap.Response{Body: soap.ResponseBody{ReturnInfo: soap.Value{Kind: soap.KindArray}}}
-	c := database.NewClient(&fakeCaller{resp: resp})
+	c := database.NewClient(&testutil.FakeCaller{Resp: resp})
 	if _, err := c.Get(context.Background(), "missing"); err == nil {
 		t.Errorf("Get on empty result err = nil, want not-found")
 	}
@@ -170,7 +120,7 @@ func TestClientGetNotFound(t *testing.T) {
 func TestClientPropagatesError(t *testing.T) {
 	t.Parallel()
 	want := errors.New("boom")
-	c := database.NewClient(&fakeCaller{err: want})
+	c := database.NewClient(&testutil.FakeCaller{Err: want})
 	if _, err := c.List(context.Background()); !errors.Is(err, want) {
 		t.Errorf("List err = %v, want %v wrapped", err, want)
 	}
@@ -181,7 +131,7 @@ func TestClientPropagatesError(t *testing.T) {
 
 func TestDatabaseListTabular(t *testing.T) {
 	t.Parallel()
-	resp := decodeFixture(t, "get_databases_response_success.xml")
+	resp := testutil.DecodeFixture(t, "database/get_databases_response_success.xml")
 	list, _ := database.DecodeDatabases(resp.Body.ReturnInfo)
 	headers := list.TableHeaders()
 	if headers[0] != "LOGIN" {
@@ -198,7 +148,7 @@ func TestDatabaseListTabular(t *testing.T) {
 
 func TestDatabaseTabular(t *testing.T) {
 	t.Parallel()
-	resp := decodeFixture(t, "get_database_response_success.xml")
+	resp := testutil.DecodeFixture(t, "database/get_database_response_success.xml")
 	list, _ := database.DecodeDatabases(resp.Body.ReturnInfo)
 	if len(list) != 1 {
 		t.Fatalf("len = %d, want 1", len(list))

--- a/internal/ddns/ddns_test.go
+++ b/internal/ddns/ddns_test.go
@@ -3,66 +3,15 @@ package ddns_test
 import (
 	"context"
 	"errors"
-	"os"
-	"path/filepath"
-	"runtime"
 	"testing"
 
 	"github.com/chmmou/kasapi-cli/internal/ddns"
-	"github.com/chmmou/kasapi-cli/internal/soap"
+	"github.com/chmmou/kasapi-cli/internal/testutil"
 )
-
-func repoRoot(t *testing.T) string {
-	t.Helper()
-	_, file, _, ok := runtime.Caller(0)
-	if !ok {
-		t.Fatal("runtime.Caller failed")
-	}
-	dir := filepath.Dir(file)
-	for {
-		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
-			return dir
-		}
-		parent := filepath.Dir(dir)
-		if parent == dir {
-			t.Fatalf("repo root not found from %q", file)
-		}
-		dir = parent
-	}
-}
-
-func decodeFixture(t *testing.T, name string) *soap.Response {
-	t.Helper()
-	path := filepath.Join(repoRoot(t), "testdata", "ddns", name)
-	f, err := os.Open(path)
-	if err != nil {
-		t.Fatalf("open %s: %v", name, err)
-	}
-	defer func() { _ = f.Close() }()
-	resp, err := soap.Decode(f)
-	if err != nil {
-		t.Fatalf("decode %s: %v", name, err)
-	}
-	return resp
-}
-
-type fakeCaller struct {
-	resp *soap.Response
-	err  error
-
-	gotAction string
-	gotParams map[string]any
-}
-
-func (f *fakeCaller) Call(_ context.Context, action string, params map[string]any) (*soap.Response, error) {
-	f.gotAction = action
-	f.gotParams = params
-	return f.resp, f.err
-}
 
 func TestDecodeDDNSUsers(t *testing.T) {
 	t.Parallel()
-	resp := decodeFixture(t, "get_ddnsusers_response_success.xml")
+	resp := testutil.DecodeFixture(t, "ddns/get_ddnsusers_response_success.xml")
 	got, err := ddns.DecodeDDNSUsers(resp.Body.ReturnInfo)
 	if err != nil {
 		t.Fatalf("DecodeDDNSUsers: %v", err)
@@ -103,7 +52,7 @@ func TestDecodeDDNSUsers(t *testing.T) {
 
 func TestDecodeDDNSUserSingular(t *testing.T) {
 	t.Parallel()
-	resp := decodeFixture(t, "get_ddnsuser_response_success.xml")
+	resp := testutil.DecodeFixture(t, "ddns/get_ddnsuser_response_success.xml")
 	got, err := ddns.DecodeDDNSUsers(resp.Body.ReturnInfo)
 	if err != nil {
 		t.Fatalf("DecodeDDNSUsers: %v", err)
@@ -152,17 +101,17 @@ func TestFQDN(t *testing.T) {
 
 func TestClientList(t *testing.T) {
 	t.Parallel()
-	resp := decodeFixture(t, "get_ddnsusers_response_success.xml")
-	fc := &fakeCaller{resp: resp}
+	resp := testutil.DecodeFixture(t, "ddns/get_ddnsusers_response_success.xml")
+	fc := &testutil.FakeCaller{Resp: resp}
 	list, err := ddns.NewClient(fc).List(context.Background())
 	if err != nil {
 		t.Fatalf("List: %v", err)
 	}
-	if fc.gotAction != "get_ddnsusers" {
-		t.Errorf("action = %q, want get_ddnsusers", fc.gotAction)
+	if fc.GotAction != "get_ddnsusers" {
+		t.Errorf("action = %q, want get_ddnsusers", fc.GotAction)
 	}
-	if fc.gotParams != nil {
-		t.Errorf("params = %v, want nil", fc.gotParams)
+	if fc.GotParams != nil {
+		t.Errorf("params = %v, want nil", fc.GotParams)
 	}
 	if len(list) != 2 {
 		t.Errorf("len = %d, want 2", len(list))
@@ -171,22 +120,22 @@ func TestClientList(t *testing.T) {
 
 func TestClientGet(t *testing.T) {
 	t.Parallel()
-	resp := decodeFixture(t, "get_ddnsuser_response_success.xml")
-	fc := &fakeCaller{resp: resp}
+	resp := testutil.DecodeFixture(t, "ddns/get_ddnsuser_response_success.xml")
+	fc := &testutil.FakeCaller{Resp: resp}
 	u, err := ddns.NewClient(fc).Get(context.Background(), "dyn0000002")
 	if err != nil {
 		t.Fatalf("Get: %v", err)
 	}
-	if fc.gotAction != "get_ddnsusers" {
-		t.Errorf("action = %q", fc.gotAction)
+	if fc.GotAction != "get_ddnsusers" {
+		t.Errorf("action = %q", fc.GotAction)
 	}
 	// Filter parameter is `ddns_login` (no y), unlike the response
 	// keys which use the dyndns_ prefix. Fixture-confirmed.
-	if got, _ := fc.gotParams["ddns_login"].(string); got != "dyn0000002" {
-		t.Errorf("params[ddns_login] = %v, want dyn0000002", fc.gotParams["ddns_login"])
+	if got, _ := fc.GotParams["ddns_login"].(string); got != "dyn0000002" {
+		t.Errorf("params[ddns_login] = %v, want dyn0000002", fc.GotParams["ddns_login"])
 	}
-	if _, ok := fc.gotParams["dyndns_login"]; ok {
-		t.Errorf("dyndns_login (with y) leaked into params: %v", fc.gotParams)
+	if _, ok := fc.GotParams["dyndns_login"]; ok {
+		t.Errorf("dyndns_login (with y) leaked into params: %v", fc.GotParams)
 	}
 	if u.Login != "dyn0000002" {
 		t.Errorf("Login = %q", u.Login)
@@ -195,7 +144,7 @@ func TestClientGet(t *testing.T) {
 
 func TestClientGetEmptyLogin(t *testing.T) {
 	t.Parallel()
-	c := ddns.NewClient(&fakeCaller{})
+	c := ddns.NewClient(&testutil.FakeCaller{})
 	if _, err := c.Get(context.Background(), ""); err == nil {
 		t.Errorf("Get(\"\") err = nil, want validation error")
 	}
@@ -204,7 +153,7 @@ func TestClientGetEmptyLogin(t *testing.T) {
 func TestClientPropagatesError(t *testing.T) {
 	t.Parallel()
 	want := errors.New("boom")
-	c := ddns.NewClient(&fakeCaller{err: want})
+	c := ddns.NewClient(&testutil.FakeCaller{Err: want})
 	if _, err := c.List(context.Background()); !errors.Is(err, want) {
 		t.Errorf("List err = %v, want %v wrapped", err, want)
 	}
@@ -215,7 +164,7 @@ func TestClientPropagatesError(t *testing.T) {
 
 func TestDDNSUserListTabular(t *testing.T) {
 	t.Parallel()
-	resp := decodeFixture(t, "get_ddnsusers_response_success.xml")
+	resp := testutil.DecodeFixture(t, "ddns/get_ddnsusers_response_success.xml")
 	list, _ := ddns.DecodeDDNSUsers(resp.Body.ReturnInfo)
 	headers := list.TableHeaders()
 	if headers[0] != "LOGIN" {
@@ -235,7 +184,7 @@ func TestDDNSUserListTabular(t *testing.T) {
 
 func TestDDNSUserTabular(t *testing.T) {
 	t.Parallel()
-	resp := decodeFixture(t, "get_ddnsuser_response_success.xml")
+	resp := testutil.DecodeFixture(t, "ddns/get_ddnsuser_response_success.xml")
 	list, _ := ddns.DecodeDDNSUsers(resp.Body.ReturnInfo)
 	if len(list) != 1 {
 		t.Fatalf("len = %d, want 1", len(list))

--- a/internal/directoryprotection/directoryprotection_test.go
+++ b/internal/directoryprotection/directoryprotection_test.go
@@ -3,66 +3,15 @@ package directoryprotection_test
 import (
 	"context"
 	"errors"
-	"os"
-	"path/filepath"
-	"runtime"
 	"testing"
 
 	"github.com/chmmou/kasapi-cli/internal/directoryprotection"
-	"github.com/chmmou/kasapi-cli/internal/soap"
+	"github.com/chmmou/kasapi-cli/internal/testutil"
 )
-
-func repoRoot(t *testing.T) string {
-	t.Helper()
-	_, file, _, ok := runtime.Caller(0)
-	if !ok {
-		t.Fatal("runtime.Caller failed")
-	}
-	dir := filepath.Dir(file)
-	for {
-		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
-			return dir
-		}
-		parent := filepath.Dir(dir)
-		if parent == dir {
-			t.Fatalf("repo root not found from %q", file)
-		}
-		dir = parent
-	}
-}
-
-func decodeFixture(t *testing.T, name string) *soap.Response {
-	t.Helper()
-	path := filepath.Join(repoRoot(t), "testdata", "directoryprotection", name)
-	f, err := os.Open(path)
-	if err != nil {
-		t.Fatalf("open %s: %v", name, err)
-	}
-	defer func() { _ = f.Close() }()
-	resp, err := soap.Decode(f)
-	if err != nil {
-		t.Fatalf("decode %s: %v", name, err)
-	}
-	return resp
-}
-
-type fakeCaller struct {
-	resp *soap.Response
-	err  error
-
-	gotAction string
-	gotParams map[string]any
-}
-
-func (f *fakeCaller) Call(_ context.Context, action string, params map[string]any) (*soap.Response, error) {
-	f.gotAction = action
-	f.gotParams = params
-	return f.resp, f.err
-}
 
 func TestDecodeDirectoryProtections(t *testing.T) {
 	t.Parallel()
-	resp := decodeFixture(t, "get_directoryprotections_response_success.xml")
+	resp := testutil.DecodeFixture(t, "directoryprotection/get_directoryprotections_response_success.xml")
 	got, err := directoryprotection.DecodeDirectoryProtections(resp.Body.ReturnInfo)
 	if err != nil {
 		t.Fatalf("DecodeDirectoryProtections: %v", err)
@@ -87,7 +36,7 @@ func TestDecodeDirectoryProtections(t *testing.T) {
 
 func TestDecodeDirectoryProtectionSingular(t *testing.T) {
 	t.Parallel()
-	resp := decodeFixture(t, "get_directoryprotection_response_success.xml")
+	resp := testutil.DecodeFixture(t, "directoryprotection/get_directoryprotection_response_success.xml")
 	got, err := directoryprotection.DecodeDirectoryProtections(resp.Body.ReturnInfo)
 	if err != nil {
 		t.Fatalf("DecodeDirectoryProtections: %v", err)
@@ -102,17 +51,17 @@ func TestDecodeDirectoryProtectionSingular(t *testing.T) {
 
 func TestClientListNoFilter(t *testing.T) {
 	t.Parallel()
-	resp := decodeFixture(t, "get_directoryprotections_response_success.xml")
-	fc := &fakeCaller{resp: resp}
+	resp := testutil.DecodeFixture(t, "directoryprotection/get_directoryprotections_response_success.xml")
+	fc := &testutil.FakeCaller{Resp: resp}
 	list, err := directoryprotection.NewClient(fc).List(context.Background(), "")
 	if err != nil {
 		t.Fatalf("List: %v", err)
 	}
-	if fc.gotAction != "get_directoryprotection" {
-		t.Errorf("action = %q, want get_directoryprotection", fc.gotAction)
+	if fc.GotAction != "get_directoryprotection" {
+		t.Errorf("action = %q, want get_directoryprotection", fc.GotAction)
 	}
-	if fc.gotParams != nil {
-		t.Errorf("params = %v, want nil", fc.gotParams)
+	if fc.GotParams != nil {
+		t.Errorf("params = %v, want nil", fc.GotParams)
 	}
 	if len(list) != 1 {
 		t.Errorf("len = %d, want 1", len(list))
@@ -121,17 +70,17 @@ func TestClientListNoFilter(t *testing.T) {
 
 func TestClientListWithPath(t *testing.T) {
 	t.Parallel()
-	resp := decodeFixture(t, "get_directoryprotection_response_success.xml")
-	fc := &fakeCaller{resp: resp}
+	resp := testutil.DecodeFixture(t, "directoryprotection/get_directoryprotection_response_success.xml")
+	fc := &testutil.FakeCaller{Resp: resp}
 	list, err := directoryprotection.NewClient(fc).List(context.Background(), "/protected/directory/")
 	if err != nil {
 		t.Fatalf("List: %v", err)
 	}
-	if fc.gotAction != "get_directoryprotection" {
-		t.Errorf("action = %q", fc.gotAction)
+	if fc.GotAction != "get_directoryprotection" {
+		t.Errorf("action = %q", fc.GotAction)
 	}
-	if got, _ := fc.gotParams["directory_path"].(string); got != "/protected/directory/" {
-		t.Errorf("params[directory_path] = %v", fc.gotParams["directory_path"])
+	if got, _ := fc.GotParams["directory_path"].(string); got != "/protected/directory/" {
+		t.Errorf("params[directory_path] = %v", fc.GotParams["directory_path"])
 	}
 	if len(list) != 1 {
 		t.Errorf("len = %d, want 1", len(list))
@@ -141,7 +90,7 @@ func TestClientListWithPath(t *testing.T) {
 func TestClientPropagatesError(t *testing.T) {
 	t.Parallel()
 	want := errors.New("boom")
-	c := directoryprotection.NewClient(&fakeCaller{err: want})
+	c := directoryprotection.NewClient(&testutil.FakeCaller{Err: want})
 	if _, err := c.List(context.Background(), ""); !errors.Is(err, want) {
 		t.Errorf("List err = %v, want %v wrapped", err, want)
 	}
@@ -152,7 +101,7 @@ func TestClientPropagatesError(t *testing.T) {
 
 func TestDirectoryProtectionListTabular(t *testing.T) {
 	t.Parallel()
-	resp := decodeFixture(t, "get_directoryprotections_response_success.xml")
+	resp := testutil.DecodeFixture(t, "directoryprotection/get_directoryprotections_response_success.xml")
 	list, _ := directoryprotection.DecodeDirectoryProtections(resp.Body.ReturnInfo)
 	headers := list.TableHeaders()
 	if headers[0] != "PATH" {

--- a/internal/dns/dns_test.go
+++ b/internal/dns/dns_test.go
@@ -3,66 +3,15 @@ package dns_test
 import (
 	"context"
 	"errors"
-	"os"
-	"path/filepath"
-	"runtime"
 	"testing"
 
 	"github.com/chmmou/kasapi-cli/internal/dns"
-	"github.com/chmmou/kasapi-cli/internal/soap"
+	"github.com/chmmou/kasapi-cli/internal/testutil"
 )
-
-func repoRoot(t *testing.T) string {
-	t.Helper()
-	_, file, _, ok := runtime.Caller(0)
-	if !ok {
-		t.Fatal("runtime.Caller failed")
-	}
-	dir := filepath.Dir(file)
-	for {
-		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
-			return dir
-		}
-		parent := filepath.Dir(dir)
-		if parent == dir {
-			t.Fatalf("repo root not found from %q", file)
-		}
-		dir = parent
-	}
-}
-
-func decodeFixture(t *testing.T, name string) *soap.Response {
-	t.Helper()
-	path := filepath.Join(repoRoot(t), "testdata", "dns", name)
-	f, err := os.Open(path)
-	if err != nil {
-		t.Fatalf("open %s: %v", name, err)
-	}
-	defer func() { _ = f.Close() }()
-	resp, err := soap.Decode(f)
-	if err != nil {
-		t.Fatalf("decode %s: %v", name, err)
-	}
-	return resp
-}
-
-type fakeCaller struct {
-	resp *soap.Response
-	err  error
-
-	gotAction string
-	gotParams map[string]any
-}
-
-func (f *fakeCaller) Call(_ context.Context, action string, params map[string]any) (*soap.Response, error) {
-	f.gotAction = action
-	f.gotParams = params
-	return f.resp, f.err
-}
 
 func TestDecodeRecords(t *testing.T) {
 	t.Parallel()
-	resp := decodeFixture(t, "get_dns_settings_response_success.xml")
+	resp := testutil.DecodeFixture(t, "dns/get_dns_settings_response_success.xml")
 	got, err := dns.DecodeRecords(resp.Body.ReturnInfo)
 	if err != nil {
 		t.Fatalf("DecodeRecords: %v", err)
@@ -102,20 +51,20 @@ func TestDecodeRecords(t *testing.T) {
 
 func TestClientSettings(t *testing.T) {
 	t.Parallel()
-	resp := decodeFixture(t, "get_dns_settings_response_success.xml")
-	fc := &fakeCaller{resp: resp}
+	resp := testutil.DecodeFixture(t, "dns/get_dns_settings_response_success.xml")
+	fc := &testutil.FakeCaller{Resp: resp}
 	list, err := dns.NewClient(fc).Settings(context.Background(), "example.com", "")
 	if err != nil {
 		t.Fatalf("Settings: %v", err)
 	}
-	if fc.gotAction != "get_dns_settings" {
-		t.Errorf("action = %q, want get_dns_settings", fc.gotAction)
+	if fc.GotAction != "get_dns_settings" {
+		t.Errorf("action = %q, want get_dns_settings", fc.GotAction)
 	}
-	if zh, _ := fc.gotParams["zone_host"].(string); zh != "example.com" {
-		t.Errorf("params[zone_host] = %v, want example.com", fc.gotParams["zone_host"])
+	if zh, _ := fc.GotParams["zone_host"].(string); zh != "example.com" {
+		t.Errorf("params[zone_host] = %v, want example.com", fc.GotParams["zone_host"])
 	}
-	if _, ok := fc.gotParams["nameserver"]; ok {
-		t.Errorf("params[nameserver] set but nameserver was empty: %v", fc.gotParams)
+	if _, ok := fc.GotParams["nameserver"]; ok {
+		t.Errorf("params[nameserver] set but nameserver was empty: %v", fc.GotParams)
 	}
 	if len(list) != 6 {
 		t.Errorf("len = %d, want 6", len(list))
@@ -124,19 +73,19 @@ func TestClientSettings(t *testing.T) {
 
 func TestClientSettingsWithNameserver(t *testing.T) {
 	t.Parallel()
-	resp := decodeFixture(t, "get_dns_settings_response_success.xml")
-	fc := &fakeCaller{resp: resp}
+	resp := testutil.DecodeFixture(t, "dns/get_dns_settings_response_success.xml")
+	fc := &testutil.FakeCaller{Resp: resp}
 	if _, err := dns.NewClient(fc).Settings(context.Background(), "example.com", "ns.example.com"); err != nil {
 		t.Fatalf("Settings: %v", err)
 	}
-	if ns, _ := fc.gotParams["nameserver"].(string); ns != "ns.example.com" {
-		t.Errorf("params[nameserver] = %v, want ns.example.com", fc.gotParams["nameserver"])
+	if ns, _ := fc.GotParams["nameserver"].(string); ns != "ns.example.com" {
+		t.Errorf("params[nameserver] = %v, want ns.example.com", fc.GotParams["nameserver"])
 	}
 }
 
 func TestClientSettingsRequiresZoneHost(t *testing.T) {
 	t.Parallel()
-	c := dns.NewClient(&fakeCaller{})
+	c := dns.NewClient(&testutil.FakeCaller{})
 	if _, err := c.Settings(context.Background(), "", ""); err == nil {
 		t.Errorf("Settings(\"\") err = nil, want validation error")
 	}
@@ -145,7 +94,7 @@ func TestClientSettingsRequiresZoneHost(t *testing.T) {
 func TestClientPropagatesError(t *testing.T) {
 	t.Parallel()
 	want := errors.New("boom")
-	c := dns.NewClient(&fakeCaller{err: want})
+	c := dns.NewClient(&testutil.FakeCaller{Err: want})
 	if _, err := c.Settings(context.Background(), "example.com", ""); !errors.Is(err, want) {
 		t.Errorf("Settings err = %v, want %v wrapped", err, want)
 	}
@@ -153,7 +102,7 @@ func TestClientPropagatesError(t *testing.T) {
 
 func TestRecordListTabular(t *testing.T) {
 	t.Parallel()
-	resp := decodeFixture(t, "get_dns_settings_response_success.xml")
+	resp := testutil.DecodeFixture(t, "dns/get_dns_settings_response_success.xml")
 	list, _ := dns.DecodeRecords(resp.Body.ReturnInfo)
 	rows := list.TableRows()
 	if len(rows) != 6 {

--- a/internal/domain/domain_test.go
+++ b/internal/domain/domain_test.go
@@ -3,66 +3,16 @@ package domain_test
 import (
 	"context"
 	"errors"
-	"os"
-	"path/filepath"
-	"runtime"
 	"testing"
 
 	"github.com/chmmou/kasapi-cli/internal/domain"
 	"github.com/chmmou/kasapi-cli/internal/soap"
+	"github.com/chmmou/kasapi-cli/internal/testutil"
 )
-
-func repoRoot(t *testing.T) string {
-	t.Helper()
-	_, file, _, ok := runtime.Caller(0)
-	if !ok {
-		t.Fatal("runtime.Caller failed")
-	}
-	dir := filepath.Dir(file)
-	for {
-		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
-			return dir
-		}
-		parent := filepath.Dir(dir)
-		if parent == dir {
-			t.Fatalf("repo root not found from %q", file)
-		}
-		dir = parent
-	}
-}
-
-func decodeFixture(t *testing.T, name string) *soap.Response {
-	t.Helper()
-	path := filepath.Join(repoRoot(t), "testdata", "domain", name)
-	f, err := os.Open(path)
-	if err != nil {
-		t.Fatalf("open %s: %v", name, err)
-	}
-	defer func() { _ = f.Close() }()
-	resp, err := soap.Decode(f)
-	if err != nil {
-		t.Fatalf("decode %s: %v", name, err)
-	}
-	return resp
-}
-
-type fakeCaller struct {
-	resp *soap.Response
-	err  error
-
-	gotAction string
-	gotParams map[string]any
-}
-
-func (f *fakeCaller) Call(_ context.Context, action string, params map[string]any) (*soap.Response, error) {
-	f.gotAction = action
-	f.gotParams = params
-	return f.resp, f.err
-}
 
 func TestDecodeDomains(t *testing.T) {
 	t.Parallel()
-	resp := decodeFixture(t, "get_domains_response_success.xml")
+	resp := testutil.DecodeFixture(t, "domain/get_domains_response_success.xml")
 	got, err := domain.DecodeDomains(resp.Body.ReturnInfo)
 	if err != nil {
 		t.Fatalf("DecodeDomains: %v", err)
@@ -94,7 +44,7 @@ func TestDecodeDomains(t *testing.T) {
 
 func TestDecodeDomainSingular(t *testing.T) {
 	t.Parallel()
-	resp := decodeFixture(t, "get_domain_response_success.xml")
+	resp := testutil.DecodeFixture(t, "domain/get_domain_response_success.xml")
 	got, err := domain.DecodeDomains(resp.Body.ReturnInfo)
 	if err != nil {
 		t.Fatalf("DecodeDomains: %v", err)
@@ -131,7 +81,7 @@ func TestDecodeDomainSingular(t *testing.T) {
 
 func TestDecodeTLDs(t *testing.T) {
 	t.Parallel()
-	resp := decodeFixture(t, "get_topleveldomains_response_success.xml")
+	resp := testutil.DecodeFixture(t, "domain/get_topleveldomains_response_success.xml")
 	got, err := domain.DecodeTLDs(resp.Body.ReturnInfo)
 	if err != nil {
 		t.Fatalf("DecodeTLDs: %v", err)
@@ -157,17 +107,17 @@ func TestDecodeTLDs(t *testing.T) {
 
 func TestClientList(t *testing.T) {
 	t.Parallel()
-	resp := decodeFixture(t, "get_domains_response_success.xml")
-	fc := &fakeCaller{resp: resp}
+	resp := testutil.DecodeFixture(t, "domain/get_domains_response_success.xml")
+	fc := &testutil.FakeCaller{Resp: resp}
 	list, err := domain.NewClient(fc).List(context.Background())
 	if err != nil {
 		t.Fatalf("List: %v", err)
 	}
-	if fc.gotAction != "get_domains" {
-		t.Errorf("action = %q, want get_domains", fc.gotAction)
+	if fc.GotAction != "get_domains" {
+		t.Errorf("action = %q, want get_domains", fc.GotAction)
 	}
-	if fc.gotParams != nil {
-		t.Errorf("params = %v, want nil", fc.gotParams)
+	if fc.GotParams != nil {
+		t.Errorf("params = %v, want nil", fc.GotParams)
 	}
 	if len(list) != 2 {
 		t.Errorf("len = %d, want 2", len(list))
@@ -176,17 +126,17 @@ func TestClientList(t *testing.T) {
 
 func TestClientGet(t *testing.T) {
 	t.Parallel()
-	resp := decodeFixture(t, "get_domain_response_success.xml")
-	fc := &fakeCaller{resp: resp}
+	resp := testutil.DecodeFixture(t, "domain/get_domain_response_success.xml")
+	fc := &testutil.FakeCaller{Resp: resp}
 	d, err := domain.NewClient(fc).Get(context.Background(), "example.com")
 	if err != nil {
 		t.Fatalf("Get: %v", err)
 	}
-	if fc.gotAction != "get_domains" {
-		t.Errorf("action = %q, want get_domains", fc.gotAction)
+	if fc.GotAction != "get_domains" {
+		t.Errorf("action = %q, want get_domains", fc.GotAction)
 	}
-	if name, _ := fc.gotParams["domain_name"].(string); name != "example.com" {
-		t.Errorf("params[domain_name] = %v, want example.com", fc.gotParams["domain_name"])
+	if name, _ := fc.GotParams["domain_name"].(string); name != "example.com" {
+		t.Errorf("params[domain_name] = %v, want example.com", fc.GotParams["domain_name"])
 	}
 	if d.Name != "example.com" {
 		t.Errorf("Name = %q", d.Name)
@@ -195,7 +145,7 @@ func TestClientGet(t *testing.T) {
 
 func TestClientGetEmptyName(t *testing.T) {
 	t.Parallel()
-	c := domain.NewClient(&fakeCaller{})
+	c := domain.NewClient(&testutil.FakeCaller{})
 	if _, err := c.Get(context.Background(), ""); err == nil {
 		t.Errorf("Get(\"\") err = nil, want validation error")
 	}
@@ -206,7 +156,7 @@ func TestClientGetNotFound(t *testing.T) {
 	// Empty array fixture: re-use get_domains_request via a hand-made
 	// soap.Response with a zero-length array.
 	resp := &soap.Response{Body: soap.ResponseBody{ReturnInfo: soap.Value{Kind: soap.KindArray}}}
-	c := domain.NewClient(&fakeCaller{resp: resp})
+	c := domain.NewClient(&testutil.FakeCaller{Resp: resp})
 	if _, err := c.Get(context.Background(), "missing.example"); err == nil {
 		t.Errorf("Get on empty result err = nil, want not-found")
 	}
@@ -214,14 +164,14 @@ func TestClientGetNotFound(t *testing.T) {
 
 func TestClientTopLevelDomains(t *testing.T) {
 	t.Parallel()
-	resp := decodeFixture(t, "get_topleveldomains_response_success.xml")
-	fc := &fakeCaller{resp: resp}
+	resp := testutil.DecodeFixture(t, "domain/get_topleveldomains_response_success.xml")
+	fc := &testutil.FakeCaller{Resp: resp}
 	list, err := domain.NewClient(fc).TopLevelDomains(context.Background())
 	if err != nil {
 		t.Fatalf("TopLevelDomains: %v", err)
 	}
-	if fc.gotAction != "get_topleveldomains" {
-		t.Errorf("action = %q, want get_topleveldomains", fc.gotAction)
+	if fc.GotAction != "get_topleveldomains" {
+		t.Errorf("action = %q, want get_topleveldomains", fc.GotAction)
 	}
 	if len(list) != 1077 {
 		t.Errorf("len = %d, want 1077", len(list))
@@ -231,7 +181,7 @@ func TestClientTopLevelDomains(t *testing.T) {
 func TestClientPropagatesError(t *testing.T) {
 	t.Parallel()
 	want := errors.New("boom")
-	c := domain.NewClient(&fakeCaller{err: want})
+	c := domain.NewClient(&testutil.FakeCaller{Err: want})
 	if _, err := c.List(context.Background()); !errors.Is(err, want) {
 		t.Errorf("List err = %v, want %v wrapped", err, want)
 	}
@@ -245,7 +195,7 @@ func TestClientPropagatesError(t *testing.T) {
 
 func TestDomainListTabular(t *testing.T) {
 	t.Parallel()
-	resp := decodeFixture(t, "get_domains_response_success.xml")
+	resp := testutil.DecodeFixture(t, "domain/get_domains_response_success.xml")
 	list, _ := domain.DecodeDomains(resp.Body.ReturnInfo)
 	rows := list.TableRows()
 	if len(rows) != 2 {
@@ -258,7 +208,7 @@ func TestDomainListTabular(t *testing.T) {
 
 func TestTLDListTabular(t *testing.T) {
 	t.Parallel()
-	resp := decodeFixture(t, "get_topleveldomains_response_success.xml")
+	resp := testutil.DecodeFixture(t, "domain/get_topleveldomains_response_success.xml")
 	list, _ := domain.DecodeTLDs(resp.Body.ReturnInfo)
 	rows := list.TableRows()
 	if len(rows) != 1077 {
@@ -271,7 +221,7 @@ func TestTLDListTabular(t *testing.T) {
 
 func TestDomainTabularSummarisesPEM(t *testing.T) {
 	t.Parallel()
-	resp := decodeFixture(t, "get_domain_response_success.xml")
+	resp := testutil.DecodeFixture(t, "domain/get_domain_response_success.xml")
 	list, _ := domain.DecodeDomains(resp.Body.ReturnInfo)
 	rows := list[0].TableRows()
 	for _, row := range rows {

--- a/internal/ftpuser/ftpuser_test.go
+++ b/internal/ftpuser/ftpuser_test.go
@@ -3,66 +3,15 @@ package ftpuser_test
 import (
 	"context"
 	"errors"
-	"os"
-	"path/filepath"
-	"runtime"
 	"testing"
 
 	"github.com/chmmou/kasapi-cli/internal/ftpuser"
-	"github.com/chmmou/kasapi-cli/internal/soap"
+	"github.com/chmmou/kasapi-cli/internal/testutil"
 )
-
-func repoRoot(t *testing.T) string {
-	t.Helper()
-	_, file, _, ok := runtime.Caller(0)
-	if !ok {
-		t.Fatal("runtime.Caller failed")
-	}
-	dir := filepath.Dir(file)
-	for {
-		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
-			return dir
-		}
-		parent := filepath.Dir(dir)
-		if parent == dir {
-			t.Fatalf("repo root not found from %q", file)
-		}
-		dir = parent
-	}
-}
-
-func decodeFixture(t *testing.T, name string) *soap.Response {
-	t.Helper()
-	path := filepath.Join(repoRoot(t), "testdata", "ftpuser", name)
-	f, err := os.Open(path)
-	if err != nil {
-		t.Fatalf("open %s: %v", name, err)
-	}
-	defer func() { _ = f.Close() }()
-	resp, err := soap.Decode(f)
-	if err != nil {
-		t.Fatalf("decode %s: %v", name, err)
-	}
-	return resp
-}
-
-type fakeCaller struct {
-	resp *soap.Response
-	err  error
-
-	gotAction string
-	gotParams map[string]any
-}
-
-func (f *fakeCaller) Call(_ context.Context, action string, params map[string]any) (*soap.Response, error) {
-	f.gotAction = action
-	f.gotParams = params
-	return f.resp, f.err
-}
 
 func TestDecodeFTPUsers(t *testing.T) {
 	t.Parallel()
-	resp := decodeFixture(t, "get_ftpusers_response_success.xml")
+	resp := testutil.DecodeFixture(t, "ftpuser/get_ftpusers_response_success.xml")
 	got, err := ftpuser.DecodeFTPUsers(resp.Body.ReturnInfo)
 	if err != nil {
 		t.Fatalf("DecodeFTPUsers: %v", err)
@@ -92,7 +41,7 @@ func TestDecodeFTPUsers(t *testing.T) {
 
 func TestDecodeFTPUserSingular(t *testing.T) {
 	t.Parallel()
-	resp := decodeFixture(t, "get_ftpuser_response_success.xml")
+	resp := testutil.DecodeFixture(t, "ftpuser/get_ftpuser_response_success.xml")
 	got, err := ftpuser.DecodeFTPUsers(resp.Body.ReturnInfo)
 	if err != nil {
 		t.Fatalf("DecodeFTPUsers: %v", err)
@@ -119,7 +68,7 @@ func TestDecodeFTPUserSingular(t *testing.T) {
 
 func TestDecodeFTPUsersEmptyList(t *testing.T) {
 	t.Parallel()
-	resp := decodeFixture(t, "get_ftpuser_response_success_empty_list.xml")
+	resp := testutil.DecodeFixture(t, "ftpuser/get_ftpuser_response_success_empty_list.xml")
 	got, err := ftpuser.DecodeFTPUsers(resp.Body.ReturnInfo)
 	if err != nil {
 		t.Fatalf("DecodeFTPUsers: %v", err)
@@ -131,17 +80,17 @@ func TestDecodeFTPUsersEmptyList(t *testing.T) {
 
 func TestClientList(t *testing.T) {
 	t.Parallel()
-	resp := decodeFixture(t, "get_ftpusers_response_success.xml")
-	fc := &fakeCaller{resp: resp}
+	resp := testutil.DecodeFixture(t, "ftpuser/get_ftpusers_response_success.xml")
+	fc := &testutil.FakeCaller{Resp: resp}
 	list, err := ftpuser.NewClient(fc).List(context.Background())
 	if err != nil {
 		t.Fatalf("List: %v", err)
 	}
-	if fc.gotAction != "get_ftpusers" {
-		t.Errorf("action = %q, want get_ftpusers", fc.gotAction)
+	if fc.GotAction != "get_ftpusers" {
+		t.Errorf("action = %q, want get_ftpusers", fc.GotAction)
 	}
-	if fc.gotParams != nil {
-		t.Errorf("params = %v, want nil", fc.gotParams)
+	if fc.GotParams != nil {
+		t.Errorf("params = %v, want nil", fc.GotParams)
 	}
 	if len(list) != 5 {
 		t.Errorf("len = %d, want 5", len(list))
@@ -150,17 +99,17 @@ func TestClientList(t *testing.T) {
 
 func TestClientGet(t *testing.T) {
 	t.Parallel()
-	resp := decodeFixture(t, "get_ftpuser_response_success.xml")
-	fc := &fakeCaller{resp: resp}
+	resp := testutil.DecodeFixture(t, "ftpuser/get_ftpuser_response_success.xml")
+	fc := &testutil.FakeCaller{Resp: resp}
 	u, err := ftpuser.NewClient(fc).Get(context.Background(), "f0000001")
 	if err != nil {
 		t.Fatalf("Get: %v", err)
 	}
-	if fc.gotAction != "get_ftpusers" {
-		t.Errorf("action = %q, want get_ftpusers", fc.gotAction)
+	if fc.GotAction != "get_ftpusers" {
+		t.Errorf("action = %q, want get_ftpusers", fc.GotAction)
 	}
-	if got, _ := fc.gotParams["ftp_login"].(string); got != "f0000001" {
-		t.Errorf("params[ftp_login] = %v, want f0000001", fc.gotParams["ftp_login"])
+	if got, _ := fc.GotParams["ftp_login"].(string); got != "f0000001" {
+		t.Errorf("params[ftp_login] = %v, want f0000001", fc.GotParams["ftp_login"])
 	}
 	if u.Login != "f0000001" {
 		t.Errorf("Login = %q, want f0000001", u.Login)
@@ -169,7 +118,7 @@ func TestClientGet(t *testing.T) {
 
 func TestClientGetEmptyLogin(t *testing.T) {
 	t.Parallel()
-	c := ftpuser.NewClient(&fakeCaller{})
+	c := ftpuser.NewClient(&testutil.FakeCaller{})
 	if _, err := c.Get(context.Background(), ""); err == nil {
 		t.Errorf("Get(\"\") err = nil, want validation error")
 	}
@@ -177,8 +126,8 @@ func TestClientGetEmptyLogin(t *testing.T) {
 
 func TestClientGetNotFound(t *testing.T) {
 	t.Parallel()
-	resp := decodeFixture(t, "get_ftpuser_response_success_empty_list.xml")
-	c := ftpuser.NewClient(&fakeCaller{resp: resp})
+	resp := testutil.DecodeFixture(t, "ftpuser/get_ftpuser_response_success_empty_list.xml")
+	c := ftpuser.NewClient(&testutil.FakeCaller{Resp: resp})
 	if _, err := c.Get(context.Background(), "missing"); err == nil {
 		t.Errorf("Get on empty result err = nil, want not-found")
 	}
@@ -187,7 +136,7 @@ func TestClientGetNotFound(t *testing.T) {
 func TestClientPropagatesError(t *testing.T) {
 	t.Parallel()
 	want := errors.New("boom")
-	c := ftpuser.NewClient(&fakeCaller{err: want})
+	c := ftpuser.NewClient(&testutil.FakeCaller{Err: want})
 	if _, err := c.List(context.Background()); !errors.Is(err, want) {
 		t.Errorf("List err = %v, want %v wrapped", err, want)
 	}
@@ -198,7 +147,7 @@ func TestClientPropagatesError(t *testing.T) {
 
 func TestFTPUserListTabular(t *testing.T) {
 	t.Parallel()
-	resp := decodeFixture(t, "get_ftpusers_response_success.xml")
+	resp := testutil.DecodeFixture(t, "ftpuser/get_ftpusers_response_success.xml")
 	list, _ := ftpuser.DecodeFTPUsers(resp.Body.ReturnInfo)
 	headers := list.TableHeaders()
 	if headers[0] != "LOGIN" {
@@ -215,7 +164,7 @@ func TestFTPUserListTabular(t *testing.T) {
 
 func TestFTPUserTabular(t *testing.T) {
 	t.Parallel()
-	resp := decodeFixture(t, "get_ftpuser_response_success.xml")
+	resp := testutil.DecodeFixture(t, "ftpuser/get_ftpuser_response_success.xml")
 	list, _ := ftpuser.DecodeFTPUsers(resp.Body.ReturnInfo)
 	if len(list) != 1 {
 		t.Fatalf("len = %d, want 1", len(list))

--- a/internal/mailaccount/mailaccount_test.go
+++ b/internal/mailaccount/mailaccount_test.go
@@ -3,66 +3,16 @@ package mailaccount_test
 import (
 	"context"
 	"errors"
-	"os"
-	"path/filepath"
-	"runtime"
 	"testing"
 
 	"github.com/chmmou/kasapi-cli/internal/mailaccount"
 	"github.com/chmmou/kasapi-cli/internal/soap"
+	"github.com/chmmou/kasapi-cli/internal/testutil"
 )
-
-func repoRoot(t *testing.T) string {
-	t.Helper()
-	_, file, _, ok := runtime.Caller(0)
-	if !ok {
-		t.Fatal("runtime.Caller failed")
-	}
-	dir := filepath.Dir(file)
-	for {
-		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
-			return dir
-		}
-		parent := filepath.Dir(dir)
-		if parent == dir {
-			t.Fatalf("repo root not found from %q", file)
-		}
-		dir = parent
-	}
-}
-
-func decodeFixture(t *testing.T, name string) *soap.Response {
-	t.Helper()
-	path := filepath.Join(repoRoot(t), "testdata", "mailaccount", name)
-	f, err := os.Open(path)
-	if err != nil {
-		t.Fatalf("open %s: %v", name, err)
-	}
-	defer func() { _ = f.Close() }()
-	resp, err := soap.Decode(f)
-	if err != nil {
-		t.Fatalf("decode %s: %v", name, err)
-	}
-	return resp
-}
-
-type fakeCaller struct {
-	resp *soap.Response
-	err  error
-
-	gotAction string
-	gotParams map[string]any
-}
-
-func (f *fakeCaller) Call(_ context.Context, action string, params map[string]any) (*soap.Response, error) {
-	f.gotAction = action
-	f.gotParams = params
-	return f.resp, f.err
-}
 
 func TestDecodeMailAccounts(t *testing.T) {
 	t.Parallel()
-	resp := decodeFixture(t, "get_mailaccounts_response_success.xml")
+	resp := testutil.DecodeFixture(t, "mailaccount/get_mailaccounts_response_success.xml")
 	got, err := mailaccount.DecodeMailAccounts(resp.Body.ReturnInfo)
 	if err != nil {
 		t.Fatalf("DecodeMailAccounts: %v", err)
@@ -93,7 +43,7 @@ func TestDecodeMailAccounts(t *testing.T) {
 
 func TestDecodeMailAccountSingular(t *testing.T) {
 	t.Parallel()
-	resp := decodeFixture(t, "get_mailaccount_response_success.xml")
+	resp := testutil.DecodeFixture(t, "mailaccount/get_mailaccount_response_success.xml")
 	got, err := mailaccount.DecodeMailAccounts(resp.Body.ReturnInfo)
 	if err != nil {
 		t.Fatalf("DecodeMailAccounts: %v", err)
@@ -112,17 +62,17 @@ func TestDecodeMailAccountSingular(t *testing.T) {
 
 func TestClientList(t *testing.T) {
 	t.Parallel()
-	resp := decodeFixture(t, "get_mailaccounts_response_success.xml")
-	fc := &fakeCaller{resp: resp}
+	resp := testutil.DecodeFixture(t, "mailaccount/get_mailaccounts_response_success.xml")
+	fc := &testutil.FakeCaller{Resp: resp}
 	list, err := mailaccount.NewClient(fc).List(context.Background())
 	if err != nil {
 		t.Fatalf("List: %v", err)
 	}
-	if fc.gotAction != "get_mailaccounts" {
-		t.Errorf("action = %q, want get_mailaccounts", fc.gotAction)
+	if fc.GotAction != "get_mailaccounts" {
+		t.Errorf("action = %q, want get_mailaccounts", fc.GotAction)
 	}
-	if fc.gotParams != nil {
-		t.Errorf("params = %v, want nil", fc.gotParams)
+	if fc.GotParams != nil {
+		t.Errorf("params = %v, want nil", fc.GotParams)
 	}
 	if len(list) != 15 {
 		t.Errorf("len = %d, want 15", len(list))
@@ -131,17 +81,17 @@ func TestClientList(t *testing.T) {
 
 func TestClientGet(t *testing.T) {
 	t.Parallel()
-	resp := decodeFixture(t, "get_mailaccount_response_success.xml")
-	fc := &fakeCaller{resp: resp}
+	resp := testutil.DecodeFixture(t, "mailaccount/get_mailaccount_response_success.xml")
+	fc := &testutil.FakeCaller{Resp: resp}
 	a, err := mailaccount.NewClient(fc).Get(context.Background(), "m0000001")
 	if err != nil {
 		t.Fatalf("Get: %v", err)
 	}
-	if fc.gotAction != "get_mailaccounts" {
-		t.Errorf("action = %q, want get_mailaccounts", fc.gotAction)
+	if fc.GotAction != "get_mailaccounts" {
+		t.Errorf("action = %q, want get_mailaccounts", fc.GotAction)
 	}
-	if got, _ := fc.gotParams["mail_login"].(string); got != "m0000001" {
-		t.Errorf("params[mail_login] = %v, want m0000001", fc.gotParams["mail_login"])
+	if got, _ := fc.GotParams["mail_login"].(string); got != "m0000001" {
+		t.Errorf("params[mail_login] = %v, want m0000001", fc.GotParams["mail_login"])
 	}
 	if a.Login == "" {
 		t.Errorf("Login empty")
@@ -150,7 +100,7 @@ func TestClientGet(t *testing.T) {
 
 func TestClientGetEmptyLogin(t *testing.T) {
 	t.Parallel()
-	c := mailaccount.NewClient(&fakeCaller{})
+	c := mailaccount.NewClient(&testutil.FakeCaller{})
 	if _, err := c.Get(context.Background(), ""); err == nil {
 		t.Errorf("Get(\"\") err = nil, want validation error")
 	}
@@ -159,7 +109,7 @@ func TestClientGetEmptyLogin(t *testing.T) {
 func TestClientGetNotFound(t *testing.T) {
 	t.Parallel()
 	resp := &soap.Response{Body: soap.ResponseBody{ReturnInfo: soap.Value{Kind: soap.KindArray}}}
-	c := mailaccount.NewClient(&fakeCaller{resp: resp})
+	c := mailaccount.NewClient(&testutil.FakeCaller{Resp: resp})
 	if _, err := c.Get(context.Background(), "missing"); err == nil {
 		t.Errorf("Get on empty result err = nil, want not-found")
 	}
@@ -168,7 +118,7 @@ func TestClientGetNotFound(t *testing.T) {
 func TestClientPropagatesError(t *testing.T) {
 	t.Parallel()
 	want := errors.New("boom")
-	c := mailaccount.NewClient(&fakeCaller{err: want})
+	c := mailaccount.NewClient(&testutil.FakeCaller{Err: want})
 	if _, err := c.List(context.Background()); !errors.Is(err, want) {
 		t.Errorf("List err = %v, want %v wrapped", err, want)
 	}
@@ -179,7 +129,7 @@ func TestClientPropagatesError(t *testing.T) {
 
 func TestMailAccountListTabular(t *testing.T) {
 	t.Parallel()
-	resp := decodeFixture(t, "get_mailaccounts_response_success.xml")
+	resp := testutil.DecodeFixture(t, "mailaccount/get_mailaccounts_response_success.xml")
 	list, _ := mailaccount.DecodeMailAccounts(resp.Body.ReturnInfo)
 	rows := list.TableRows()
 	if len(rows) != 15 {
@@ -192,7 +142,7 @@ func TestMailAccountListTabular(t *testing.T) {
 
 func TestMailAccountTabular(t *testing.T) {
 	t.Parallel()
-	resp := decodeFixture(t, "get_mailaccount_response_success.xml")
+	resp := testutil.DecodeFixture(t, "mailaccount/get_mailaccount_response_success.xml")
 	list, _ := mailaccount.DecodeMailAccounts(resp.Body.ReturnInfo)
 	rows := list[0].TableRows()
 	if len(rows) == 0 {

--- a/internal/mailfilter/mailfilter_test.go
+++ b/internal/mailfilter/mailfilter_test.go
@@ -3,66 +3,15 @@ package mailfilter_test
 import (
 	"context"
 	"errors"
-	"os"
-	"path/filepath"
-	"runtime"
 	"testing"
 
 	"github.com/chmmou/kasapi-cli/internal/mailfilter"
-	"github.com/chmmou/kasapi-cli/internal/soap"
+	"github.com/chmmou/kasapi-cli/internal/testutil"
 )
-
-func repoRoot(t *testing.T) string {
-	t.Helper()
-	_, file, _, ok := runtime.Caller(0)
-	if !ok {
-		t.Fatal("runtime.Caller failed")
-	}
-	dir := filepath.Dir(file)
-	for {
-		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
-			return dir
-		}
-		parent := filepath.Dir(dir)
-		if parent == dir {
-			t.Fatalf("repo root not found from %q", file)
-		}
-		dir = parent
-	}
-}
-
-func decodeFixture(t *testing.T, name string) *soap.Response {
-	t.Helper()
-	path := filepath.Join(repoRoot(t), "testdata", "mailfilter", name)
-	f, err := os.Open(path)
-	if err != nil {
-		t.Fatalf("open %s: %v", name, err)
-	}
-	defer func() { _ = f.Close() }()
-	resp, err := soap.Decode(f)
-	if err != nil {
-		t.Fatalf("decode %s: %v", name, err)
-	}
-	return resp
-}
-
-type fakeCaller struct {
-	resp *soap.Response
-	err  error
-
-	gotAction string
-	gotParams map[string]any
-}
-
-func (f *fakeCaller) Call(_ context.Context, action string, params map[string]any) (*soap.Response, error) {
-	f.gotAction = action
-	f.gotParams = params
-	return f.resp, f.err
-}
 
 func TestDecodeStandardFilters(t *testing.T) {
 	t.Parallel()
-	resp := decodeFixture(t, "get_mailstandardfilter_response_success.xml")
+	resp := testutil.DecodeFixture(t, "mailfilter/get_mailstandardfilter_response_success.xml")
 	got, err := mailfilter.DecodeStandardFilters(resp.Body.ReturnInfo)
 	if err != nil {
 		t.Fatalf("DecodeStandardFilters: %v", err)
@@ -87,17 +36,17 @@ func TestDecodeStandardFilters(t *testing.T) {
 
 func TestClientList(t *testing.T) {
 	t.Parallel()
-	resp := decodeFixture(t, "get_mailstandardfilter_response_success.xml")
-	fc := &fakeCaller{resp: resp}
+	resp := testutil.DecodeFixture(t, "mailfilter/get_mailstandardfilter_response_success.xml")
+	fc := &testutil.FakeCaller{Resp: resp}
 	list, err := mailfilter.NewClient(fc).List(context.Background())
 	if err != nil {
 		t.Fatalf("List: %v", err)
 	}
-	if fc.gotAction != "get_mailstandardfilter" {
-		t.Errorf("action = %q, want get_mailstandardfilter", fc.gotAction)
+	if fc.GotAction != "get_mailstandardfilter" {
+		t.Errorf("action = %q, want get_mailstandardfilter", fc.GotAction)
 	}
-	if fc.gotParams != nil {
-		t.Errorf("params = %v, want nil", fc.gotParams)
+	if fc.GotParams != nil {
+		t.Errorf("params = %v, want nil", fc.GotParams)
 	}
 	if len(list) != 9 {
 		t.Errorf("len = %d, want 9", len(list))
@@ -107,7 +56,7 @@ func TestClientList(t *testing.T) {
 func TestClientPropagatesError(t *testing.T) {
 	t.Parallel()
 	want := errors.New("boom")
-	c := mailfilter.NewClient(&fakeCaller{err: want})
+	c := mailfilter.NewClient(&testutil.FakeCaller{Err: want})
 	if _, err := c.List(context.Background()); !errors.Is(err, want) {
 		t.Errorf("List err = %v, want %v wrapped", err, want)
 	}
@@ -115,7 +64,7 @@ func TestClientPropagatesError(t *testing.T) {
 
 func TestStandardFilterListTabular(t *testing.T) {
 	t.Parallel()
-	resp := decodeFixture(t, "get_mailstandardfilter_response_success.xml")
+	resp := testutil.DecodeFixture(t, "mailfilter/get_mailstandardfilter_response_success.xml")
 	list, _ := mailfilter.DecodeStandardFilters(resp.Body.ReturnInfo)
 	rows := list.TableRows()
 	if len(rows) != 9 {

--- a/internal/mailforward/mailforward_test.go
+++ b/internal/mailforward/mailforward_test.go
@@ -3,66 +3,16 @@ package mailforward_test
 import (
 	"context"
 	"errors"
-	"os"
-	"path/filepath"
-	"runtime"
 	"testing"
 
 	"github.com/chmmou/kasapi-cli/internal/mailforward"
 	"github.com/chmmou/kasapi-cli/internal/soap"
+	"github.com/chmmou/kasapi-cli/internal/testutil"
 )
-
-func repoRoot(t *testing.T) string {
-	t.Helper()
-	_, file, _, ok := runtime.Caller(0)
-	if !ok {
-		t.Fatal("runtime.Caller failed")
-	}
-	dir := filepath.Dir(file)
-	for {
-		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
-			return dir
-		}
-		parent := filepath.Dir(dir)
-		if parent == dir {
-			t.Fatalf("repo root not found from %q", file)
-		}
-		dir = parent
-	}
-}
-
-func decodeFixture(t *testing.T, name string) *soap.Response {
-	t.Helper()
-	path := filepath.Join(repoRoot(t), "testdata", "mailforward", name)
-	f, err := os.Open(path)
-	if err != nil {
-		t.Fatalf("open %s: %v", name, err)
-	}
-	defer func() { _ = f.Close() }()
-	resp, err := soap.Decode(f)
-	if err != nil {
-		t.Fatalf("decode %s: %v", name, err)
-	}
-	return resp
-}
-
-type fakeCaller struct {
-	resp *soap.Response
-	err  error
-
-	gotAction string
-	gotParams map[string]any
-}
-
-func (f *fakeCaller) Call(_ context.Context, action string, params map[string]any) (*soap.Response, error) {
-	f.gotAction = action
-	f.gotParams = params
-	return f.resp, f.err
-}
 
 func TestDecodeMailForwards(t *testing.T) {
 	t.Parallel()
-	resp := decodeFixture(t, "get_mailforwards_response_success.xml")
+	resp := testutil.DecodeFixture(t, "mailforward/get_mailforwards_response_success.xml")
 	got, err := mailforward.DecodeMailForwards(resp.Body.ReturnInfo)
 	if err != nil {
 		t.Fatalf("DecodeMailForwards: %v", err)
@@ -87,7 +37,7 @@ func TestDecodeMailForwards(t *testing.T) {
 
 func TestDecodeMailForwardSingular(t *testing.T) {
 	t.Parallel()
-	resp := decodeFixture(t, "get_mailforward_response_success.xml")
+	resp := testutil.DecodeFixture(t, "mailforward/get_mailforward_response_success.xml")
 	got, err := mailforward.DecodeMailForwards(resp.Body.ReturnInfo)
 	if err != nil {
 		t.Fatalf("DecodeMailForwards: %v", err)
@@ -102,17 +52,17 @@ func TestDecodeMailForwardSingular(t *testing.T) {
 
 func TestClientList(t *testing.T) {
 	t.Parallel()
-	resp := decodeFixture(t, "get_mailforwards_response_success.xml")
-	fc := &fakeCaller{resp: resp}
+	resp := testutil.DecodeFixture(t, "mailforward/get_mailforwards_response_success.xml")
+	fc := &testutil.FakeCaller{Resp: resp}
 	list, err := mailforward.NewClient(fc).List(context.Background())
 	if err != nil {
 		t.Fatalf("List: %v", err)
 	}
-	if fc.gotAction != "get_mailforwards" {
-		t.Errorf("action = %q, want get_mailforwards", fc.gotAction)
+	if fc.GotAction != "get_mailforwards" {
+		t.Errorf("action = %q, want get_mailforwards", fc.GotAction)
 	}
-	if fc.gotParams != nil {
-		t.Errorf("params = %v, want nil", fc.gotParams)
+	if fc.GotParams != nil {
+		t.Errorf("params = %v, want nil", fc.GotParams)
 	}
 	if len(list) != 2 {
 		t.Errorf("len = %d, want 2", len(list))
@@ -121,17 +71,17 @@ func TestClientList(t *testing.T) {
 
 func TestClientGet(t *testing.T) {
 	t.Parallel()
-	resp := decodeFixture(t, "get_mailforward_response_success.xml")
-	fc := &fakeCaller{resp: resp}
+	resp := testutil.DecodeFixture(t, "mailforward/get_mailforward_response_success.xml")
+	fc := &testutil.FakeCaller{Resp: resp}
 	f, err := mailforward.NewClient(fc).Get(context.Background(), "from@example.de")
 	if err != nil {
 		t.Fatalf("Get: %v", err)
 	}
-	if fc.gotAction != "get_mailforwards" {
-		t.Errorf("action = %q, want get_mailforwards", fc.gotAction)
+	if fc.GotAction != "get_mailforwards" {
+		t.Errorf("action = %q, want get_mailforwards", fc.GotAction)
 	}
-	if got, _ := fc.gotParams["mail_forward"].(string); got != "from@example.de" {
-		t.Errorf("params[mail_forward] = %v, want from@example.de", fc.gotParams["mail_forward"])
+	if got, _ := fc.GotParams["mail_forward"].(string); got != "from@example.de" {
+		t.Errorf("params[mail_forward] = %v, want from@example.de", fc.GotParams["mail_forward"])
 	}
 	if f.Address == "" {
 		t.Errorf("Address empty")
@@ -140,7 +90,7 @@ func TestClientGet(t *testing.T) {
 
 func TestClientGetEmptyAddress(t *testing.T) {
 	t.Parallel()
-	c := mailforward.NewClient(&fakeCaller{})
+	c := mailforward.NewClient(&testutil.FakeCaller{})
 	if _, err := c.Get(context.Background(), ""); err == nil {
 		t.Errorf("Get(\"\") err = nil, want validation error")
 	}
@@ -149,7 +99,7 @@ func TestClientGetEmptyAddress(t *testing.T) {
 func TestClientGetNotFound(t *testing.T) {
 	t.Parallel()
 	resp := &soap.Response{Body: soap.ResponseBody{ReturnInfo: soap.Value{Kind: soap.KindArray}}}
-	c := mailforward.NewClient(&fakeCaller{resp: resp})
+	c := mailforward.NewClient(&testutil.FakeCaller{Resp: resp})
 	if _, err := c.Get(context.Background(), "missing@example.de"); err == nil {
 		t.Errorf("Get on empty result err = nil, want not-found")
 	}
@@ -158,7 +108,7 @@ func TestClientGetNotFound(t *testing.T) {
 func TestClientPropagatesError(t *testing.T) {
 	t.Parallel()
 	want := errors.New("boom")
-	c := mailforward.NewClient(&fakeCaller{err: want})
+	c := mailforward.NewClient(&testutil.FakeCaller{Err: want})
 	if _, err := c.List(context.Background()); !errors.Is(err, want) {
 		t.Errorf("List err = %v, want %v wrapped", err, want)
 	}
@@ -169,7 +119,7 @@ func TestClientPropagatesError(t *testing.T) {
 
 func TestMailForwardListTabular(t *testing.T) {
 	t.Parallel()
-	resp := decodeFixture(t, "get_mailforwards_response_success.xml")
+	resp := testutil.DecodeFixture(t, "mailforward/get_mailforwards_response_success.xml")
 	list, _ := mailforward.DecodeMailForwards(resp.Body.ReturnInfo)
 	rows := list.TableRows()
 	if len(rows) != 2 {

--- a/internal/mailinglist/mailinglist_test.go
+++ b/internal/mailinglist/mailinglist_test.go
@@ -3,66 +3,16 @@ package mailinglist_test
 import (
 	"context"
 	"errors"
-	"os"
-	"path/filepath"
-	"runtime"
 	"testing"
 
 	"github.com/chmmou/kasapi-cli/internal/mailinglist"
 	"github.com/chmmou/kasapi-cli/internal/soap"
+	"github.com/chmmou/kasapi-cli/internal/testutil"
 )
-
-func repoRoot(t *testing.T) string {
-	t.Helper()
-	_, file, _, ok := runtime.Caller(0)
-	if !ok {
-		t.Fatal("runtime.Caller failed")
-	}
-	dir := filepath.Dir(file)
-	for {
-		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
-			return dir
-		}
-		parent := filepath.Dir(dir)
-		if parent == dir {
-			t.Fatalf("repo root not found from %q", file)
-		}
-		dir = parent
-	}
-}
-
-func decodeFixture(t *testing.T, name string) *soap.Response {
-	t.Helper()
-	path := filepath.Join(repoRoot(t), "testdata", "mailinglist", name)
-	f, err := os.Open(path)
-	if err != nil {
-		t.Fatalf("open %s: %v", name, err)
-	}
-	defer func() { _ = f.Close() }()
-	resp, err := soap.Decode(f)
-	if err != nil {
-		t.Fatalf("decode %s: %v", name, err)
-	}
-	return resp
-}
-
-type fakeCaller struct {
-	resp *soap.Response
-	err  error
-
-	gotAction string
-	gotParams map[string]any
-}
-
-func (f *fakeCaller) Call(_ context.Context, action string, params map[string]any) (*soap.Response, error) {
-	f.gotAction = action
-	f.gotParams = params
-	return f.resp, f.err
-}
 
 func TestDecodeMailingLists(t *testing.T) {
 	t.Parallel()
-	resp := decodeFixture(t, "get_mailinglists_response_success.xml")
+	resp := testutil.DecodeFixture(t, "mailinglist/get_mailinglists_response_success.xml")
 	got, err := mailinglist.DecodeMailingLists(resp.Body.ReturnInfo)
 	if err != nil {
 		t.Fatalf("DecodeMailingLists: %v", err)
@@ -84,7 +34,7 @@ func TestDecodeMailingLists(t *testing.T) {
 
 func TestDecodeMailingListSingular(t *testing.T) {
 	t.Parallel()
-	resp := decodeFixture(t, "get_mailinglist_response_success.xml")
+	resp := testutil.DecodeFixture(t, "mailinglist/get_mailinglist_response_success.xml")
 	got, err := mailinglist.DecodeMailingLists(resp.Body.ReturnInfo)
 	if err != nil {
 		t.Fatalf("DecodeMailingLists: %v", err)
@@ -99,17 +49,17 @@ func TestDecodeMailingListSingular(t *testing.T) {
 
 func TestClientList(t *testing.T) {
 	t.Parallel()
-	resp := decodeFixture(t, "get_mailinglists_response_success.xml")
-	fc := &fakeCaller{resp: resp}
+	resp := testutil.DecodeFixture(t, "mailinglist/get_mailinglists_response_success.xml")
+	fc := &testutil.FakeCaller{Resp: resp}
 	list, err := mailinglist.NewClient(fc).List(context.Background())
 	if err != nil {
 		t.Fatalf("List: %v", err)
 	}
-	if fc.gotAction != "get_mailinglists" {
-		t.Errorf("action = %q, want get_mailinglists", fc.gotAction)
+	if fc.GotAction != "get_mailinglists" {
+		t.Errorf("action = %q, want get_mailinglists", fc.GotAction)
 	}
-	if fc.gotParams != nil {
-		t.Errorf("params = %v, want nil", fc.gotParams)
+	if fc.GotParams != nil {
+		t.Errorf("params = %v, want nil", fc.GotParams)
 	}
 	if len(list) != 2 {
 		t.Errorf("len = %d, want 2", len(list))
@@ -118,17 +68,17 @@ func TestClientList(t *testing.T) {
 
 func TestClientGet(t *testing.T) {
 	t.Parallel()
-	resp := decodeFixture(t, "get_mailinglist_response_success.xml")
-	fc := &fakeCaller{resp: resp}
+	resp := testutil.DecodeFixture(t, "mailinglist/get_mailinglist_response_success.xml")
+	fc := &testutil.FakeCaller{Resp: resp}
 	m, err := mailinglist.NewClient(fc).Get(context.Background(), "announce@example.com")
 	if err != nil {
 		t.Fatalf("Get: %v", err)
 	}
-	if fc.gotAction != "get_mailinglists" {
-		t.Errorf("action = %q, want get_mailinglists", fc.gotAction)
+	if fc.GotAction != "get_mailinglists" {
+		t.Errorf("action = %q, want get_mailinglists", fc.GotAction)
 	}
-	if got, _ := fc.gotParams["mailinglist_name"].(string); got != "announce@example.com" {
-		t.Errorf("params[mailinglist_name] = %v, want announce@example.com", fc.gotParams["mailinglist_name"])
+	if got, _ := fc.GotParams["mailinglist_name"].(string); got != "announce@example.com" {
+		t.Errorf("params[mailinglist_name] = %v, want announce@example.com", fc.GotParams["mailinglist_name"])
 	}
 	if m.Name != "announce@example.com" {
 		t.Errorf("Name = %q", m.Name)
@@ -137,7 +87,7 @@ func TestClientGet(t *testing.T) {
 
 func TestClientGetEmptyName(t *testing.T) {
 	t.Parallel()
-	c := mailinglist.NewClient(&fakeCaller{})
+	c := mailinglist.NewClient(&testutil.FakeCaller{})
 	if _, err := c.Get(context.Background(), ""); err == nil {
 		t.Errorf("Get(\"\") err = nil, want validation error")
 	}
@@ -146,7 +96,7 @@ func TestClientGetEmptyName(t *testing.T) {
 func TestClientGetNotFound(t *testing.T) {
 	t.Parallel()
 	resp := &soap.Response{Body: soap.ResponseBody{ReturnInfo: soap.Value{Kind: soap.KindArray}}}
-	c := mailinglist.NewClient(&fakeCaller{resp: resp})
+	c := mailinglist.NewClient(&testutil.FakeCaller{Resp: resp})
 	if _, err := c.Get(context.Background(), "missing@example.com"); err == nil {
 		t.Errorf("Get on empty result err = nil, want not-found")
 	}
@@ -155,7 +105,7 @@ func TestClientGetNotFound(t *testing.T) {
 func TestClientPropagatesError(t *testing.T) {
 	t.Parallel()
 	want := errors.New("boom")
-	c := mailinglist.NewClient(&fakeCaller{err: want})
+	c := mailinglist.NewClient(&testutil.FakeCaller{Err: want})
 	if _, err := c.List(context.Background()); !errors.Is(err, want) {
 		t.Errorf("List err = %v, want %v wrapped", err, want)
 	}
@@ -166,7 +116,7 @@ func TestClientPropagatesError(t *testing.T) {
 
 func TestMailingListListTabular(t *testing.T) {
 	t.Parallel()
-	resp := decodeFixture(t, "get_mailinglists_response_success.xml")
+	resp := testutil.DecodeFixture(t, "mailinglist/get_mailinglists_response_success.xml")
 	list, _ := mailinglist.DecodeMailingLists(resp.Body.ReturnInfo)
 	rows := list.TableRows()
 	if len(rows) != 2 {
@@ -179,7 +129,7 @@ func TestMailingListListTabular(t *testing.T) {
 
 func TestMailingListSingularTabular(t *testing.T) {
 	t.Parallel()
-	resp := decodeFixture(t, "get_mailinglist_response_success.xml")
+	resp := testutil.DecodeFixture(t, "mailinglist/get_mailinglist_response_success.xml")
 	list, _ := mailinglist.DecodeMailingLists(resp.Body.ReturnInfo)
 	if len(list) != 1 {
 		t.Fatalf("len = %d, want 1", len(list))

--- a/internal/sambauser/sambauser_test.go
+++ b/internal/sambauser/sambauser_test.go
@@ -3,66 +3,16 @@ package sambauser_test
 import (
 	"context"
 	"errors"
-	"os"
-	"path/filepath"
-	"runtime"
 	"testing"
 
 	"github.com/chmmou/kasapi-cli/internal/sambauser"
 	"github.com/chmmou/kasapi-cli/internal/soap"
+	"github.com/chmmou/kasapi-cli/internal/testutil"
 )
-
-func repoRoot(t *testing.T) string {
-	t.Helper()
-	_, file, _, ok := runtime.Caller(0)
-	if !ok {
-		t.Fatal("runtime.Caller failed")
-	}
-	dir := filepath.Dir(file)
-	for {
-		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
-			return dir
-		}
-		parent := filepath.Dir(dir)
-		if parent == dir {
-			t.Fatalf("repo root not found from %q", file)
-		}
-		dir = parent
-	}
-}
-
-func decodeFixture(t *testing.T, name string) *soap.Response {
-	t.Helper()
-	path := filepath.Join(repoRoot(t), "testdata", "sambauser", name)
-	f, err := os.Open(path)
-	if err != nil {
-		t.Fatalf("open %s: %v", name, err)
-	}
-	defer func() { _ = f.Close() }()
-	resp, err := soap.Decode(f)
-	if err != nil {
-		t.Fatalf("decode %s: %v", name, err)
-	}
-	return resp
-}
-
-type fakeCaller struct {
-	resp *soap.Response
-	err  error
-
-	gotAction string
-	gotParams map[string]any
-}
-
-func (f *fakeCaller) Call(_ context.Context, action string, params map[string]any) (*soap.Response, error) {
-	f.gotAction = action
-	f.gotParams = params
-	return f.resp, f.err
-}
 
 func TestDecodeSambaUsers(t *testing.T) {
 	t.Parallel()
-	resp := decodeFixture(t, "get_sambausers_response_success.xml")
+	resp := testutil.DecodeFixture(t, "sambauser/get_sambausers_response_success.xml")
 	got, err := sambauser.DecodeSambaUsers(resp.Body.ReturnInfo)
 	if err != nil {
 		t.Fatalf("DecodeSambaUsers: %v", err)
@@ -87,17 +37,17 @@ func TestDecodeSambaUsers(t *testing.T) {
 
 func TestClientList(t *testing.T) {
 	t.Parallel()
-	resp := decodeFixture(t, "get_sambausers_response_success.xml")
-	fc := &fakeCaller{resp: resp}
+	resp := testutil.DecodeFixture(t, "sambauser/get_sambausers_response_success.xml")
+	fc := &testutil.FakeCaller{Resp: resp}
 	list, err := sambauser.NewClient(fc).List(context.Background())
 	if err != nil {
 		t.Fatalf("List: %v", err)
 	}
-	if fc.gotAction != "get_sambausers" {
-		t.Errorf("action = %q, want get_sambausers", fc.gotAction)
+	if fc.GotAction != "get_sambausers" {
+		t.Errorf("action = %q, want get_sambausers", fc.GotAction)
 	}
-	if fc.gotParams != nil {
-		t.Errorf("params = %v, want nil", fc.gotParams)
+	if fc.GotParams != nil {
+		t.Errorf("params = %v, want nil", fc.GotParams)
 	}
 	if len(list) != 3 {
 		t.Errorf("len = %d, want 3", len(list))
@@ -106,7 +56,7 @@ func TestClientList(t *testing.T) {
 
 func TestDecodeSambaUserSingular(t *testing.T) {
 	t.Parallel()
-	resp := decodeFixture(t, "get_sambauser_response_success.xml")
+	resp := testutil.DecodeFixture(t, "sambauser/get_sambauser_response_success.xml")
 	got, err := sambauser.DecodeSambaUsers(resp.Body.ReturnInfo)
 	if err != nil {
 		t.Fatalf("DecodeSambaUsers: %v", err)
@@ -125,17 +75,17 @@ func TestDecodeSambaUserSingular(t *testing.T) {
 
 func TestClientGet(t *testing.T) {
 	t.Parallel()
-	resp := decodeFixture(t, "get_sambauser_response_success.xml")
-	fc := &fakeCaller{resp: resp}
+	resp := testutil.DecodeFixture(t, "sambauser/get_sambauser_response_success.xml")
+	fc := &testutil.FakeCaller{Resp: resp}
 	u, err := sambauser.NewClient(fc).Get(context.Background(), "s0000000")
 	if err != nil {
 		t.Fatalf("Get: %v", err)
 	}
-	if fc.gotAction != "get_sambausers" {
-		t.Errorf("action = %q, want get_sambausers", fc.gotAction)
+	if fc.GotAction != "get_sambausers" {
+		t.Errorf("action = %q, want get_sambausers", fc.GotAction)
 	}
-	if got, _ := fc.gotParams["samba_login"].(string); got != "s0000000" {
-		t.Errorf("params[samba_login] = %v, want s0000000", fc.gotParams["samba_login"])
+	if got, _ := fc.GotParams["samba_login"].(string); got != "s0000000" {
+		t.Errorf("params[samba_login] = %v, want s0000000", fc.GotParams["samba_login"])
 	}
 	if u.Login != "s0000000" {
 		t.Errorf("Login = %q, want s0000000", u.Login)
@@ -144,7 +94,7 @@ func TestClientGet(t *testing.T) {
 
 func TestClientGetEmptyLogin(t *testing.T) {
 	t.Parallel()
-	c := sambauser.NewClient(&fakeCaller{})
+	c := sambauser.NewClient(&testutil.FakeCaller{})
 	if _, err := c.Get(context.Background(), ""); err == nil {
 		t.Errorf("Get(\"\") err = nil, want validation error")
 	}
@@ -153,7 +103,7 @@ func TestClientGetEmptyLogin(t *testing.T) {
 func TestClientGetNotFound(t *testing.T) {
 	t.Parallel()
 	resp := &soap.Response{Body: soap.ResponseBody{ReturnInfo: soap.Value{Kind: soap.KindArray}}}
-	c := sambauser.NewClient(&fakeCaller{resp: resp})
+	c := sambauser.NewClient(&testutil.FakeCaller{Resp: resp})
 	if _, err := c.Get(context.Background(), "missing"); err == nil {
 		t.Errorf("Get on empty result err = nil, want not-found")
 	}
@@ -162,7 +112,7 @@ func TestClientGetNotFound(t *testing.T) {
 func TestClientPropagatesError(t *testing.T) {
 	t.Parallel()
 	want := errors.New("boom")
-	c := sambauser.NewClient(&fakeCaller{err: want})
+	c := sambauser.NewClient(&testutil.FakeCaller{Err: want})
 	if _, err := c.List(context.Background()); !errors.Is(err, want) {
 		t.Errorf("List err = %v, want %v wrapped", err, want)
 	}
@@ -173,7 +123,7 @@ func TestClientPropagatesError(t *testing.T) {
 
 func TestSambaUserTabular(t *testing.T) {
 	t.Parallel()
-	resp := decodeFixture(t, "get_sambauser_response_success.xml")
+	resp := testutil.DecodeFixture(t, "sambauser/get_sambauser_response_success.xml")
 	list, _ := sambauser.DecodeSambaUsers(resp.Body.ReturnInfo)
 	if len(list) != 1 {
 		t.Fatalf("len = %d, want 1", len(list))
@@ -191,7 +141,7 @@ func TestSambaUserTabular(t *testing.T) {
 
 func TestSambaUserListTabular(t *testing.T) {
 	t.Parallel()
-	resp := decodeFixture(t, "get_sambausers_response_success.xml")
+	resp := testutil.DecodeFixture(t, "sambauser/get_sambausers_response_success.xml")
 	list, _ := sambauser.DecodeSambaUsers(resp.Body.ReturnInfo)
 	headers := list.TableHeaders()
 	if headers[0] != "LOGIN" {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -3,52 +3,15 @@ package server_test
 import (
 	"context"
 	"errors"
-	"os"
-	"path/filepath"
-	"runtime"
 	"testing"
 
 	"github.com/chmmou/kasapi-cli/internal/server"
-	"github.com/chmmou/kasapi-cli/internal/soap"
+	"github.com/chmmou/kasapi-cli/internal/testutil"
 )
-
-func repoRoot(t *testing.T) string {
-	t.Helper()
-	_, file, _, ok := runtime.Caller(0)
-	if !ok {
-		t.Fatal("runtime.Caller failed")
-	}
-	dir := filepath.Dir(file)
-	for {
-		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
-			return dir
-		}
-		parent := filepath.Dir(dir)
-		if parent == dir {
-			t.Fatalf("repo root not found from %q", file)
-		}
-		dir = parent
-	}
-}
-
-func decodeFixture(t *testing.T) *soap.Response {
-	t.Helper()
-	path := filepath.Join(repoRoot(t), "testdata", "account", "get_server_information_response_success.xml")
-	f, err := os.Open(path)
-	if err != nil {
-		t.Fatalf("open: %v", err)
-	}
-	defer func() { _ = f.Close() }()
-	resp, err := soap.Decode(f)
-	if err != nil {
-		t.Fatalf("decode: %v", err)
-	}
-	return resp
-}
 
 func TestDecodeServices(t *testing.T) {
 	t.Parallel()
-	resp := decodeFixture(t)
+	resp := testutil.DecodeFixture(t, "account/get_server_information_response_success.xml")
 	got, err := server.DecodeServices(resp.Body.ReturnInfo)
 	if err != nil {
 		t.Fatalf("DecodeServices: %v", err)
@@ -68,19 +31,10 @@ func TestDecodeServices(t *testing.T) {
 	}
 }
 
-type fakeCaller struct {
-	resp *soap.Response
-	err  error
-}
-
-func (f fakeCaller) Call(_ context.Context, _ string, _ map[string]any) (*soap.Response, error) {
-	return f.resp, f.err
-}
-
 func TestClientInformation(t *testing.T) {
 	t.Parallel()
-	resp := decodeFixture(t)
-	c := server.NewClient(fakeCaller{resp: resp})
+	resp := testutil.DecodeFixture(t, "account/get_server_information_response_success.xml")
+	c := server.NewClient(&testutil.FakeCaller{Resp: resp})
 	list, err := c.Information(context.Background())
 	if err != nil {
 		t.Fatalf("Information: %v", err)
@@ -93,7 +47,7 @@ func TestClientInformation(t *testing.T) {
 func TestClientInformationPropagatesError(t *testing.T) {
 	t.Parallel()
 	want := errors.New("boom")
-	c := server.NewClient(fakeCaller{err: want})
+	c := server.NewClient(&testutil.FakeCaller{Err: want})
 	if _, err := c.Information(context.Background()); !errors.Is(err, want) {
 		t.Errorf("err = %v, want %v wrapped", err, want)
 	}
@@ -101,7 +55,7 @@ func TestClientInformationPropagatesError(t *testing.T) {
 
 func TestServiceListTabular(t *testing.T) {
 	t.Parallel()
-	resp := decodeFixture(t)
+	resp := testutil.DecodeFixture(t, "account/get_server_information_response_success.xml")
 	list, _ := server.DecodeServices(resp.Body.ReturnInfo)
 	rows := list.TableRows()
 	if len(rows) != 8 {

--- a/internal/soap/soap_test.go
+++ b/internal/soap/soap_test.go
@@ -5,31 +5,12 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
 
 	"github.com/chmmou/kasapi-cli/internal/soap"
+	"github.com/chmmou/kasapi-cli/internal/testutil"
 )
-
-func repoRoot(t *testing.T) string {
-	t.Helper()
-	_, file, _, ok := runtime.Caller(0)
-	if !ok {
-		t.Fatal("runtime.Caller failed")
-	}
-	dir := filepath.Dir(file)
-	for {
-		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
-			return dir
-		}
-		parent := filepath.Dir(dir)
-		if parent == dir {
-			t.Fatalf("repo root not found from %q", file)
-		}
-		dir = parent
-	}
-}
 
 func isFaultEnvelope(t *testing.T, path string) bool {
 	t.Helper()
@@ -55,7 +36,7 @@ func decodeFile(t *testing.T, path string) (*soap.Response, error) {
 // by content: fixtures that contain SOAP-ENV:Fault must produce a
 // *FaultError; everything else must decode into a populated Response.
 func TestDecodeAllResponseFixtures(t *testing.T) {
-	root := filepath.Join(repoRoot(t), "testdata")
+	root := filepath.Join(testutil.RepoRoot(t), "testdata")
 	sessionPath := filepath.Join(root, "session") + string(filepath.Separator)
 	var paths []string
 	err := filepath.WalkDir(root, func(p string, d os.DirEntry, err error) error {
@@ -82,7 +63,7 @@ func TestDecodeAllResponseFixtures(t *testing.T) {
 		t.Fatal("no response fixtures found")
 	}
 	for _, p := range paths {
-		rel, _ := filepath.Rel(repoRoot(t), p)
+		rel, _ := filepath.Rel(testutil.RepoRoot(t), p)
 		t.Run(rel, func(t *testing.T) {
 			expectFault := isFaultEnvelope(t, p)
 			resp, err := decodeFile(t, p)
@@ -115,7 +96,7 @@ func TestDecodeAllResponseFixtures(t *testing.T) {
 // TestDecodeGetAccountsShape pins the most-used response fixture: it must
 // produce a 4-element array of account maps with the documented columns.
 func TestDecodeGetAccountsShape(t *testing.T) {
-	resp, err := decodeFile(t, filepath.Join(repoRoot(t), "testdata/account/get_accounts_response_success.xml"))
+	resp, err := decodeFile(t, filepath.Join(testutil.RepoRoot(t), "testdata/account/get_accounts_response_success.xml"))
 	if err != nil {
 		t.Fatalf("Decode: %v", err)
 	}
@@ -138,7 +119,7 @@ func TestDecodeGetAccountsShape(t *testing.T) {
 // TestDecodeGetServerInformationShape exercises the array-of-maps shape
 // where ReturnInfo lists installed services.
 func TestDecodeGetServerInformationShape(t *testing.T) {
-	resp, err := decodeFile(t, filepath.Join(repoRoot(t), "testdata/account/get_server_information_response_success.xml"))
+	resp, err := decodeFile(t, filepath.Join(testutil.RepoRoot(t), "testdata/account/get_server_information_response_success.xml"))
 	if err != nil {
 		t.Fatalf("Decode: %v", err)
 	}
@@ -158,7 +139,7 @@ func TestDecodeGetServerInformationShape(t *testing.T) {
 // TestDecodeFaultDetail verifies that fault fixtures expose faultstring and
 // detail correctly.
 func TestDecodeFaultDetail(t *testing.T) {
-	_, err := decodeFile(t, filepath.Join(repoRoot(t), "testdata/response_failed_no_auth.xml"))
+	_, err := decodeFile(t, filepath.Join(testutil.RepoRoot(t), "testdata/response_failed_no_auth.xml"))
 	var fe *soap.FaultError
 	if !errors.As(err, &fe) {
 		t.Fatalf("expected *FaultError, got %v", err)
@@ -175,7 +156,7 @@ func TestDecodeFaultDetail(t *testing.T) {
 // <value SOAP-ENC:arrayType="xsd:ur-type[0]" xsi:type="SOAP-ENC:Array"/>
 // case (empty KasRequestParams in the echoed request).
 func TestDecodeEmptyArray(t *testing.T) {
-	resp, err := decodeFile(t, filepath.Join(repoRoot(t), "testdata/account/get_accounts_response_success.xml"))
+	resp, err := decodeFile(t, filepath.Join(testutil.RepoRoot(t), "testdata/account/get_accounts_response_success.xml"))
 	if err != nil {
 		t.Fatalf("Decode: %v", err)
 	}

--- a/internal/softwareinstall/softwareinstall_test.go
+++ b/internal/softwareinstall/softwareinstall_test.go
@@ -3,66 +3,16 @@ package softwareinstall_test
 import (
 	"context"
 	"errors"
-	"os"
-	"path/filepath"
-	"runtime"
 	"testing"
 
 	"github.com/chmmou/kasapi-cli/internal/soap"
 	"github.com/chmmou/kasapi-cli/internal/softwareinstall"
+	"github.com/chmmou/kasapi-cli/internal/testutil"
 )
-
-func repoRoot(t *testing.T) string {
-	t.Helper()
-	_, file, _, ok := runtime.Caller(0)
-	if !ok {
-		t.Fatal("runtime.Caller failed")
-	}
-	dir := filepath.Dir(file)
-	for {
-		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
-			return dir
-		}
-		parent := filepath.Dir(dir)
-		if parent == dir {
-			t.Fatalf("repo root not found from %q", file)
-		}
-		dir = parent
-	}
-}
-
-func decodeFixture(t *testing.T, name string) *soap.Response {
-	t.Helper()
-	path := filepath.Join(repoRoot(t), "testdata", "softwareinstall", name)
-	f, err := os.Open(path)
-	if err != nil {
-		t.Fatalf("open %s: %v", name, err)
-	}
-	defer func() { _ = f.Close() }()
-	resp, err := soap.Decode(f)
-	if err != nil {
-		t.Fatalf("decode %s: %v", name, err)
-	}
-	return resp
-}
-
-type fakeCaller struct {
-	resp *soap.Response
-	err  error
-
-	gotAction string
-	gotParams map[string]any
-}
-
-func (f *fakeCaller) Call(_ context.Context, action string, params map[string]any) (*soap.Response, error) {
-	f.gotAction = action
-	f.gotParams = params
-	return f.resp, f.err
-}
 
 func TestDecodeSoftwareInstalls(t *testing.T) {
 	t.Parallel()
-	resp := decodeFixture(t, "get_softwareinstalls_response_success.xml")
+	resp := testutil.DecodeFixture(t, "softwareinstall/get_softwareinstalls_response_success.xml")
 	got, err := softwareinstall.DecodeSoftwareInstalls(resp.Body.ReturnInfo)
 	if err != nil {
 		t.Fatalf("DecodeSoftwareInstalls: %v", err)
@@ -103,7 +53,7 @@ func TestDecodeSoftwareInstalls(t *testing.T) {
 
 func TestDecodeSoftwareInstallSingular(t *testing.T) {
 	t.Parallel()
-	resp := decodeFixture(t, "get_softwareinstall_response_success.xml")
+	resp := testutil.DecodeFixture(t, "softwareinstall/get_softwareinstall_response_success.xml")
 	got, err := softwareinstall.DecodeSoftwareInstalls(resp.Body.ReturnInfo)
 	if err != nil {
 		t.Fatalf("DecodeSoftwareInstalls: %v", err)
@@ -125,17 +75,17 @@ func TestDecodeSoftwareInstallSingular(t *testing.T) {
 
 func TestClientList(t *testing.T) {
 	t.Parallel()
-	resp := decodeFixture(t, "get_softwareinstalls_response_success.xml")
-	fc := &fakeCaller{resp: resp}
+	resp := testutil.DecodeFixture(t, "softwareinstall/get_softwareinstalls_response_success.xml")
+	fc := &testutil.FakeCaller{Resp: resp}
 	list, err := softwareinstall.NewClient(fc).List(context.Background())
 	if err != nil {
 		t.Fatalf("List: %v", err)
 	}
-	if fc.gotAction != "get_softwareinstall" {
-		t.Errorf("action = %q, want get_softwareinstall (singular for both)", fc.gotAction)
+	if fc.GotAction != "get_softwareinstall" {
+		t.Errorf("action = %q, want get_softwareinstall (singular for both)", fc.GotAction)
 	}
-	if fc.gotParams != nil {
-		t.Errorf("params = %v, want nil", fc.gotParams)
+	if fc.GotParams != nil {
+		t.Errorf("params = %v, want nil", fc.GotParams)
 	}
 	if len(list) != 22 {
 		t.Errorf("len = %d, want 22", len(list))
@@ -144,17 +94,17 @@ func TestClientList(t *testing.T) {
 
 func TestClientGet(t *testing.T) {
 	t.Parallel()
-	resp := decodeFixture(t, "get_softwareinstall_response_success.xml")
-	fc := &fakeCaller{resp: resp}
+	resp := testutil.DecodeFixture(t, "softwareinstall/get_softwareinstall_response_success.xml")
+	fc := &testutil.FakeCaller{Resp: resp}
 	s, err := softwareinstall.NewClient(fc).Get(context.Background(), "joomla_v6.1.0")
 	if err != nil {
 		t.Fatalf("Get: %v", err)
 	}
-	if fc.gotAction != "get_softwareinstall" {
-		t.Errorf("action = %q", fc.gotAction)
+	if fc.GotAction != "get_softwareinstall" {
+		t.Errorf("action = %q", fc.GotAction)
 	}
-	if got, _ := fc.gotParams["software_id"].(string); got != "joomla_v6.1.0" {
-		t.Errorf("params[software_id] = %v", fc.gotParams["software_id"])
+	if got, _ := fc.GotParams["software_id"].(string); got != "joomla_v6.1.0" {
+		t.Errorf("params[software_id] = %v", fc.GotParams["software_id"])
 	}
 	if s.ID != "joomla_v6.1.0" {
 		t.Errorf("ID = %q", s.ID)
@@ -163,7 +113,7 @@ func TestClientGet(t *testing.T) {
 
 func TestClientGetEmptyID(t *testing.T) {
 	t.Parallel()
-	c := softwareinstall.NewClient(&fakeCaller{})
+	c := softwareinstall.NewClient(&testutil.FakeCaller{})
 	if _, err := c.Get(context.Background(), ""); err == nil {
 		t.Errorf("Get(\"\") err = nil, want validation error")
 	}
@@ -172,7 +122,7 @@ func TestClientGetEmptyID(t *testing.T) {
 func TestClientGetNotFound(t *testing.T) {
 	t.Parallel()
 	resp := &soap.Response{Body: soap.ResponseBody{ReturnInfo: soap.Value{Kind: soap.KindArray}}}
-	c := softwareinstall.NewClient(&fakeCaller{resp: resp})
+	c := softwareinstall.NewClient(&testutil.FakeCaller{Resp: resp})
 	if _, err := c.Get(context.Background(), "nope_v0.0"); err == nil {
 		t.Errorf("Get on empty result err = nil, want not-found")
 	}
@@ -181,7 +131,7 @@ func TestClientGetNotFound(t *testing.T) {
 func TestClientPropagatesError(t *testing.T) {
 	t.Parallel()
 	want := errors.New("boom")
-	c := softwareinstall.NewClient(&fakeCaller{err: want})
+	c := softwareinstall.NewClient(&testutil.FakeCaller{Err: want})
 	if _, err := c.List(context.Background()); !errors.Is(err, want) {
 		t.Errorf("List err = %v, want %v wrapped", err, want)
 	}
@@ -192,7 +142,7 @@ func TestClientPropagatesError(t *testing.T) {
 
 func TestSoftwareInstallListTabular(t *testing.T) {
 	t.Parallel()
-	resp := decodeFixture(t, "get_softwareinstalls_response_success.xml")
+	resp := testutil.DecodeFixture(t, "softwareinstall/get_softwareinstalls_response_success.xml")
 	list, _ := softwareinstall.DecodeSoftwareInstalls(resp.Body.ReturnInfo)
 	headers := list.TableHeaders()
 	if headers[0] != "ID" {
@@ -217,7 +167,7 @@ func TestSoftwareInstallListTabular(t *testing.T) {
 
 func TestSoftwareInstallTabular(t *testing.T) {
 	t.Parallel()
-	resp := decodeFixture(t, "get_softwareinstall_response_success.xml")
+	resp := testutil.DecodeFixture(t, "softwareinstall/get_softwareinstall_response_success.xml")
 	list, _ := softwareinstall.DecodeSoftwareInstalls(resp.Body.ReturnInfo)
 	if len(list) != 1 {
 		t.Fatalf("len = %d, want 1", len(list))

--- a/internal/subdomain/subdomain_test.go
+++ b/internal/subdomain/subdomain_test.go
@@ -3,66 +3,16 @@ package subdomain_test
 import (
 	"context"
 	"errors"
-	"os"
-	"path/filepath"
-	"runtime"
 	"testing"
 
 	"github.com/chmmou/kasapi-cli/internal/soap"
 	"github.com/chmmou/kasapi-cli/internal/subdomain"
+	"github.com/chmmou/kasapi-cli/internal/testutil"
 )
-
-func repoRoot(t *testing.T) string {
-	t.Helper()
-	_, file, _, ok := runtime.Caller(0)
-	if !ok {
-		t.Fatal("runtime.Caller failed")
-	}
-	dir := filepath.Dir(file)
-	for {
-		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
-			return dir
-		}
-		parent := filepath.Dir(dir)
-		if parent == dir {
-			t.Fatalf("repo root not found from %q", file)
-		}
-		dir = parent
-	}
-}
-
-func decodeFixture(t *testing.T, name string) *soap.Response {
-	t.Helper()
-	path := filepath.Join(repoRoot(t), "testdata", "subdomain", name)
-	f, err := os.Open(path)
-	if err != nil {
-		t.Fatalf("open %s: %v", name, err)
-	}
-	defer func() { _ = f.Close() }()
-	resp, err := soap.Decode(f)
-	if err != nil {
-		t.Fatalf("decode %s: %v", name, err)
-	}
-	return resp
-}
-
-type fakeCaller struct {
-	resp *soap.Response
-	err  error
-
-	gotAction string
-	gotParams map[string]any
-}
-
-func (f *fakeCaller) Call(_ context.Context, action string, params map[string]any) (*soap.Response, error) {
-	f.gotAction = action
-	f.gotParams = params
-	return f.resp, f.err
-}
 
 func TestDecodeSubdomains(t *testing.T) {
 	t.Parallel()
-	resp := decodeFixture(t, "get_subdomains_response_success.xml")
+	resp := testutil.DecodeFixture(t, "subdomain/get_subdomains_response_success.xml")
 	got, err := subdomain.DecodeSubdomains(resp.Body.ReturnInfo)
 	if err != nil {
 		t.Fatalf("DecodeSubdomains: %v", err)
@@ -87,17 +37,17 @@ func TestDecodeSubdomains(t *testing.T) {
 
 func TestClientList(t *testing.T) {
 	t.Parallel()
-	resp := decodeFixture(t, "get_subdomains_response_success.xml")
-	fc := &fakeCaller{resp: resp}
+	resp := testutil.DecodeFixture(t, "subdomain/get_subdomains_response_success.xml")
+	fc := &testutil.FakeCaller{Resp: resp}
 	list, err := subdomain.NewClient(fc).List(context.Background())
 	if err != nil {
 		t.Fatalf("List: %v", err)
 	}
-	if fc.gotAction != "get_subdomains" {
-		t.Errorf("action = %q, want get_subdomains", fc.gotAction)
+	if fc.GotAction != "get_subdomains" {
+		t.Errorf("action = %q, want get_subdomains", fc.GotAction)
 	}
-	if fc.gotParams != nil {
-		t.Errorf("params = %v, want nil", fc.gotParams)
+	if fc.GotParams != nil {
+		t.Errorf("params = %v, want nil", fc.GotParams)
 	}
 	if len(list) != 2 {
 		t.Errorf("len = %d, want 2", len(list))
@@ -106,17 +56,17 @@ func TestClientList(t *testing.T) {
 
 func TestClientGet(t *testing.T) {
 	t.Parallel()
-	resp := decodeFixture(t, "get_subdomains_response_success.xml")
-	fc := &fakeCaller{resp: resp}
+	resp := testutil.DecodeFixture(t, "subdomain/get_subdomains_response_success.xml")
+	fc := &testutil.FakeCaller{Resp: resp}
 	s, err := subdomain.NewClient(fc).Get(context.Background(), "sub1.example.com")
 	if err != nil {
 		t.Fatalf("Get: %v", err)
 	}
-	if fc.gotAction != "get_subdomains" {
-		t.Errorf("action = %q, want get_subdomains", fc.gotAction)
+	if fc.GotAction != "get_subdomains" {
+		t.Errorf("action = %q, want get_subdomains", fc.GotAction)
 	}
-	if name, _ := fc.gotParams["subdomain_name"].(string); name != "sub1.example.com" {
-		t.Errorf("params[subdomain_name] = %v, want sub1.example.com", fc.gotParams["subdomain_name"])
+	if name, _ := fc.GotParams["subdomain_name"].(string); name != "sub1.example.com" {
+		t.Errorf("params[subdomain_name] = %v, want sub1.example.com", fc.GotParams["subdomain_name"])
 	}
 	// The fixture is the list-view payload; Get unwraps the first entry.
 	if s.Name != "sub1.example.com" {
@@ -126,7 +76,7 @@ func TestClientGet(t *testing.T) {
 
 func TestClientGetEmptyName(t *testing.T) {
 	t.Parallel()
-	c := subdomain.NewClient(&fakeCaller{})
+	c := subdomain.NewClient(&testutil.FakeCaller{})
 	if _, err := c.Get(context.Background(), ""); err == nil {
 		t.Errorf("Get(\"\") err = nil, want validation error")
 	}
@@ -135,7 +85,7 @@ func TestClientGetEmptyName(t *testing.T) {
 func TestClientGetNotFound(t *testing.T) {
 	t.Parallel()
 	resp := &soap.Response{Body: soap.ResponseBody{ReturnInfo: soap.Value{Kind: soap.KindArray}}}
-	c := subdomain.NewClient(&fakeCaller{resp: resp})
+	c := subdomain.NewClient(&testutil.FakeCaller{Resp: resp})
 	if _, err := c.Get(context.Background(), "missing.example.com"); err == nil {
 		t.Errorf("Get on empty result err = nil, want not-found")
 	}
@@ -144,7 +94,7 @@ func TestClientGetNotFound(t *testing.T) {
 func TestClientPropagatesError(t *testing.T) {
 	t.Parallel()
 	want := errors.New("boom")
-	c := subdomain.NewClient(&fakeCaller{err: want})
+	c := subdomain.NewClient(&testutil.FakeCaller{Err: want})
 	if _, err := c.List(context.Background()); !errors.Is(err, want) {
 		t.Errorf("List err = %v, want %v wrapped", err, want)
 	}
@@ -155,7 +105,7 @@ func TestClientPropagatesError(t *testing.T) {
 
 func TestSubdomainTabularKeyValue(t *testing.T) {
 	t.Parallel()
-	resp := decodeFixture(t, "get_subdomains_response_success.xml")
+	resp := testutil.DecodeFixture(t, "subdomain/get_subdomains_response_success.xml")
 	list, _ := subdomain.DecodeSubdomains(resp.Body.ReturnInfo)
 	if len(list) == 0 {
 		t.Fatal("fixture empty")
@@ -178,7 +128,7 @@ func TestSubdomainTabularKeyValue(t *testing.T) {
 
 func TestSubdomainListTabular(t *testing.T) {
 	t.Parallel()
-	resp := decodeFixture(t, "get_subdomains_response_success.xml")
+	resp := testutil.DecodeFixture(t, "subdomain/get_subdomains_response_success.xml")
 	list, _ := subdomain.DecodeSubdomains(resp.Body.ReturnInfo)
 	rows := list.TableRows()
 	if len(rows) != 2 {

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -1,0 +1,77 @@
+// Package testutil provides shared helpers used by tests across the
+// internal/ packages: repository-root discovery, SOAP fixture loading,
+// and a fake Caller stub for module Client tests.
+//
+// All helpers depend only on the testing package and on internal/soap,
+// so any external test package (package <pkg>_test) under internal/ can
+// import this package without creating a cycle.
+package testutil
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/chmmou/kasapi-cli/internal/soap"
+)
+
+// RepoRoot returns the absolute path to the repository root by climbing
+// from this file's location until a go.mod is found. Tests use it to
+// resolve fixtures under the repo-level testdata/ directory.
+func RepoRoot(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	dir := filepath.Dir(file)
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatalf("repo root not found from %q", file)
+		}
+		dir = parent
+	}
+}
+
+// DecodeFixture opens testdata/<relPath> and decodes the SOAP envelope.
+// relPath is forward-slash separated relative to the repo's testdata/
+// directory (e.g. "mailinglist/get_mailinglists_response_success.xml").
+func DecodeFixture(t *testing.T, relPath string) *soap.Response {
+	t.Helper()
+	path := filepath.Join(RepoRoot(t), "testdata", filepath.FromSlash(relPath))
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open %s: %v", relPath, err)
+	}
+	defer func() { _ = f.Close() }()
+	resp, err := soap.Decode(f)
+	if err != nil {
+		t.Fatalf("decode %s: %v", relPath, err)
+	}
+	return resp
+}
+
+// FakeCaller is a minimal stub for the Caller interface implemented by
+// every internal/<module>.Client. It returns the configured Resp/Err
+// verbatim and records the most recent action and params for assertions.
+type FakeCaller struct {
+	Resp *soap.Response
+	Err  error
+
+	GotAction string
+	GotParams map[string]any
+}
+
+// Call satisfies the per-module Caller interface (Call(ctx, action,
+// params) (*soap.Response, error)).
+func (f *FakeCaller) Call(_ context.Context, action string, params map[string]any) (*soap.Response, error) {
+	f.GotAction = action
+	f.GotParams = params
+	return f.Resp, f.Err
+}

--- a/internal/usage/usage_test.go
+++ b/internal/usage/usage_test.go
@@ -3,66 +3,15 @@ package usage_test
 import (
 	"context"
 	"errors"
-	"os"
-	"path/filepath"
-	"runtime"
 	"testing"
 
-	"github.com/chmmou/kasapi-cli/internal/soap"
+	"github.com/chmmou/kasapi-cli/internal/testutil"
 	"github.com/chmmou/kasapi-cli/internal/usage"
 )
 
-func repoRoot(t *testing.T) string {
-	t.Helper()
-	_, file, _, ok := runtime.Caller(0)
-	if !ok {
-		t.Fatal("runtime.Caller failed")
-	}
-	dir := filepath.Dir(file)
-	for {
-		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
-			return dir
-		}
-		parent := filepath.Dir(dir)
-		if parent == dir {
-			t.Fatalf("repo root not found from %q", file)
-		}
-		dir = parent
-	}
-}
-
-func decodeFixture(t *testing.T, name string) *soap.Response {
-	t.Helper()
-	path := filepath.Join(repoRoot(t), "testdata", "statistic", name)
-	f, err := os.Open(path)
-	if err != nil {
-		t.Fatalf("open %s: %v", name, err)
-	}
-	defer func() { _ = f.Close() }()
-	resp, err := soap.Decode(f)
-	if err != nil {
-		t.Fatalf("decode %s: %v", name, err)
-	}
-	return resp
-}
-
-type fakeCaller struct {
-	resp *soap.Response
-	err  error
-
-	gotAction string
-	gotParams map[string]any
-}
-
-func (f *fakeCaller) Call(_ context.Context, action string, params map[string]any) (*soap.Response, error) {
-	f.gotAction = action
-	f.gotParams = params
-	return f.resp, f.err
-}
-
 func TestDecodeSpace(t *testing.T) {
 	t.Parallel()
-	resp := decodeFixture(t, "get_space_response_success.xml")
+	resp := testutil.DecodeFixture(t, "statistic/get_space_response_success.xml")
 	got, err := usage.DecodeSpace(resp.Body.ReturnInfo)
 	if err != nil {
 		t.Fatalf("DecodeSpace: %v", err)
@@ -89,7 +38,7 @@ func TestDecodeSpace(t *testing.T) {
 
 func TestDecodeSpaceUsage(t *testing.T) {
 	t.Parallel()
-	resp := decodeFixture(t, "get_space_usage_response_success.xml")
+	resp := testutil.DecodeFixture(t, "statistic/get_space_usage_response_success.xml")
 	got, err := usage.DecodeSpaceUsage(resp.Body.ReturnInfo)
 	if err != nil {
 		t.Fatalf("DecodeSpaceUsage: %v", err)
@@ -115,7 +64,7 @@ func TestDecodeSpaceUsage(t *testing.T) {
 
 func TestDecodeTraffic(t *testing.T) {
 	t.Parallel()
-	resp := decodeFixture(t, "get_traffic_response_success.xml")
+	resp := testutil.DecodeFixture(t, "statistic/get_traffic_response_success.xml")
 	got, err := usage.DecodeTraffic(resp.Body.ReturnInfo)
 	if err != nil {
 		t.Fatalf("DecodeTraffic: %v", err)
@@ -155,17 +104,17 @@ func TestDecodeTraffic(t *testing.T) {
 
 func TestClientSpace(t *testing.T) {
 	t.Parallel()
-	resp := decodeFixture(t, "get_space_response_success.xml")
-	fc := &fakeCaller{resp: resp}
+	resp := testutil.DecodeFixture(t, "statistic/get_space_response_success.xml")
+	fc := &testutil.FakeCaller{Resp: resp}
 	list, err := usage.NewClient(fc).Space(context.Background())
 	if err != nil {
 		t.Fatalf("Space: %v", err)
 	}
-	if fc.gotAction != "get_space" {
-		t.Errorf("action = %q, want get_space", fc.gotAction)
+	if fc.GotAction != "get_space" {
+		t.Errorf("action = %q, want get_space", fc.GotAction)
 	}
-	if fc.gotParams != nil {
-		t.Errorf("params = %v, want nil", fc.gotParams)
+	if fc.GotParams != nil {
+		t.Errorf("params = %v, want nil", fc.GotParams)
 	}
 	if len(list) != 5 {
 		t.Errorf("len = %d, want 5", len(list))
@@ -174,63 +123,63 @@ func TestClientSpace(t *testing.T) {
 
 func TestClientSpaceUsageWithDirectory(t *testing.T) {
 	t.Parallel()
-	resp := decodeFixture(t, "get_space_usage_response_success.xml")
-	fc := &fakeCaller{resp: resp}
+	resp := testutil.DecodeFixture(t, "statistic/get_space_usage_response_success.xml")
+	fc := &testutil.FakeCaller{Resp: resp}
 	_, err := usage.NewClient(fc).SpaceUsage(context.Background(), "/htdocs")
 	if err != nil {
 		t.Fatalf("SpaceUsage: %v", err)
 	}
-	if fc.gotAction != "get_space_usage" {
-		t.Errorf("action = %q, want get_space_usage", fc.gotAction)
+	if fc.GotAction != "get_space_usage" {
+		t.Errorf("action = %q, want get_space_usage", fc.GotAction)
 	}
-	if dir, ok := fc.gotParams["directory"].(string); !ok || dir != "/htdocs" {
-		t.Errorf("params[directory] = %v, want /htdocs", fc.gotParams["directory"])
+	if dir, ok := fc.GotParams["directory"].(string); !ok || dir != "/htdocs" {
+		t.Errorf("params[directory] = %v, want /htdocs", fc.GotParams["directory"])
 	}
 }
 
 func TestClientSpaceUsageEmptyDirectoryOmitsParams(t *testing.T) {
 	t.Parallel()
-	resp := decodeFixture(t, "get_space_usage_response_success.xml")
-	fc := &fakeCaller{resp: resp}
+	resp := testutil.DecodeFixture(t, "statistic/get_space_usage_response_success.xml")
+	fc := &testutil.FakeCaller{Resp: resp}
 	if _, err := usage.NewClient(fc).SpaceUsage(context.Background(), ""); err != nil {
 		t.Fatalf("SpaceUsage: %v", err)
 	}
-	if fc.gotParams != nil {
-		t.Errorf("params = %v, want nil for empty directory", fc.gotParams)
+	if fc.GotParams != nil {
+		t.Errorf("params = %v, want nil for empty directory", fc.GotParams)
 	}
 }
 
 func TestClientTrafficZeroOmitsParams(t *testing.T) {
 	t.Parallel()
-	resp := decodeFixture(t, "get_traffic_response_success.xml")
-	fc := &fakeCaller{resp: resp}
+	resp := testutil.DecodeFixture(t, "statistic/get_traffic_response_success.xml")
+	fc := &testutil.FakeCaller{Resp: resp}
 	if _, err := usage.NewClient(fc).Traffic(context.Background(), 0, 0); err != nil {
 		t.Fatalf("Traffic: %v", err)
 	}
-	if fc.gotParams != nil {
-		t.Errorf("params = %v, want nil when year and month are zero", fc.gotParams)
+	if fc.GotParams != nil {
+		t.Errorf("params = %v, want nil when year and month are zero", fc.GotParams)
 	}
 }
 
 func TestClientTrafficWithYearMonthZeroPads(t *testing.T) {
 	t.Parallel()
-	resp := decodeFixture(t, "get_traffic_response_success.xml")
-	fc := &fakeCaller{resp: resp}
+	resp := testutil.DecodeFixture(t, "statistic/get_traffic_response_success.xml")
+	fc := &testutil.FakeCaller{Resp: resp}
 	if _, err := usage.NewClient(fc).Traffic(context.Background(), 2026, 3); err != nil {
 		t.Fatalf("Traffic: %v", err)
 	}
-	if fc.gotParams["year"] != "2026" {
-		t.Errorf("params[year] = %v, want \"2026\"", fc.gotParams["year"])
+	if fc.GotParams["year"] != "2026" {
+		t.Errorf("params[year] = %v, want \"2026\"", fc.GotParams["year"])
 	}
-	if fc.gotParams["month"] != "03" {
-		t.Errorf("params[month] = %v, want \"03\" (zero-padded)", fc.gotParams["month"])
+	if fc.GotParams["month"] != "03" {
+		t.Errorf("params[month] = %v, want \"03\" (zero-padded)", fc.GotParams["month"])
 	}
 }
 
 func TestClientPropagatesError(t *testing.T) {
 	t.Parallel()
 	want := errors.New("boom")
-	c := usage.NewClient(&fakeCaller{err: want})
+	c := usage.NewClient(&testutil.FakeCaller{Err: want})
 	if _, err := c.Space(context.Background()); !errors.Is(err, want) {
 		t.Errorf("Space err = %v, want %v wrapped", err, want)
 	}
@@ -244,7 +193,7 @@ func TestClientPropagatesError(t *testing.T) {
 
 func TestSpaceListTabular(t *testing.T) {
 	t.Parallel()
-	resp := decodeFixture(t, "get_space_response_success.xml")
+	resp := testutil.DecodeFixture(t, "statistic/get_space_response_success.xml")
 	list, _ := usage.DecodeSpace(resp.Body.ReturnInfo)
 	rows := list.TableRows()
 	if len(rows) != 5 {
@@ -257,7 +206,7 @@ func TestSpaceListTabular(t *testing.T) {
 
 func TestSpaceUsageListTabular(t *testing.T) {
 	t.Parallel()
-	resp := decodeFixture(t, "get_space_usage_response_success.xml")
+	resp := testutil.DecodeFixture(t, "statistic/get_space_usage_response_success.xml")
 	list, _ := usage.DecodeSpaceUsage(resp.Body.ReturnInfo)
 	rows := list.TableRows()
 	if len(rows) != 13 {
@@ -273,7 +222,7 @@ func TestSpaceUsageListTabular(t *testing.T) {
 
 func TestTrafficListTabular(t *testing.T) {
 	t.Parallel()
-	resp := decodeFixture(t, "get_traffic_response_success.xml")
+	resp := testutil.DecodeFixture(t, "statistic/get_traffic_response_success.xml")
 	list, _ := usage.DecodeTraffic(resp.Body.ReturnInfo)
 	rows := list.TableRows()
 	if len(rows) != 2 {


### PR DESCRIPTION
## Summary

Each per-module test file carried a private copy of `repoRoot`, `decodeFixture`, and `fakeCaller`. Lift them into a single shared package `internal/testutil` and migrate all 20 test files (17 module suites + `internal/{soap,auth,api}` root-discovery helpers).

`DecodeFixture` now takes a slash-separated path rooted at `testdata/` (e.g. `"mailinglist/get_mailinglists_response_success.xml"`) so the fixture layout is visible at the call site instead of being hidden inside per-module wrappers. `FakeCaller` is exported (`Resp` / `Err` / `GotAction` / `GotParams`) so cross-module test code can construct it directly.

Net effect: ~910 lines of word-for-word boilerplate removed; behaviour unchanged. `go test -race ./...` and `golangci-lint run ./...` are clean.