### PR TITLE
chore: add security scans stage 2 (CodeQL, Scorecard, SECURITY.md, SBOM)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,40 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly run catches advisories that GitHub's CodeQL bundle
+    # ships between PR-driven scans.
+    - cron: "37 6 * * 1"
+
+permissions:
+  contents: read
+  security-events: write   # upload SARIF to the Security tab
+  actions: read
+
+jobs:
+  analyze:
+    name: analyze go
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.25"
+          cache: true
+
+      - name: initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: go
+          build-mode: autobuild
+          queries: security-extended
+
+      - name: analyze
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:go"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,9 +29,8 @@ jobs:
         with:
           cosign-release: "v2.4.1"
 
-      - name: install syft (SBOM, future-proofing)
+      - name: "install syft (used by goreleaser sboms: block)"
         uses: anchore/sbom-action/download-syft@v0
-        continue-on-error: true
 
       - name: goreleaser release
         uses: goreleaser/goreleaser-action@v6

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,45 @@
+name: Scorecard
+
+on:
+  branch_protection_rule:
+  push:
+    branches: [main]
+  schedule:
+    - cron: "21 7 * * 1"
+
+permissions: read-all
+
+jobs:
+  analyze:
+    name: scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write   # upload SARIF to the Security tab
+      id-token: write          # publish_results requires keyless cosign signing
+      contents: read
+      actions: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: run scorecard
+        uses: ossf/scorecard-action@v2.4.0
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # Publish the score so it shows up at
+          # https://securityscorecards.dev/viewer/?uri=github.com/chmmou/kasapi-cli
+          publish_results: true
+
+      - name: upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: upload to code-scanning
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -79,6 +79,22 @@ checksum:
   name_template: "SHA256SUMS"
   algorithm: sha256
 
+# SBOMs are generated per artefact via syft and uploaded next to the
+# binaries on the GitHub Release. SPDX is the lowest-friction format
+# for downstream tooling (Grype, Dependency-Track, GitHub's own SBOM
+# import). The `*.sbom.spdx.json` files are also picked up by the
+# `signs:` block below and end up cosign-signed alongside the
+# archives and packages.
+sboms:
+  - id: archive
+    artifacts: archive
+    documents:
+      - "${artifact}.sbom.spdx.json"
+  - id: package
+    artifacts: package
+    documents:
+      - "${artifact}.sbom.spdx.json"
+
 # Keyless cosign signing via GitHub OIDC. The private key never exists on
 # disk — sigstore's Fulcio mints a short-lived certificate bound to the
 # workflow's OIDC identity. Verification:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Vulnerability and security scanning, stage 2 of two: GitHub-native
+  CodeQL workflow (`.github/workflows/codeql.yml`) running on PR +
+  push to `main` + weekly cron, with the `security-extended` query
+  pack; OSSF Scorecard workflow (`.github/workflows/scorecard.yml`)
+  running weekly + on push to `main`, publishing the score for the
+  public dashboard at <https://securityscorecards.dev>; `SECURITY.md`
+  at the repo root with the disclosure policy, response expectations,
+  and verification recipe (the short hint in `CONTRIBUTING.md` now
+  links here); SBOMs (SPDX-JSON) generated per release artefact via
+  goreleaser's `sboms:` block — Syft is now load-bearing in
+  `release.yml`, so the previous `continue-on-error: true` was
+  removed.
+
 - Vulnerability and security scanning, stage 1 of two: a new
   `govulncheck` CI job (official Go vulnerability scanner, call-graph
   aware) on every PR + push to `main`; `gosec` added to the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,7 +102,7 @@ Corrections from review land on a dedicated `fix/<topic>` branch via a separate 
 
 ## Reporting security issues
 
-Please do **not** open a public issue for security vulnerabilities. Contact the maintainer privately (see the commit author email or the `LICENSE` copyright holder) with a description, reproduction steps, and an assessment of impact.
+Please do **not** open a public issue for security vulnerabilities. Use the [private vulnerability reporting flow](https://github.com/chmmou/kasapi-cli/security/advisories/new) under the repository's Security tab, or e-mail the maintainer. Full policy in [SECURITY.md](SECURITY.md).
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,70 @@
+# Security Policy
+
+## Supported Versions
+
+`kasapi-cli` is in pre-1.0 development. Only the latest released
+`v0.x.y` minor receives security fixes; older minors are not
+backported.
+
+| Version  | Supported          |
+| -------- | ------------------ |
+| `v0.x.y` (latest) | yes |
+| anything else | no  |
+
+## Reporting a Vulnerability
+
+**Do not open a public GitHub issue for security vulnerabilities.**
+
+Use one of these channels instead:
+
+- GitHub's private vulnerability reporting: open the
+  [Report a vulnerability](https://github.com/chmmou/kasapi-cli/security/advisories/new)
+  flow under the repository's Security tab.
+- E-mail: `developer@kasapi-cli.chm-projects.de`.
+
+Please include:
+
+- a clear description of the issue,
+- reproduction steps or a proof-of-concept,
+- the affected version (`kasapi-cli --version`),
+- your assessment of impact and any suggested mitigation.
+
+## Response Expectations
+
+This is a maintainer-driven hobby project, not a paid product. You
+can expect:
+
+- an initial acknowledgement within seven days,
+- a follow-up with a triage outcome (accepted / not a vulnerability /
+  needs more information) within three weeks,
+- a fix landing in a tagged release as soon as practical for accepted
+  vulnerabilities, with credit in the release notes unless you prefer
+  to remain anonymous.
+
+There is no bug bounty.
+
+## Scope
+
+In scope:
+
+- the `kasapi-cli` binary and its supporting Go packages under
+  `internal/`,
+- the GitHub Actions workflows under `.github/workflows/`,
+- the release artefacts published on the
+  [Releases page](https://github.com/chmmou/kasapi-cli/releases) and
+  their `cosign` signatures.
+
+Out of scope:
+
+- vulnerabilities in the All-Inkl KAS API itself — please report
+  those to All-Inkl directly,
+- vulnerabilities in third-party dependencies for which an upstream
+  patch already exists; please file or link the upstream advisory
+  instead.
+
+## Verifying Releases
+
+Every release artefact and the `SHA256SUMS` file are signed
+keylessly with `cosign` via GitHub Actions OIDC. See the
+[Install section in `README.md`](README.md#install) for the
+verification recipe.


### PR DESCRIPTION
Second of two PRs introducing vulnerability and security scanning. Stage 1 (govulncheck, gosec, Dependabot, Go-toolchain bump) landed in #86.

- **CodeQL** (`.github/workflows/codeql.yml`) — GitHub-native SAST for Go, runs on PR + push to main + weekly cron, with the `security-extended` query pack. Findings appear in the repo's Security tab.
- **OSSF Scorecard** (`.github/workflows/scorecard.yml`) — supply-chain posture analysis, weekly + on push to main. `publish_results: true` exposes the score on `securityscorecards.dev`.
- **`SECURITY.md`** — disclosure policy, supported versions, reporting channels (GitHub private vulnerability reporting + maintainer mail), response expectations, scope, cosign-verification pointer. The short hint in `CONTRIBUTING.md` now links here instead of duplicating.
- **SBOM in goreleaser** (`.goreleaser.yaml`) — native `sboms:` block emits `*.sbom.spdx.json` per archive and per package; the existing `signs:` block picks them up so SBOMs ship cosign-signed alongside the binaries. The `continue-on-error: true` on the syft installer in `release.yml` is removed since syft is now load-bearing.

Local: `make fmt vet test` and `golangci-lint run ./...` clean.

Closes #85