### PR TITLE
chore: add security scans stage 1 (govulncheck, gosec, dependabot)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+# Dependabot keeps Go modules and GitHub Actions pinned versions
+# refreshed and surfaces CVE-bearing updates automatically.
+#
+# Docs: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+    labels:
+      - "area/build"
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(ci)"
+    labels:
+      - "area/build"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v7
         with:
-          version: v2.1
+          version: v2.12
 
       - name: go test
         run: go test ./...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,3 +83,23 @@ jobs:
           distribution: goreleaser
           version: "~> v2"
           args: check
+
+  govulncheck:
+    name: govulncheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.23"
+          cache: true
+
+      # Official Go vulnerability scanner. Reads go.mod plus the call
+      # graph and only reports CVEs on reachable code paths, so the
+      # signal-to-noise ratio is much higher than a flat `go list -m`
+      # advisory check. Fails the job on any reachable advisory.
+      - uses: golang/govulncheck-action@v1
+        with:
+          go-version-input: "1.23"
+          check-latest: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.24"
+          go-version: "1.25"
           cache: true
 
       - name: gofmt
@@ -54,7 +54,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.24"
+          go-version: "1.25"
           cache: true
 
       # Regenerate docs/cli/ from the live command tree and fail if the
@@ -92,7 +92,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.24"
+          go-version: "1.25"
           cache: true
 
       # Official Go vulnerability scanner. Reads go.mod plus the call
@@ -101,5 +101,5 @@ jobs:
       # advisory check. Fails the job on any reachable advisory.
       - uses: golang/govulncheck-action@v1
         with:
-          go-version-input: "1.24"
+          go-version-input: "1.25"
           check-latest: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.23"
+          go-version: "1.24"
           cache: true
 
       - name: gofmt
@@ -54,7 +54,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.23"
+          go-version: "1.24"
           cache: true
 
       # Regenerate docs/cli/ from the live command tree and fail if the
@@ -92,7 +92,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.23"
+          go-version: "1.24"
           cache: true
 
       # Official Go vulnerability scanner. Reads go.mod plus the call
@@ -101,5 +101,5 @@ jobs:
       # advisory check. Fails the job on any reachable advisory.
       - uses: golang/govulncheck-action@v1
         with:
-          go-version-input: "1.23"
+          go-version-input: "1.24"
           check-latest: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.23"
+          go-version: "1.24"
           cache: true
 
       - name: install cosign

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.24"
+          go-version: "1.25"
           cache: true
 
       - name: install cosign

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,6 +8,7 @@ linters:
   default: none
   enable:
     - errcheck
+    - gosec
     - govet
     - ineffassign
     - staticcheck

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   CodeQL, OSSF Scorecard, `SECURITY.md`, and SBOM-in-release land in
   stage 2.
 
+### Changed
+
+- Go toolchain bumped from 1.23 to 1.24 (`go.mod` directive plus
+  `go-version: "1.24"` in both `ci.yml` and `release.yml`). Required
+  to clear 18 reachable Go-stdlib CVEs that the new `govulncheck`
+  job surfaced (asn1 / net/url / encoding/pem / crypto/tls /
+  crypto/x509 — all fixed in 1.24.8 / 1.24.9, no 1.23.x backport
+  available since 1.23 has dropped out of the security-supported
+  window). No source-level changes were needed for the bump itself.
+
 - Release pipeline (`.goreleaser.yaml` + `.github/workflows/release.yml`)
   driven by `git tag v*`. Builds Linux + Windows × `amd64`/`arm64`
   binaries with `internal/version` ldflags wired up, packages Linux

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,13 +23,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Go toolchain bumped from 1.23 to 1.24 (`go.mod` directive plus
-  `go-version: "1.24"` in both `ci.yml` and `release.yml`). Required
-  to clear 18 reachable Go-stdlib CVEs that the new `govulncheck`
-  job surfaced (asn1 / net/url / encoding/pem / crypto/tls /
-  crypto/x509 — all fixed in 1.24.8 / 1.24.9, no 1.23.x backport
-  available since 1.23 has dropped out of the security-supported
-  window). No source-level changes were needed for the bump itself.
+- Go toolchain bumped from 1.23 to 1.25 (`go.mod` directive plus
+  `go-version: "1.25"` in `ci.yml` and `release.yml`). Required to
+  clear all reachable Go-stdlib CVEs that the new `govulncheck` job
+  surfaced — 18 against 1.23, 7 of which (asn1 / net/url /
+  encoding/pem / crypto/tls / crypto/x509 / os) only have 1.25.x
+  backports, since 1.23 and 1.24 have both dropped out of the
+  security-supported window. No source-level changes were needed
+  for the bump itself.
 
 - Release pipeline (`.goreleaser.yaml` + `.github/workflows/release.yml`)
   driven by `git tag v*`. Builds Linux + Windows × `amd64`/`arm64`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Vulnerability and security scanning, stage 1 of two: a new
+  `govulncheck` CI job (official Go vulnerability scanner, call-graph
+  aware) on every PR + push to `main`; `gosec` added to the
+  `golangci-lint` linter set in `.golangci.yml`; Dependabot configured
+  for `gomod` and `github-actions` ecosystems via
+  `.github/dependabot.yml`. Existing call sites that triggered gosec
+  false-positives (test fixture loaders, `os.Stdin.Fd()` conversion,
+  public-docs `MkdirAll` mode) were annotated with targeted
+  `//nolint:gosec` markers carrying the rule ID and a one-line reason.
+  CodeQL, OSSF Scorecard, `SECURITY.md`, and SBOM-in-release land in
+  stage 2.
+
 - Release pipeline (`.goreleaser.yaml` + `.github/workflows/release.yml`)
   driven by `git tag v*`. Builds Linux + Windows × `amd64`/`arm64`
   binaries with `internal/version` ldflags wired up, packages Linux

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@
 
 Early development. The transport, authentication, configuration, and several read modules are wired up; many write paths and the remaining read endpoints are still pending — see [ROADMAP.md](ROADMAP.md) for the current state. The repository also ships recorded KAS-API response fixtures under `testdata/` that drive offline parser tests.
 
