### PR TITLE
chore(ci): add docs-sync job that fails on stale docs/cli/

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,3 +45,29 @@ jobs:
 
       - name: build
         run: go build ./cmd/kasapi-cli
+
+  docs-sync:
+    name: docs sync
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.23"
+          cache: true
+
+      # Regenerate docs/cli/ from the live command tree and fail if the
+      # checked-in copy drifted from what `make docs` produces. Ensures
+      # any flag, subcommand, or short/long-description change comes
+      # paired with a docs/cli/ refresh.
+      - name: regenerate docs/cli/
+        run: make docs
+
+      - name: verify docs/cli/ is up to date
+        run: |
+          if ! git diff --exit-code -- docs/cli; then
+            echo
+            echo "docs/cli/ is out of date — run 'make docs' locally and commit the result."
+            exit 1
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- CI job `docs sync` (`.github/workflows/ci.yml`) that runs
+  `make docs` and fails when the checked-in `docs/cli/` differs
+  from the regenerated output. Ensures any change to a flag,
+  subcommand registration, or short/long description comes paired
+  with a `docs/cli/` refresh.
+
 - Per-resource usage docs under `docs/usage/` (eight pages — `accounts`,
   `server`, `domains`, `dns`, `mail`, `databases`, `usage`, `hosting` —
   plus an index `README.md`). Each page lists the most common


### PR DESCRIPTION
## Summary

A new \`docs sync\` job runs \`make docs\` and \`git diff --exit-code -- docs/cli\` on every push and pull request. The check fails when the checked-in \`docs/cli/\` tree differs from what regenerating the hidden \`kasapi-cli gen-docs\` subcommand would produce, so any flag, subcommand registration, or short/long-description change comes paired with a \`docs/cli/\` refresh.

The job runs in parallel to \`lint & test\` so a docs miss surfaces as its own status check rather than blocking test feedback.