### PR TITLE
fix: wire --verbose to a slog logger across api/transport/auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -202,6 +202,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   with the server-side window. Practical effect: rerun a command and
   no `--otp` prompt is needed for as long as the session is alive.
 
+### Fixed
+
+- `--verbose` / `-v` was bound to a `RootOptions` field but never
+  read anywhere; the flag was effectively a no-op. Plumb a
+  `*slog.Logger` (text handler on stderr when verbose, discard
+  otherwise) through `BuildAPIClient` into `transport.Client`,
+  `api.Client`, and `auth.Client`. Events emitted: resolved
+  credentials with `auth_data` redacted (`cli`); SOAP action
+  before each request, auth-failure retry, `flood_protection`
+  fallback gate, applied `KasFloodDelay` (`api`); `KasFloodDelay`
+  gate wait, transient-error retry attempt (`transport`);
+  `KasAuth` bootstrap and credential-token issued with login +
+  token length only (`auth`). Stdout stays clean for `-o json |
+  jq` pipes; logs go to stderr only.
+
 ### Changed
 
 - `README.md`: expand with a Configuration section (TOML profile

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
+	"log/slog"
 	"time"
 
 	"github.com/chmmou/kasapi-cli/internal/soap"
@@ -68,6 +70,12 @@ type Client struct {
 	Transport *transport.Client
 	Tokens    TokenSource
 	Endpoint  string
+
+	// Logger receives verbose-mode trace events: action being called,
+	// auth-failure retry, flood_protection fallback, KasFloodDelay
+	// applied. New() seeds it with a discard logger so callers may
+	// write to it unconditionally.
+	Logger *slog.Logger
 }
 
 // New returns a Client wired with the given transport and token source.
@@ -77,7 +85,15 @@ func New(t *transport.Client, ts TokenSource) *Client {
 		Transport: t,
 		Tokens:    ts,
 		Endpoint:  DefaultEndpoint,
+		Logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
 	}
+}
+
+func (c *Client) logger() *slog.Logger {
+	if c.Logger != nil {
+		return c.Logger
+	}
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
 }
 
 // Call posts one KasApi action with the given parameters and returns
@@ -92,8 +108,10 @@ func (c *Client) Call(ctx context.Context, action string, params map[string]any)
 	if action == "" {
 		return nil, errors.New("api: action is required")
 	}
+	c.logger().Info("api: call", "action", action)
 	resp, err := c.callOnce(ctx, action, params)
 	if err != nil && IsAuthFailure(err) {
+		c.logger().Info("api: auth failure, refreshing token and retrying", "action", action)
 		c.Tokens.Invalidate()
 		resp, err = c.callOnce(ctx, action, params)
 	}