+CI gates `gofmt`/`go vet`/`golangci-lint` (with `gosec`)/`go test`/`go test -race`/`go build`, plus a `govulncheck` job on every PR. Dependabot keeps `gomod` and `github-actions` versions current.
+
 ## What it does
 
 `kasapi-cli` is a command-line client for the All-Inkl KAS-API. It wraps the SOAP/`ns2:Map` wire format the API uses, handles the `KasAuth` credential-token flow (plain or session, optional 2FA), enforces the `KasFloodDelay` between calls, and exposes read and write operations for the resources documented at <https://kasapi.kasserver.com/dokumentation/phpdoc/>.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/chmmou/kasapi-cli
 
-go 1.24
+go 1.25
 
 require (
 	github.com/BurntSushi/toml v1.6.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/chmmou/kasapi-cli
 
-go 1.23.0
+go 1.24
 
 require (
 	github.com/BurntSushi/toml v1.6.0

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -21,6 +21,7 @@ import (
 
 func loadFixture(t *testing.T, rel string) []byte {
 	t.Helper()
+	//nolint:gosec // G304: test fixture loader, path is rooted at testutil.RepoRoot(t).
 	b, err := os.ReadFile(filepath.Join(testutil.RepoRoot(t), "testdata", rel))
 	if err != nil {
 		t.Fatalf("load %s: %v", rel, err)

--- a/internal/auth/codec_test.go
+++ b/internal/auth/codec_test.go
@@ -16,6 +16,7 @@ import (
 
 func loadFixture(t *testing.T, rel string) []byte {
 	t.Helper()
+	//nolint:gosec // G304: test fixture loader, path is rooted at testutil.RepoRoot(t).
 	b, err := os.ReadFile(filepath.Join(testutil.RepoRoot(t), "testdata", rel))
 	if err != nil {
 		t.Fatalf("load %s: %v", rel, err)

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -128,6 +128,7 @@ type configIO struct {
 }
 
 func defaultConfigIO() configIO {
+	//nolint:gosec // G115: file descriptors fit in int on every platform Go targets; term.IsTerminal/term.ReadPassword take int.
 	stdinFD := int(os.Stdin.Fd())
 	return configIO{
 		In:    os.Stdin,

--- a/internal/cli/gendocs.go
+++ b/internal/cli/gendocs.go
@@ -30,6 +30,7 @@ func NewGenDocsCmd() *cobra.Command {
 		Args:   cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			out := args[0]
+			//nolint:gosec // G301: output dir holds public CLI reference docs (docs/cli/), 0o755 is the intentional umask-friendly default.
 			if err := os.MkdirAll(out, 0o755); err != nil {
 				return fmt.Errorf("gen-docs: mkdir %s: %w", out, err)
 			}

--- a/internal/soap/soap_test.go
+++ b/internal/soap/soap_test.go
@@ -14,6 +14,7 @@ import (
 
 func isFaultEnvelope(t *testing.T, path string) bool {
 	t.Helper()
+	//nolint:gosec // G304: test-only helper, path comes from filepath.Walk over testdata/.
 	b, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatalf("read %s: %v", path, err)
@@ -23,6 +24,7 @@ func isFaultEnvelope(t *testing.T, path string) bool {
 
 func decodeFile(t *testing.T, path string) (*soap.Response, error) {
 	t.Helper()
+	//nolint:gosec // G304: test-only helper, path comes from filepath.Walk over testdata/.
 	f, err := os.Open(path)
 	if err != nil {
 		t.Fatalf("open %s: %v", path, err)

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -45,6 +45,7 @@ func RepoRoot(t *testing.T) string {
 func DecodeFixture(t *testing.T, relPath string) *soap.Response {
 	t.Helper()
 	path := filepath.Join(RepoRoot(t), "testdata", filepath.FromSlash(relPath))
+	//nolint:gosec // G304: test fixture loader, path is rooted at RepoRoot(t).
 	f, err := os.Open(path)
 	if err != nil {
 		t.Fatalf("open %s: %v", relPath, err)


### PR DESCRIPTION
First of two PRs introducing vulnerability and security scanning to CI. Stage 2 (CodeQL, OSSF Scorecard, SECURITY.md, SBOM-in-release) is tracked in #85.

- New CI job `govulncheck` (`golang/govulncheck-action@v1`) on every PR + push to main.
- `gosec` added to `.golangci.yml` linter set.
- Dependabot configured for `gomod` + `github-actions` (weekly) via `.github/dependabot.yml`.
- Six pre-existing call sites annotated with targeted `//nolint:gosec` markers — all gosec false-positives where the trust-boundary context is not visible to the linter:
  - 4× G304 in test fixture loaders rooted at `testutil.RepoRoot(t)`,
  - 1× G115 on `int(os.Stdin.Fd())` for `term.IsTerminal` / `term.ReadPassword`,
  - 1× G301 on `os.MkdirAll(out, 0o755)` for the public CLI-reference docs dir.

Local validation: `golangci-lint run ./...` clean, `govulncheck ./...` reports no vulnerabilities.

Closes #84