### PR TITLE
docs: expand README with config, quick start, troubleshooting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -218,7 +218,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `CONTRIBUTING.md`: add explicit pointers to the
   `kasapi-cli-git-workflow` and `kasapi-cli-code-review` skill
   files alongside the existing references to `AGENTS.md` and the
-  `docs/go/` set.
+  `docs/go/` set; absorb the contributor-facing "Repository layout"
+  section that previously lived in `README.md`.
 
 - `internal/testutil`: extract the `repoRoot` / `decodeFixture` /
   `fakeCaller` helpers that every per-module `*_test.go` carried as

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -204,6 +204,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `README.md`: expand with a Configuration section (TOML profile
+  example for both `auth_type=plain` and `auth_type=session`,
+  `KAS_LOGIN`/`KAS_AUTHDATA`/`KAS_AUTHTYPE` env-var reference,
+  flag/env/profile precedence), a Quick start section with the
+  read commands that exist today (`accounts list|get|resources`,
+  `server info`, `--output` formats), and a Troubleshooting section
+  covering `KasFloodDelay`, the `no_auth`/`unknown_session`/
+  `kas_session_invalid` retry behaviour, `--verbose`, and a pointer
+  at the signed-commit / branch-protection rules in `CONTRIBUTING.md`.
+  Closes #14.
+
+- `CONTRIBUTING.md`: add explicit pointers to the
+  `kasapi-cli-git-workflow` and `kasapi-cli-code-review` skill
+  files alongside the existing references to `AGENTS.md` and the
+  `docs/go/` set.
+
 - `internal/testutil`: extract the `repoRoot` / `decodeFixture` /
   `fakeCaller` helpers that every per-module `*_test.go` carried as
   a private copy into a single shared package, and migrate all 20

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,8 @@ Read these before designing changes — do not duplicate their content into new 
 - [`docs/go/STYLE_GUIDE.md`](docs/go/STYLE_GUIDE.md) — Go style.
 - [`docs/go/PATTERNS.md`](docs/go/PATTERNS.md) — recurring patterns (e.g. the per-package `Caller` interface, fixture-backed decoders, `cli.Tabular`).
 - [`docs/go/LINTING.md`](docs/go/LINTING.md) — the CI gate set.
+- [`.claude/skills/kasapi-cli-git-workflow/SKILL.md`](.claude/skills/kasapi-cli-git-workflow/SKILL.md) — git, branch, signed-commit, PR, and FF-push merge mechanics enforced for this project.
+- [`.claude/skills/kasapi-cli-code-review/SKILL.md`](.claude/skills/kasapi-cli-code-review/SKILL.md) — code-review loop (Blocker/Should/Nice classification, re-review cycle).
 
 ## Development setup
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,16 @@ Read these before designing changes — do not duplicate their content into new 
 - [`.claude/skills/kasapi-cli-git-workflow/SKILL.md`](.claude/skills/kasapi-cli-git-workflow/SKILL.md) — git, branch, signed-commit, PR, and FF-push merge mechanics enforced for this project.
 - [`.claude/skills/kasapi-cli-code-review/SKILL.md`](.claude/skills/kasapi-cli-code-review/SKILL.md) — code-review loop (Blocker/Should/Nice classification, re-review cycle).
 
+## Repository layout
+
+- `cmd/kasapi-cli/` — CLI entry point.
+- `internal/` — domain types, transport, mappers, CLI wiring; one package per KAS resource (see `internal/account/`, `internal/domain/`, `internal/dns/`, …) plus shared infrastructure (`internal/soap`, `internal/api`, `internal/auth`, `internal/transport`, `internal/session`, `internal/config`, `internal/cli`).
+- `testdata/` — recorded KAS-API SOAP responses; the source of truth for response shape, used by offline parser tests.
+- `docs/go/` — Go style, architecture, patterns, and linting reference for this repo.
+- `.claude/skills/kasapi-cli-git-workflow/` — git/PR/merge mechanics enforced for this project.
+- `.claude/skills/kasapi-cli-code-review/` — code-review loop (Blocker/Should/Nice classification, re-review cycle).
+- `AGENTS.md`, `CLAUDE.md` — agent guidance.
+
 ## Development setup
 
 Prerequisites:

--- a/README.md
+++ b/README.md
@@ -131,23 +131,9 @@ If you see `no_auth` with `auth_type=plain`, the password in `auth_data` is wron
 
 `--verbose` / `-v` enables logging on stderr, including the resolved credentials (with `auth_data` redacted) and the SOAP action being called. Use it to confirm which profile / env var / flag combination actually took effect.
 
-### Contributing & branch protection
-
-`main` is protected with `required_signatures` + `enforce_admins` + `linear_history`. The GitHub UI / `gh pr merge` strips signatures and is therefore not used for this repo. Contributors only need to keep their commits signed and the branch rebased on `main`; the maintainer performs the signed fast-forward push. See [CONTRIBUTING.md](CONTRIBUTING.md) for the full workflow.
-
-## Repository layout
-
-- `cmd/kasapi-cli/` — CLI entry point.
-- `internal/` — domain types, transport, mappers, CLI wiring; one package per KAS resource (see `internal/account/`, `internal/domain/`, `internal/dns/`, …) plus shared infrastructure (`internal/soap`, `internal/api`, `internal/auth`, `internal/transport`, `internal/session`, `internal/config`, `internal/cli`).
-- `testdata/` — recorded KAS-API SOAP responses; the source of truth for response shape, used by offline parser tests.
-- `docs/go/` — Go style, architecture, patterns, and linting reference for this repo.
-- `.claude/skills/kasapi-cli-git-workflow/` — git/PR/merge mechanics enforced for this project.
-- `.claude/skills/kasapi-cli-code-review/` — code-review loop (Blocker/Should/Nice classification, re-review cycle).
-- `AGENTS.md`, `CLAUDE.md` — agent guidance.
-
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for setup, coding conventions, the vertical-slice pattern used per KAS endpoint, the commit/PR workflow, and the code-review loop.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the repository layout, setup, coding conventions, the vertical-slice pattern used per KAS endpoint, the commit/PR workflow (incl. signed commits and the FF-push merge model required by `main`'s branch protection), and the code-review loop.
 
 ## Roadmap
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,106 @@ go build ./cmd/kasapi-cli
 go test ./...
 ```
 
+## Configuration
+
+`kasapi-cli` resolves credentials in this precedence (highest first):
+
+1. `--login`, `--auth-data`, `--auth-type` flags on the command,
+2. environment variables `KAS_LOGIN`, `KAS_AUTHDATA`, `KAS_AUTHTYPE`,
+3. the active profile from the config file (`--profile <name>` if given, otherwise `default_profile`).
+
+Each field is resolved independently, so a flag can override a single profile field without re-specifying the whole profile.
+
+### Config file
+
+Default location (Linux): `$XDG_CONFIG_HOME/kasapi-cli/config.toml`, falling back to `$HOME/.config/kasapi-cli/config.toml`. macOS and Windows use the equivalent OS-specific config dir. Override with `--config <path>`.
+
+The file is TOML; profiles live under `[profiles.<name>]`. `auth_type` accepts `plain` or `session`.
+
+```toml
+# ~/.config/kasapi-cli/config.toml
+default_profile = "main"
+
+[profiles.main]
+# session: bootstrap a credential token via KasAuth and reuse it for the
+# call sequence. Required for 2FA. Recommended for interactive use.
+login     = "w0000000"
+auth_data = "your-account-password"
+auth_type = "session"
+
+[profiles.scripted]
+# plain: send the password on every KasApi call. No KasAuth round-trip,
+# but no 2FA support either. Useful for one-shot scripted calls.
+login     = "w0000001"
+auth_data = "service-account-password"
+auth_type = "plain"
+```
+
+Pick a non-default profile with `--profile <name>`:
+
+```sh
+kasapi-cli --profile scripted accounts list
+```
+
+### Environment variables
+
+Useful for CI, sandboxes, and `direnv`-style per-directory overrides:
+
+| Variable       | Maps to     | Notes                                  |
+|----------------|-------------|----------------------------------------|
+| `KAS_LOGIN`    | `login`     | KAS account login (`w<digits>`).       |
+| `KAS_AUTHDATA` | `auth_data` | Password or pre-issued session token.  |
+| `KAS_AUTHTYPE` | `auth_type` | `plain` or `session`.                  |
+
+Env vars are consulted only when the matching flag is unset; they override the profile file.
+
+## Quick start
+
+The read surface that exists today covers accounts, server info, domains/subdomains/TLDs, DNS, mail, databases, FTP/Samba users, cronjobs, directory protection, software installs, DDNS users, and usage statistics. A few representative commands:
+
+```sh
+# All accounts visible to the login.
+kasapi-cli accounts list
+
+# A single account by login.
+kasapi-cli accounts get w0000001
+
+# Quota counters for the authenticated account.
+kasapi-cli accounts resources
+
+# Server / hosting information for the account.
+kasapi-cli server info
+```
+
+Output formats are selected with `--output` / `-o`; the default is human-readable. JSON is available everywhere:
+
+```sh
+kasapi-cli accounts list -o json
+kasapi-cli accounts list -o table
+```
+
+For the full subcommand tree run `kasapi-cli --help` (or `<subcommand> --help`).
+
+## Troubleshooting
+
+### `KasFloodDelay` (rate limiting)
+
+Every successful KAS-API response carries a server-side `KasFloodDelay` (typically `0.5` s); the next call from the same login must wait at least that long. `kasapi-cli` honours it transparently — the second of two back-to-back calls will appear to hang for ~500 ms. There is also a server-side `flood_protection` fault that carries no delay value; if you see it repeatedly, slow down the caller (e.g. add a sleep in scripts).
+
+### `no_auth` / `unknown_session` / `kas_session_invalid`
+
+These three faults all mean "your credential token is no longer valid" — typically because the session expired, the server was restarted, or another tool invalidated the token. With `auth_type=session`, `kasapi-cli` invalidates its cached token and retries the call once with fresh credentials, so the user-visible result is just a slightly slower response. If the retry also fails the original fault is returned as a typed error and the command exits non-zero.
+
+If you see `no_auth` with `auth_type=plain`, the password in `auth_data` is wrong — there is no token cache to invalidate, and the call will not be retried.
+
+### `--verbose`
+
+`--verbose` / `-v` enables logging on stderr, including the resolved credentials (with `auth_data` redacted) and the SOAP action being called. Use it to confirm which profile / env var / flag combination actually took effect.
+
+### Contributing & branch protection
+
+`main` is protected with `required_signatures` + `enforce_admins` + `linear_history`. The GitHub UI / `gh pr merge` strips signatures and is therefore not used for this repo. Contributors only need to keep their commits signed and the branch rebased on `main`; the maintainer performs the signed fast-forward push. See [CONTRIBUTING.md](CONTRIBUTING.md) for the full workflow.
+
 ## Repository layout
 
 - `cmd/kasapi-cli/` — CLI entry point.


### PR DESCRIPTION
## Summary

- **README**: add Configuration (TOML profile example for `plain` + `session`, env-var reference, flag/env/profile precedence), Quick start (existing read commands, output formats), and Troubleshooting (`KasFloodDelay`, `no_auth`/`unknown_session`/`kas_session_invalid` retry behaviour, `--verbose`).
- **CONTRIBUTING**: add explicit pointers to the `kasapi-cli-git-workflow` and `kasapi-cli-code-review` skill files alongside the existing `AGENTS.md` / `docs/go/` references.

Closes #14.