### PR TITLE
fix(docs): correct KAS-API links + invented function names in docs/usage/

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -230,6 +230,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `docs/usage/`: replace 404 KAS-API anchor URL
+  (`packages/API%20Functions.html`, used as a generic placeholder
+  in every page) with per-function `files/<kas_action>-inc.html`
+  URLs. Five referenced KAS actions did not exist — replace with
+  the canonical names captured in `testdata/`: `get_accountusage`
+  → `get_space`, `get_accountusagedetail` → `get_space_usage`,
+  `get_accounttraffic` → `get_traffic`, `get_tlds` →
+  `get_topleveldomains`, `get_mailfilter` →
+  `get_mailstandardfilter`. All 24 external doc links in the
+  user-facing markdown set now resolve to HTTP 200.
+
 - `--verbose` / `-v` was bound to a `RootOptions` field but never
   read anywhere; the flag was effectively a no-op. Plumb a
   `*slog.Logger` (text handler on stderr when verbose, discard

--- a/docs/usage/accounts.md
+++ b/docs/usage/accounts.md
@@ -2,7 +2,7 @@
 
 Inspect KAS accounts visible to the authenticated login.
 
-KAS API: [`get_accounts`](https://kasapi.kasserver.com/dokumentation/phpdoc/packages/API%20Functions.html), [`get_accountsettings`](https://kasapi.kasserver.com/dokumentation/phpdoc/packages/API%20Functions.html), [`get_accountresources`](https://kasapi.kasserver.com/dokumentation/phpdoc/packages/API%20Functions.html).
+KAS API: [`get_accounts`](https://kasapi.kasserver.com/dokumentation/phpdoc/files/get-accounts-inc.html), [`get_accountsettings`](https://kasapi.kasserver.com/dokumentation/phpdoc/files/get-accountsettings-inc.html), [`get_accountresources`](https://kasapi.kasserver.com/dokumentation/phpdoc/files/get-accountresources-inc.html).
 
 ## List accounts
 

--- a/docs/usage/databases.md
+++ b/docs/usage/databases.md
@@ -2,7 +2,7 @@
 
 Inspect MariaDB / MySQL databases visible to the login.
 
-KAS API: [`get_databases`](https://kasapi.kasserver.com/dokumentation/phpdoc/packages/API%20Functions.html).
+KAS API: [`get_databases`](https://kasapi.kasserver.com/dokumentation/phpdoc/files/get-databases-inc.html).
 
 ## List databases
 

--- a/docs/usage/dns.md
+++ b/docs/usage/dns.md
@@ -2,7 +2,7 @@
 
 List DNS records for a single zone.
 
-KAS API: [`get_dns_settings`](https://kasapi.kasserver.com/dokumentation/phpdoc/packages/API%20Functions.html).
+KAS API: [`get_dns_settings`](https://kasapi.kasserver.com/dokumentation/phpdoc/files/get-dns-settings-inc.html).
 
 ## List records
 

--- a/docs/usage/domains.md
+++ b/docs/usage/domains.md
@@ -2,7 +2,7 @@
 
 Inspect domains, subdomains, and the catalog of registrable top-level domains.
 
-KAS API: [`get_domains`](https://kasapi.kasserver.com/dokumentation/phpdoc/packages/API%20Functions.html), [`get_subdomains`](https://kasapi.kasserver.com/dokumentation/phpdoc/packages/API%20Functions.html), [`get_tlds`](https://kasapi.kasserver.com/dokumentation/phpdoc/packages/API%20Functions.html).
+KAS API: [`get_domains`](https://kasapi.kasserver.com/dokumentation/phpdoc/files/get-domains-inc.html), [`get_subdomains`](https://kasapi.kasserver.com/dokumentation/phpdoc/files/get-subdomains-inc.html), [`get_topleveldomains`](https://kasapi.kasserver.com/dokumentation/phpdoc/files/get-topleveldomains-inc.html).
 
 ## List domains
 
@@ -35,7 +35,7 @@ kasapi-cli subdomains get www.example.com -o json
 
 ## Registrable TLDs
 
-`tlds list` calls `get_tlds` and returns the catalog of TLDs the All-Inkl registrar can register, with their per-year price and whether they support transfer / DNSSEC.
+`tlds list` calls `get_topleveldomains` and returns the catalog of TLDs the All-Inkl registrar can register, with their per-year price and whether they support transfer / DNSSEC.
 
 ```sh
 kasapi-cli tlds list -o json | jq '.[] | select(.tld_dnssec_supported == "Y") | .tld_name'

--- a/docs/usage/hosting.md
+++ b/docs/usage/hosting.md
@@ -2,7 +2,7 @@
 
 Read-only inspection of the various hosting features that hang off an All-Inkl webspace: FTP / Samba users, cronjobs, directory protection, software installs, and DDNS users. Grouped because they share the same shape (one resource type per top-level command, almost always with `list` + `get`).
 
-KAS API: [`get_ftpuser`](https://kasapi.kasserver.com/dokumentation/phpdoc/packages/API%20Functions.html), [`get_sambauser`](https://kasapi.kasserver.com/dokumentation/phpdoc/packages/API%20Functions.html), [`get_cronjobs`](https://kasapi.kasserver.com/dokumentation/phpdoc/packages/API%20Functions.html), [`get_directoryprotection`](https://kasapi.kasserver.com/dokumentation/phpdoc/packages/API%20Functions.html), [`get_softwareinstall`](https://kasapi.kasserver.com/dokumentation/phpdoc/packages/API%20Functions.html), [`get_ddnsusers`](https://kasapi.kasserver.com/dokumentation/phpdoc/packages/API%20Functions.html).
+KAS API: [`get_ftpusers`](https://kasapi.kasserver.com/dokumentation/phpdoc/files/get-ftpusers-inc.html), [`get_sambausers`](https://kasapi.kasserver.com/dokumentation/phpdoc/files/get-sambausers-inc.html), [`get_cronjobs`](https://kasapi.kasserver.com/dokumentation/phpdoc/files/get-cronjobs-inc.html), [`get_directoryprotection`](https://kasapi.kasserver.com/dokumentation/phpdoc/files/get-directoryprotection-inc.html), [`get_softwareinstall`](https://kasapi.kasserver.com/dokumentation/phpdoc/files/get-softwareinstall-inc.html), [`get_ddnsusers`](https://kasapi.kasserver.com/dokumentation/phpdoc/files/get-ddnsusers-inc.html).
 
 ## FTP users
 

--- a/docs/usage/mail.md
+++ b/docs/usage/mail.md
@@ -2,7 +2,7 @@
 
 Inspect mail accounts, forwards, filters, and mailing lists.
 
-KAS API: [`get_mailaccounts`](https://kasapi.kasserver.com/dokumentation/phpdoc/packages/API%20Functions.html), [`get_mailforwards`](https://kasapi.kasserver.com/dokumentation/phpdoc/packages/API%20Functions.html), [`get_mailfilter`](https://kasapi.kasserver.com/dokumentation/phpdoc/packages/API%20Functions.html), [`get_mailinglists`](https://kasapi.kasserver.com/dokumentation/phpdoc/packages/API%20Functions.html).
+KAS API: [`get_mailaccounts`](https://kasapi.kasserver.com/dokumentation/phpdoc/files/get-mailaccounts-inc.html), [`get_mailforwards`](https://kasapi.kasserver.com/dokumentation/phpdoc/files/get-mailforwards-inc.html), [`get_mailstandardfilter`](https://kasapi.kasserver.com/dokumentation/phpdoc/files/get-mailstandardfilter-inc.html), [`get_mailinglists`](https://kasapi.kasserver.com/dokumentation/phpdoc/files/get-mailinglists-inc.html).
 
 ## Mail accounts
 
@@ -34,7 +34,7 @@ The `TARGETS` column flattens `mail_forward_target_*` into one comma-joined list
 
 ## Mail filters
 
-`mail filters list` returns the server-side filter rules (Sieve-style: condition + action). The filter view is read-only — write paths are part of the v0.2.0 backlog.
+`mail filters list` calls `get_mailstandardfilter` and returns the server-side filter rules (Sieve-style: condition + action). The filter view is read-only — write paths are part of the v0.2.0 backlog.
 
 ## Mailing lists
 

--- a/docs/usage/server.md
+++ b/docs/usage/server.md
@@ -2,7 +2,7 @@
 
 Inspect the host server `kasapi-cli` is talking to.
 
-KAS API: [`get_server_information`](https://kasapi.kasserver.com/dokumentation/phpdoc/packages/API%20Functions.html).
+KAS API: [`get_server_information`](https://kasapi.kasserver.com/dokumentation/phpdoc/files/get-server-information-inc.html).
 
 ## Server info
 

--- a/docs/usage/usage.md
+++ b/docs/usage/usage.md
@@ -2,11 +2,11 @@
 
 Inspect webspace and traffic counters for the authenticated account.
 
-KAS API: [`get_accountusage`](https://kasapi.kasserver.com/dokumentation/phpdoc/packages/API%20Functions.html), [`get_accountusagedetail`](https://kasapi.kasserver.com/dokumentation/phpdoc/packages/API%20Functions.html), [`get_accounttraffic`](https://kasapi.kasserver.com/dokumentation/phpdoc/packages/API%20Functions.html).
+KAS API: [`get_space`](https://kasapi.kasserver.com/dokumentation/phpdoc/files/get-space-inc.html), [`get_space_usage`](https://kasapi.kasserver.com/dokumentation/phpdoc/files/get-space-usage-inc.html), [`get_traffic`](https://kasapi.kasserver.com/dokumentation/phpdoc/files/get-traffic-inc.html).
 
 ## Webspace summary
 
-`usage space` returns the rolled-up webspace usage (one row per category — mail, databases, www, backup, ...).
+`usage space` calls `get_space` and returns the rolled-up webspace usage (one row per category — mail, databases, www, backup, ...).
 
 ```sh
 kasapi-cli usage space
@@ -22,7 +22,7 @@ backup    62.0     0           0.0
 
 ## Webspace per directory
 
-`usage space-detail` calls `get_accountusagedetail` and returns one row per top-level subdirectory under the webspace root. Useful when the summary shows an unexpected delta and you want to find the responsible directory:
+`usage space-detail` calls `get_space_usage` and returns one row per top-level subdirectory under the webspace root. Useful when the summary shows an unexpected delta and you want to find the responsible directory:
 
 ```sh
 kasapi-cli usage space-detail -o json | jq 'sort_by(-.detail_size_mb)[:10]'
@@ -30,7 +30,7 @@ kasapi-cli usage space-detail -o json | jq 'sort_by(-.detail_size_mb)[:10]'
 
 ## Traffic
 
-`usage traffic` returns the per-day traffic counters for the current billing window. The first row (`Day == 0`) is the rolled-up summary for the whole window — use the `(Traffic).IsSummary()` helper from `internal/usage` if you consume the data programmatically, or filter on `day != 0` in shell:
+`usage traffic` calls `get_traffic` and returns the per-day traffic counters for the current billing window. The first row (`Day == 0`) is the rolled-up summary for the whole window — use the `(Traffic).IsSummary()` helper from `internal/usage` if you consume the data programmatically, or filter on `day != 0` in shell:
 
 ```sh
 kasapi-cli usage traffic -o json | jq '.[] | select(.day != 0)'


### PR DESCRIPTION
## Summary

Two errors slipped into the per-resource pages added in 2847679 (#76):

1. Every page used a generic placeholder URL — `https://kasapi.kasserver.com/dokumentation/phpdoc/packages/API%20Functions.html` — for all KAS API references. That page returns **HTTP 404**. The KAS phpdoc actually exposes one page per function under `files/<kas_action>-inc.html`.

2. Five referenced KAS action names did not exist in the API:

| invented           | canonical (per testdata/) |
|--------------------|---------------------------|
| `get_accountusage` | `get_space`               |
| `get_accountusagedetail` | `get_space_usage`   |
| `get_accounttraffic` | `get_traffic`           |
| `get_tlds`         | `get_topleveldomains`     |
| `get_mailfilter`   | `get_mailstandardfilter`  |

After the fix all 24 external documentation links in the user-facing markdown set resolve to HTTP 200 (verified via `curl -L -o /dev/null -w "%{http_code}"`).