### PR TITLE
chore: add goreleaser release pipeline with cosign signing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,3 +71,15 @@ jobs:
             echo "docs/cli/ is out of date — run 'make docs' locally and commit the result."
             exit 1
           fi
+
+  goreleaser-check:
+    name: goreleaser config check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,43 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write   # create the GitHub Release + upload assets
+  id-token: write   # cosign keyless signing via GitHub OIDC
+  packages: write   # reserved for future container/OCI publishing
+
+jobs:
+  goreleaser:
+    name: goreleaser
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # goreleaser needs full history + tags
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.23"
+          cache: true
+
+      - name: install cosign
+        uses: sigstore/cosign-installer@v3
+        with:
+          cosign-release: "v2.4.1"
+
+      - name: install syft (SBOM, future-proofing)
+        uses: anchore/sbom-action/download-syft@v0
+        continue-on-error: true
+
+      - name: goreleaser release
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,122 @@
+# Release pipeline for kasapi-cli.
+#
+# Local dry run:    goreleaser release --snapshot --clean
+# Real release:     git tag vX.Y.Z && git push --tags  (CI takes over)
+#
+# Docs: https://goreleaser.com/customization/
+
+version: 2
+
+project_name: kasapi-cli
+
+before:
+  hooks:
+    - go mod tidy
+    - go mod verify
+
+builds:
+  - id: kasapi-cli
+    main: ./cmd/kasapi-cli
+    binary: kasapi-cli
+    env:
+      - CGO_ENABLED=0
+    flags:
+      - -trimpath
+    ldflags:
+      - -s -w
+      - -X github.com/chmmou/kasapi-cli/internal/version.Version={{.Version}}
+      - -X github.com/chmmou/kasapi-cli/internal/version.Commit={{.ShortCommit}}
+      - -X github.com/chmmou/kasapi-cli/internal/version.Date={{.CommitDate}}
+    goos:
+      - linux
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    mod_timestamp: "{{ .CommitTimestamp }}"
+
+archives:
+  - id: default
+    name_template: >-
+      {{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}
+    formats: [tar.gz]
+    format_overrides:
+      - goos: windows
+        formats: [zip]
+    files:
+      - LICENSE
+      - README.md
+      - CHANGELOG.md
+      - docs/cli/**/*
+      - docs/usage/**/*
+
+nfpms:
+  - id: linux-packages
+    package_name: kasapi-cli
+    vendor: Alexander Saal
+    homepage: https://github.com/chmmou/kasapi-cli
+    maintainer: Alexander Saal <alex.saal@gmx.de>
+    description: |-
+      Command-line client for the All-Inkl KAS API (Kunden-Administrations-System).
+      Read-phase coverage for accounts, server, domains, DNS, mail, databases,
+      FTP/Samba users, cronjobs, directory protection, software installs, DDNS
+      users, and usage statistics.
+    license: BSD-3-Clause
+    formats:
+      - deb
+      - rpm
+    bindir: /usr/bin
+    section: utils
+    contents:
+      - src: LICENSE
+        dst: /usr/share/doc/kasapi-cli/LICENSE
+      - src: README.md
+        dst: /usr/share/doc/kasapi-cli/README.md
+      - src: CHANGELOG.md
+        dst: /usr/share/doc/kasapi-cli/CHANGELOG.md
+
+checksum:
+  name_template: "SHA256SUMS"
+  algorithm: sha256
+
+# Keyless cosign signing via GitHub OIDC. The private key never exists on
+# disk — sigstore's Fulcio mints a short-lived certificate bound to the
+# workflow's OIDC identity. Verification:
+#
+#   cosign verify-blob \
+#     --certificate kasapi-cli_<ver>_linux_amd64.tar.gz.pem \
+#     --signature  kasapi-cli_<ver>_linux_amd64.tar.gz.sig \
+#     --certificate-identity-regexp 'https://github.com/chmmou/kasapi-cli/.*' \
+#     --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+#     kasapi-cli_<ver>_linux_amd64.tar.gz
+signs:
+  - id: cosign-artefacts
+    cmd: cosign
+    signature: "${artifact}.sig"
+    certificate: "${artifact}.pem"
+    args:
+      - sign-blob
+      - "--output-signature=${signature}"
+      - "--output-certificate=${certificate}"
+      - "--yes"
+      - "${artifact}"
+    artifacts: all
+    output: true
+
+snapshot:
+  version_template: "{{ incpatch .Version }}-snapshot"
+
+changelog:
+  # The repo maintains CHANGELOG.md by hand; let the release notes pull
+  # from there (configured per-release via gh / goreleaser body) instead
+  # of generating from commit history.
+  disable: true
+
+release:
+  github:
+    owner: chmmou
+    name: kasapi-cli
+  draft: false
+  prerelease: auto
+  mode: replace
+  name_template: "{{ .ProjectName }} {{ .Version }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Release pipeline (`.goreleaser.yaml` + `.github/workflows/release.yml`)
+  driven by `git tag v*`. Builds Linux + Windows × `amd64`/`arm64`
+  binaries with `internal/version` ldflags wired up, packages Linux
+  artefacts as `deb` and `rpm` via `nfpm`, ships tarballs (`tar.gz`) /
+  ZIPs alongside, and signs every artefact plus `SHA256SUMS` keylessly
+  with `cosign` via GitHub OIDC. A new CI job `goreleaser config check`
+  validates `.goreleaser.yaml` on every PR. README gains an `Install`
+  section pointing at the Releases page with a `cosign verify-blob`
+  recipe. Makefile gets `release-snapshot` (local dry run into `./dist`,
+  skips signing) and `release-check` targets. AUR `PKGBUILD` and a
+  Homebrew tap are tracked separately as a follow-up.
+
 - CI job `docs sync` (`.github/workflows/ci.yml`) that runs
   `make docs` and fails when the checked-in `docs/cli/` differs
   from the regenerated output. Ensures any change to a flag,

--- a/Makefile
+++ b/Makefile
@@ -6,17 +6,19 @@ BIN      ?= kasapi-cli
 PKG      := ./cmd/kasapi-cli
 CLI_DOCS := docs/cli
 
-.PHONY: help build test lint vet fmt docs clean
+.PHONY: help build test lint vet fmt docs release-snapshot release-check clean
 
 help:
 	@echo "Targets:"
-	@echo "  build  — go build ./cmd/kasapi-cli"
-	@echo "  test   — go test ./..."
-	@echo "  lint   — golangci-lint run ./..."
-	@echo "  vet    — go vet ./..."
-	@echo "  fmt    — go fmt ./..."
-	@echo "  docs   — regenerate $(CLI_DOCS)/ from the live command tree"
-	@echo "  clean  — remove build output"
+	@echo "  build             — go build ./cmd/kasapi-cli"
+	@echo "  test              — go test ./..."
+	@echo "  lint              — golangci-lint run ./..."
+	@echo "  vet               — go vet ./..."
+	@echo "  fmt               — go fmt ./..."
+	@echo "  docs              — regenerate $(CLI_DOCS)/ from the live command tree"
+	@echo "  release-snapshot  — local goreleaser dry run into ./dist (no push, skips signing)"
+	@echo "  release-check     — validate .goreleaser.yaml"
+	@echo "  clean             — remove build output"
 
 build:
 	$(GO) build -o $(BIN) $(PKG)
@@ -43,5 +45,14 @@ docs:
 	mkdir -p $(CLI_DOCS)
 	$(GO) run $(PKG) gen-docs $(CLI_DOCS)
 
+# release-snapshot builds every artefact (binaries, deb, rpm, archives,
+# checksums) into ./dist without publishing or signing. Use to verify
+# .goreleaser.yaml changes locally before tagging.
+release-snapshot:
+	goreleaser release --snapshot --clean --skip=sign,publish
+
+release-check:
+	goreleaser check
+
 clean:
-	rm -f $(BIN)
+	rm -rf $(BIN) dist/

--- a/README.md
+++ b/README.md
@@ -28,7 +28,22 @@ Early development. The transport, authentication, configuration, and several rea
 
 `kasapi-cli` is a command-line client for the All-Inkl KAS-API. It wraps the SOAP/`ns2:Map` wire format the API uses, handles the `KasAuth` credential-token flow (plain or session, optional 2FA), enforces the `KasFloodDelay` between calls, and exposes read and write operations for the resources documented at <https://kasapi.kasserver.com/dokumentation/phpdoc/>.
 
-## Building
+## Install
+
+Pre-built binaries, `deb` and `rpm` packages, and `tar.gz` / `zip` archives for Linux and Windows (`amd64` + `arm64`) are published on the [Releases page](https://github.com/chmmou/kasapi-cli/releases). Each artefact ships with a cosign keyless signature (`*.sig` + `*.pem`); verify with:
+
+```sh
+cosign verify-blob \
+  --certificate kasapi-cli_<ver>_linux_amd64.tar.gz.pem \
+  --signature  kasapi-cli_<ver>_linux_amd64.tar.gz.sig \
+  --certificate-identity-regexp 'https://github.com/chmmou/kasapi-cli/.*' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  kasapi-cli_<ver>_linux_amd64.tar.gz
+```
+
+`SHA256SUMS` (and its signature) covers every artefact in the release.
+
+## Building from source
 
 ```sh
 go build ./cmd/kasapi-cli


### PR DESCRIPTION
Tag-driven release pipeline (`v*` tag → GitHub Release).

- `.goreleaser.yaml` builds Linux + Windows × amd64/arm64 binaries, deb + rpm packages, and tar.gz / zip archives. Ldflags wire `internal/version.{Version,Commit,Date}`.
- `.github/workflows/release.yml` runs goreleaser on tag push, signs every artefact and `SHA256SUMS` keylessly with cosign via GitHub OIDC.
- New CI job `goreleaser config check` validates `.goreleaser.yaml` on every PR.
- README gains an `Install` section + `cosign verify-blob` recipe.
- Makefile: `release-snapshot` (local dry run, no push, skips signing) and `release-check`.

AUR `PKGBUILD` and Homebrew tap deferred to #82.

Closes #81