@@ -135,6 +153,8 @@ func (c *Client) callOnce(ctx context.Context, action string, params map[string]
 		if errors.As(err, &fe) {
 			apiErr := newError(action, c.Endpoint, fe)
 			if IsFloodProtection(apiErr) {
+				c.logger().Info("api: flood_protection fault, seeding fallback gate",
+					"action", action, "fallback_ms", floodFallback.Milliseconds())
 				c.Transport.RecordDelay(floodFallback)
 			}
 			return nil, apiErr
@@ -143,6 +163,7 @@ func (c *Client) callOnce(ctx context.Context, action string, params map[string]
 	}
 
 	if d := time.Duration(resp.Body.KasFloodDelay * float64(time.Second)); d > 0 {
+		c.logger().Info("api: KasFloodDelay applied", "action", action, "delay_ms", d.Milliseconds())
 		c.Transport.RecordDelay(d)
 	}
 	return resp, nil

--- a/internal/auth/client.go
+++ b/internal/auth/client.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
+	"log/slog"
 
 	"github.com/chmmou/kasapi-cli/internal/soap"
 	"github.com/chmmou/kasapi-cli/internal/transport"
@@ -36,6 +38,11 @@ type Client struct {
 	AuthType  soap.AuthType
 	Options   Options
 	Endpoint  string
+
+	// Logger receives verbose-mode trace events around the KasAuth
+	// bootstrap. New() seeds it with a discard logger so callers may
+	// write to it unconditionally.
+	Logger *slog.Logger
 }
 
 // New returns a Client configured for the given credentials and options.
@@ -48,7 +55,15 @@ func New(t *transport.Client, login, authData string, authType soap.AuthType, op
 		AuthType:  authType,
 		Options:   opts,
 		Endpoint:  DefaultEndpoint,
+		Logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
 	}
+}
+
+func (c *Client) logger() *slog.Logger {
+	if c.Logger != nil {
+		return c.Logger
+	}
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
 }
 
 // GetCredentialToken posts the KasAuth request and returns the
@@ -58,6 +73,8 @@ func (c *Client) GetCredentialToken(ctx context.Context) (string, error) {
 	if c.Login == "" || c.AuthData == "" || c.AuthType == "" {
 		return "", errors.New("auth: Client has empty credential fields")
 	}
+	c.logger().Info("auth: KasAuth bootstrap",
+		"login", c.Login, "auth_type", c.AuthType, "lifetime", c.Options.Lifetime, "otp", c.Options.OTP != "")
 	var buf bytes.Buffer
 	req := Request{
 		Login:          c.Login,
@@ -82,5 +99,6 @@ func (c *Client) GetCredentialToken(ctx context.Context) (string, error) {
 		}
 		return "", fmt.Errorf("auth: decode: %w", err)
 	}
+	c.logger().Info("auth: credential token issued", "login", c.Login, "token_length", len(token))
 	return token, nil
 }

--- a/internal/cli/wire.go
+++ b/internal/cli/wire.go
@@ -3,6 +3,9 @@ package cli
 import (
 	"errors"
 	"fmt"
+	"io"
+	"log/slog"
+	"os"
 	"time"
 
 	"github.com/chmmou/kasapi-cli/internal/api"
@@ -34,6 +37,8 @@ func BuildAPIClient(opts *RootOptions) (*api.Client, error) {
 		return nil, UserError(errors.New("nil RootOptions"), "cli")
 	}
 
+	logger := buildLogger(opts.Verbose)
+
 	cfg, err := config.Load(opts.ConfigPath)
 	if err != nil && !errors.Is(err, config.ErrNoConfig) {
 		return nil, UserError(err, "load config")
@@ -47,18 +52,34 @@ func BuildAPIClient(opts *RootOptions) (*api.Client, error) {
 	if err != nil {
 		return nil, UserError(err, "")
 	}
+	logger.Info("cli: credentials resolved",
+		"login", creds.Login, "auth_type", creds.AuthType, "auth_data", "<redacted>")
 
 	tr := transport.New()
+	tr.Logger = logger
 	ts, err := tokenSource(tr, creds, sessionOpts{
 		ConfigPath:     opts.ConfigPath,
 		OTP:            opts.OTP,
 		Lifetime:       opts.SessionLifetime,
 		UpdateLifetime: opts.SessionUpdateLifetime,
-	})
+	}, logger)
 	if err != nil {
 		return nil, UserError(err, "")
 	}
-	return api.New(tr, ts), nil
+	c := api.New(tr, ts)
+	c.Logger = logger
+	return c, nil
+}
+
+// buildLogger returns a stderr text-handler logger when verbose is set,
+// otherwise a discard logger. Subcommands obtain a logger via this
+// helper so the same instance can be plumbed into transport, api, and
+// auth without each package having to consult --verbose itself.
+func buildLogger(verbose bool) *slog.Logger {
+	if verbose {
+		return slog.New(slog.NewTextHandler(os.Stderr, nil))
+	}
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
 }
 
 // sessionOpts groups the KasAuth-only flag values plumbed through to
@@ -76,7 +97,7 @@ func (s sessionOpts) any() bool {
 	return s.OTP != "" || s.Lifetime != 0 || s.UpdateLifetime != ""
 }
 
-func tokenSource(tr *transport.Client, creds config.Credentials, s sessionOpts) (api.TokenSource, error) {
+func tokenSource(tr *transport.Client, creds config.Credentials, s sessionOpts, logger *slog.Logger) (api.TokenSource, error) {
 	switch creds.AuthType {
 	case config.AuthPlain:
 		if s.any() {
@@ -96,6 +117,7 @@ func tokenSource(tr *transport.Client, creds config.Credentials, s sessionOpts) 
 			return nil, err
 		}
 		authClient := auth.New(tr, creds.Login, creds.AuthData, soap.AuthPlain, authOpts)
+		authClient.Logger = logger
 		src := auth.NewSessionTokenSource(authClient)
 		storePath, serr := session.PathFor(s.ConfigPath)
 		if serr != nil {

--- a/internal/transport/client.go
+++ b/internal/transport/client.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"sync"
 	"time"
@@ -34,6 +35,11 @@ type Client struct {
 	UserAgent  string
 	MaxRetries int
 
+	// Logger receives verbose-mode trace events: gate waits, retries.
+	// New() seeds it with a discard logger so callers may write to it
+	// unconditionally; cli wires --verbose to a stderr handler.
+	Logger *slog.Logger
+
 	// Now and Sleep are overridable for tests so retry/flood-delay
 	// timing can be asserted without real wall-clock waits.
 	Now   func() time.Time
@@ -50,9 +56,14 @@ func New() *Client {
 		HTTPClient: &http.Client{Timeout: DefaultTimeout},
 		UserAgent:  DefaultUserAgent,
 		MaxRetries: DefaultMaxRetries,
+		Logger:     discardLogger(),
 		Now:        time.Now,
 		Sleep:      ctxSleep,
 	}
+}
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
 }
 
 // RecordDelay schedules a window during which subsequent calls to Do
@@ -81,6 +92,8 @@ func (c *Client) Do(ctx context.Context, endpoint string, body []byte) ([]byte, 
 	var lastErr error
 	for attempt := 0; attempt <= c.MaxRetries; attempt++ {
 		if attempt > 0 {
+			c.logger().Info("transport: retry after transient failure",
+				"attempt", attempt, "max", c.MaxRetries, "backoff_ms", backoff.Milliseconds())
 			if err := c.Sleep(ctx, backoff); err != nil {
 				return nil, err
 			}
@@ -109,7 +122,15 @@ func (c *Client) waitGate(ctx context.Context) error {
 	if wait <= 0 {
 		return nil
 	}
+	c.logger().Info("transport: waiting for KasFloodDelay gate", "wait_ms", wait.Milliseconds())
 	return c.Sleep(ctx, wait)
+}
+
+func (c *Client) logger() *slog.Logger {
+	if c.Logger != nil {
+		return c.Logger
+	}
+	return discardLogger()
 }
 
 func (c *Client) doOnce(ctx context.Context, endpoint string, body []byte) ([]byte, error) {


### PR DESCRIPTION
## Summary

`--verbose` / `-v` was bound to `RootOptions.Verbose` but never read anywhere — the flag was a no-op despite the README and the flag help text promising stderr logging.

Plumb a `*slog.Logger` (stderr text handler when verbose, discard handler otherwise) through `BuildAPIClient` into `transport.Client`, `api.Client`, and `auth.Client`, and emit events at the points the README documents:

- **cli**: credentials resolved (`login`, `auth_type`; `auth_data` redacted)
- **api**: call action; auth-failure retry; `flood_protection` fallback gate seeded; applied `KasFloodDelay`
- **transport**: `KasFloodDelay` gate wait; transient-error retry attempt
- **auth**: `KasAuth` bootstrap; credential-token issued (login + token length only)

Stdout stays clean for `-o json | jq` pipes; logs go to stderr only. Verified live against an active session.