### PR TITLE
refactor(soap): extract DecodeArray helper, migrate 19 decoders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Replaced the duplicated KAS `Array` of `Map` decoder boilerplate
+  in 19 read decoders with a single generic helper
+  `soap.DecodeArray[T]`. Each module's `Decode<Foo>s` now delegates
+  the kind/item-shape checks to the helper and only declares its
+  per-item mapper; behaviour and error messages are unchanged. Part
+  one of the cross-module-duplication clean-up bundle tracked in
+  issue #73.
+
 ### Added
 
 - Vulnerability and security scanning, stage 2 of two: GitHub-native

--- a/internal/account/decode.go
+++ b/internal/account/decode.go
@@ -11,17 +11,7 @@ import (
 // the typed slice. ReturnInfo must be a Map[]; each entry is itself a
 // Map carrying the documented fields.
 func DecodeAccounts(returnInfo soap.Value) ([]Account, error) {
-	if returnInfo.Kind != soap.KindArray {
-		return nil, fmt.Errorf("account: expected ReturnInfo array, got kind %d", returnInfo.Kind)
-	}
-	out := make([]Account, 0, len(returnInfo.Array))
-	for i, item := range returnInfo.Array {
-		if item.Kind != soap.KindMap {
-			return nil, fmt.Errorf("account: ReturnInfo[%d] is not a Map", i)
-		}
-		out = append(out, decodeAccount(item))
-	}
-	return out, nil
+	return soap.DecodeArray(returnInfo, "account", decodeAccount)
 }
 
 // DecodeAccountSettings maps the ReturnInfo of a get_accountsettings

--- a/internal/cronjob/cronjob.go
+++ b/internal/cronjob/cronjob.go
@@ -129,15 +129,8 @@ func (c *Client) Get(ctx context.Context, id string) (Cronjob, error) {
 // DecodeCronjobs maps the ReturnInfo of a get_cronjobs response (an
 // Array of Maps) into the typed CronjobList.
 func DecodeCronjobs(returnInfo soap.Value) (CronjobList, error) {
-	if returnInfo.Kind != soap.KindArray {
-		return nil, fmt.Errorf("cronjob: expected ReturnInfo array, got kind %d", returnInfo.Kind)
-	}
-	out := make(CronjobList, 0, len(returnInfo.Array))
-	for i, item := range returnInfo.Array {
-		if item.Kind != soap.KindMap {
-			return nil, fmt.Errorf("cronjob: ReturnInfo[%d] is not a Map", i)
-		}
-		out = append(out, Cronjob{
+	out, err := soap.DecodeArray(returnInfo, "cronjob", func(item soap.Value) Cronjob {
+		return Cronjob{
 			ID:            item.MapString("cronjob_id"),
 			Comment:       item.MapString("cronjob_comment"),
 			ShellCommand:  item.MapString("shell_command"),
@@ -155,9 +148,12 @@ func DecodeCronjobs(returnInfo soap.Value) (CronjobList, error) {
 			MailCondition: item.MapString("mail_condition"),
 			MailSubject:   item.MapString("mail_subject"),
 			IsActive:      item.MapString("is_active"),
-		})
+		}
+	})
+	if err != nil {
+		return nil, err
 	}
-	return out, nil
+	return CronjobList(out), nil
 }
 
 // TableHeaders returns the columns used by --output=table for

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -79,24 +79,20 @@ func (c *Client) Get(ctx context.Context, login string) (Database, error) {
 // DecodeDatabases maps the ReturnInfo of a get_databases response (an
 // Array of Maps) into the typed DatabaseList.
 func DecodeDatabases(returnInfo soap.Value) (DatabaseList, error) {
-	if returnInfo.Kind != soap.KindArray {
-		return nil, fmt.Errorf("database: expected ReturnInfo array, got kind %d", returnInfo.Kind)
-	}
-	out := make(DatabaseList, 0, len(returnInfo.Array))
-	for i, item := range returnInfo.Array {
-		if item.Kind != soap.KindMap {
-			return nil, fmt.Errorf("database: ReturnInfo[%d] is not a Map", i)
-		}
-		out = append(out, Database{
+	out, err := soap.DecodeArray(returnInfo, "database", func(item soap.Value) Database {
+		return Database{
 			Name:              item.MapString("database_name"),
 			Login:             item.MapString("database_login"),
 			Password:          item.MapString("database_password"),
 			Comment:           item.MapString("database_comment"),
 			AllowedHosts:      item.MapString("database_allowed_hosts"),
 			UsedDatabaseSpace: item.MapFloat("used_database_space"),
-		})
+		}
+	})
+	if err != nil {
+		return nil, err
 	}
-	return out, nil
+	return DatabaseList(out), nil
 }
 
 // TableHeaders returns the columns used by --output=table for

--- a/internal/ddns/ddns.go
+++ b/internal/ddns/ddns.go
@@ -119,15 +119,8 @@ func (c *Client) Get(ctx context.Context, login string) (DDNSUser, error) {
 // DecodeDDNSUsers maps the ReturnInfo of a get_ddnsusers response
 // (an Array of Maps) into the typed DDNSUserList.
 func DecodeDDNSUsers(returnInfo soap.Value) (DDNSUserList, error) {
-	if returnInfo.Kind != soap.KindArray {
-		return nil, fmt.Errorf("ddns: expected ReturnInfo array, got kind %d", returnInfo.Kind)
-	}
-	out := make(DDNSUserList, 0, len(returnInfo.Array))
-	for i, item := range returnInfo.Array {
-		if item.Kind != soap.KindMap {
-			return nil, fmt.Errorf("ddns: ReturnInfo[%d] is not a Map", i)
-		}
-		out = append(out, DDNSUser{
+	out, err := soap.DecodeArray(returnInfo, "ddns", func(item soap.Value) DDNSUser {
+		return DDNSUser{
 			Login:      item.MapString("dyndns_login"),
 			Password:   item.MapString("dyndns_password"),
 			Zone:       item.MapString("dyndns_zone"),
@@ -138,9 +131,12 @@ func DecodeDDNSUsers(returnInfo soap.Value) (DDNSUserList, error) {
 			DualStack:  item.MapString("dyndns_dual_stack"),
 			Comment:    item.MapString("dyndns_comment"),
 			InProgress: item.MapString("in_progress"),
-		})
+		}
+	})
+	if err != nil {
+		return nil, err
 	}
-	return out, nil
+	return DDNSUserList(out), nil
 }
 
 // TableHeaders returns the columns used by --output=table for

--- a/internal/directoryprotection/directoryprotection.go
+++ b/internal/directoryprotection/directoryprotection.go
@@ -69,23 +69,19 @@ func (c *Client) List(ctx context.Context, path string) (DirectoryProtectionList
 // get_directoryprotection response (an Array of Maps) into the typed
 // DirectoryProtectionList.
 func DecodeDirectoryProtections(returnInfo soap.Value) (DirectoryProtectionList, error) {
-	if returnInfo.Kind != soap.KindArray {
-		return nil, fmt.Errorf("directoryprotection: expected ReturnInfo array, got kind %d", returnInfo.Kind)
-	}
-	out := make(DirectoryProtectionList, 0, len(returnInfo.Array))
-	for i, item := range returnInfo.Array {
-		if item.Kind != soap.KindMap {
-			return nil, fmt.Errorf("directoryprotection: ReturnInfo[%d] is not a Map", i)
-		}
-		out = append(out, DirectoryProtection{
+	out, err := soap.DecodeArray(returnInfo, "directoryprotection", func(item soap.Value) DirectoryProtection {
+		return DirectoryProtection{
 			User:       item.MapString("directory_user"),
 			Path:       item.MapString("directory_path"),
 			AuthName:   item.MapString("directory_authname"),
 			Password:   item.MapString("directory_password"),
 			InProgress: item.MapString("in_progress"),
-		})
+		}
+	})
+	if err != nil {
+		return nil, err
 	}
-	return out, nil
+	return DirectoryProtectionList(out), nil
 }
 
 // TableHeaders returns the columns used by --output=table for

--- a/internal/dns/dns.go
+++ b/internal/dns/dns.go
@@ -69,15 +69,8 @@ func (c *Client) Settings(ctx context.Context, zoneHost, nameserver string) (Rec
 // DecodeRecords maps the ReturnInfo of a get_dns_settings response
 // (an Array of Maps) into the typed RecordList.
 func DecodeRecords(returnInfo soap.Value) (RecordList, error) {
-	if returnInfo.Kind != soap.KindArray {
-		return nil, fmt.Errorf("dns: expected ReturnInfo array, got kind %d", returnInfo.Kind)
-	}
-	out := make(RecordList, 0, len(returnInfo.Array))
-	for i, item := range returnInfo.Array {
-		if item.Kind != soap.KindMap {
-			return nil, fmt.Errorf("dns: ReturnInfo[%d] is not a Map", i)
-		}
-		out = append(out, Record{
+	out, err := soap.DecodeArray(returnInfo, "dns", func(item soap.Value) Record {
+		return Record{
 			Zone:       item.MapString("record_zone"),
 			Name:       item.MapString("record_name"),
 			Type:       item.MapString("record_type"),
@@ -86,9 +79,12 @@ func DecodeRecords(returnInfo soap.Value) (RecordList, error) {
 			ID:         item.MapString("record_id"),
 			Changeable: item.MapString("record_changeable"),
 			Deleteable: item.MapString("record_deleteable"),
-		})
+		}
+	})
+	if err != nil {
+		return nil, err
 	}
-	return out, nil
+	return RecordList(out), nil
 }
 
 // TableHeaders returns the columns used by --output=table for

--- a/internal/domain/domain.go
+++ b/internal/domain/domain.go
@@ -138,37 +138,27 @@ func (c *Client) TopLevelDomains(ctx context.Context) (TLDList, error) {
 // DecodeDomains maps the ReturnInfo of a get_domains response (an
 // Array of Maps) into the typed DomainList.
 func DecodeDomains(returnInfo soap.Value) (DomainList, error) {
-	if returnInfo.Kind != soap.KindArray {
-		return nil, fmt.Errorf("domain: expected ReturnInfo array, got kind %d", returnInfo.Kind)
+	out, err := soap.DecodeArray(returnInfo, "domain", decodeDomain)
+	if err != nil {
+		return nil, err
 	}
-	out := make(DomainList, 0, len(returnInfo.Array))
-	for i, item := range returnInfo.Array {
-		if item.Kind != soap.KindMap {
-			return nil, fmt.Errorf("domain: ReturnInfo[%d] is not a Map", i)
-		}
-		out = append(out, decodeDomain(item))
-	}
-	return out, nil
+	return DomainList(out), nil
 }
 
 // DecodeTLDs maps the ReturnInfo of a get_topleveldomains response
 // (an Array of Maps) into the typed TLDList.
 func DecodeTLDs(returnInfo soap.Value) (TLDList, error) {
-	if returnInfo.Kind != soap.KindArray {
-		return nil, fmt.Errorf("domain: expected ReturnInfo array, got kind %d", returnInfo.Kind)
-	}
-	out := make(TLDList, 0, len(returnInfo.Array))
-	for i, item := range returnInfo.Array {
-		if item.Kind != soap.KindMap {
-			return nil, fmt.Errorf("domain: ReturnInfo[%d] is not a Map", i)
-		}
-		out = append(out, TLD{
+	out, err := soap.DecodeArray(returnInfo, "domain", func(item soap.Value) TLD {
+		return TLD{
 			Name:   item.MapString("tld_name"),
 			MinLen: item.MapInt("tld_minlen"),
 			MaxLen: item.MapInt("tld_maxlen"),
-		})
+		}
+	})
+	if err != nil {
+		return nil, err
 	}
-	return out, nil
+	return TLDList(out), nil
 }
 
 func decodeDomain(m soap.Value) Domain {

--- a/internal/ftpuser/ftpuser.go
+++ b/internal/ftpuser/ftpuser.go
@@ -91,15 +91,8 @@ func (c *Client) Get(ctx context.Context, login string) (FTPUser, error) {
 // DecodeFTPUsers maps the ReturnInfo of a get_ftpusers response (an
 // Array of Maps) into the typed FTPUserList.
 func DecodeFTPUsers(returnInfo soap.Value) (FTPUserList, error) {
-	if returnInfo.Kind != soap.KindArray {
-		return nil, fmt.Errorf("ftpuser: expected ReturnInfo array, got kind %d", returnInfo.Kind)
-	}
-	out := make(FTPUserList, 0, len(returnInfo.Array))
-	for i, item := range returnInfo.Array {
-		if item.Kind != soap.KindMap {
-			return nil, fmt.Errorf("ftpuser: ReturnInfo[%d] is not a Map", i)
-		}
-		out = append(out, FTPUser{
+	out, err := soap.DecodeArray(returnInfo, "ftpuser", func(item soap.Value) FTPUser {
+		return FTPUser{
 			Login:           item.MapString("ftp_login"),
 			Password:        item.MapString("ftp_password"),
 			Passwort:        item.MapString("ftp_passwort"),
@@ -111,9 +104,12 @@ func DecodeFTPUsers(returnInfo soap.Value) (FTPUserList, error) {
 			PermissionWrite: item.MapString("ftp_permission_write"),
 			VirusClamAV:     item.MapString("ftp_virus_clamav"),
 			InProgress:      item.MapString("in_progress"),
-		})
+		}
+	})
+	if err != nil {
+		return nil, err
 	}
-	return out, nil
+	return FTPUserList(out), nil
 }
 
 // TableHeaders returns the columns used by --output=table for

--- a/internal/mailaccount/mailaccount.go
+++ b/internal/mailaccount/mailaccount.go
@@ -114,15 +114,8 @@ func (c *Client) Get(ctx context.Context, login string) (MailAccount, error) {
 // DecodeMailAccounts maps the ReturnInfo of a get_mailaccounts response
 // (an Array of Maps) into the typed MailAccountList.
 func DecodeMailAccounts(returnInfo soap.Value) (MailAccountList, error) {
-	if returnInfo.Kind != soap.KindArray {
-		return nil, fmt.Errorf("mailaccount: expected ReturnInfo array, got kind %d", returnInfo.Kind)
-	}
-	out := make(MailAccountList, 0, len(returnInfo.Array))
-	for i, item := range returnInfo.Array {
-		if item.Kind != soap.KindMap {
-			return nil, fmt.Errorf("mailaccount: ReturnInfo[%d] is not a Map", i)
-		}
-		out = append(out, MailAccount{
+	out, err := soap.DecodeArray(returnInfo, "mailaccount", func(item soap.Value) MailAccount {
+		return MailAccount{
 			Login:                item.MapString("mail_login"),
 			Password:             item.MapString("mail_password"),
 			Adresses:             item.MapString("mail_adresses"),
@@ -150,9 +143,12 @@ func DecodeMailAccounts(returnInfo soap.Value) (MailAccountList, error) {
 			TwoFA:                item.MapString("mail_2fa"),
 			QuotaRule:            item.MapInt("quota_rule"),
 			WebmailAutologin:     item.MapString("webmail_autologin"),
-		})
+		}
+	})
+	if err != nil {
+		return nil, err
 	}
-	return out, nil
+	return MailAccountList(out), nil
 }
 
 // TableHeaders returns the columns used by --output=table for

--- a/internal/mailfilter/mailfilter.go
+++ b/internal/mailfilter/mailfilter.go
@@ -52,22 +52,18 @@ func (c *Client) List(ctx context.Context) (StandardFilterList, error) {
 // DecodeStandardFilters maps the ReturnInfo of a get_mailstandardfilter
 // response (an Array of Maps) into the typed StandardFilterList.
 func DecodeStandardFilters(returnInfo soap.Value) (StandardFilterList, error) {
-	if returnInfo.Kind != soap.KindArray {
-		return nil, fmt.Errorf("mailfilter: expected ReturnInfo array, got kind %d", returnInfo.Kind)
-	}
-	out := make(StandardFilterList, 0, len(returnInfo.Array))
-	for i, item := range returnInfo.Array {
-		if item.Kind != soap.KindMap {
-			return nil, fmt.Errorf("mailfilter: ReturnInfo[%d] is not a Map", i)
-		}
-		out = append(out, StandardFilter{
+	out, err := soap.DecodeArray(returnInfo, "mailfilter", func(item soap.Value) StandardFilter {
+		return StandardFilter{
 			Filter:      item.MapString("filter"),
 			Type:        item.MapString("type"),
 			Title:       item.MapString("title"),
 			Recommended: item.MapString("recommended"),
-		})
+		}
+	})
+	if err != nil {
+		return nil, err
 	}
-	return out, nil
+	return StandardFilterList(out), nil
 }
 
 // TableHeaders returns the columns used by --output=table for

--- a/internal/mailforward/mailforward.go
+++ b/internal/mailforward/mailforward.go
@@ -83,24 +83,20 @@ func (c *Client) Get(ctx context.Context, address string) (MailForward, error) {
 // DecodeMailForwards maps the ReturnInfo of a get_mailforwards response
 // (an Array of Maps) into the typed MailForwardList.
 func DecodeMailForwards(returnInfo soap.Value) (MailForwardList, error) {
-	if returnInfo.Kind != soap.KindArray {
-		return nil, fmt.Errorf("mailforward: expected ReturnInfo array, got kind %d", returnInfo.Kind)
-	}
-	out := make(MailForwardList, 0, len(returnInfo.Array))
-	for i, item := range returnInfo.Array {
-		if item.Kind != soap.KindMap {
-			return nil, fmt.Errorf("mailforward: ReturnInfo[%d] is not a Map", i)
-		}
-		out = append(out, MailForward{
+	out, err := soap.DecodeArray(returnInfo, "mailforward", func(item soap.Value) MailForward {
+		return MailForward{
 			Adress:     item.MapString("mail_forward_adress"),
 			Address:    item.MapString("mail_forward_address"),
 			Comment:    item.MapString("mail_forward_comment"),
 			Targets:    item.MapString("mail_forward_targets"),
 			Spamfilter: item.MapString("mail_forward_spamfilter"),
 			InProgress: item.MapString("in_progress"),
-		})
+		}
+	})
+	if err != nil {
+		return nil, err
 	}
-	return out, nil
+	return MailForwardList(out), nil
 }
 
 // TableHeaders returns the columns used by --output=table for

--- a/internal/mailinglist/mailinglist.go
+++ b/internal/mailinglist/mailinglist.go
@@ -76,22 +76,18 @@ func (c *Client) Get(ctx context.Context, name string) (MailingList, error) {
 // DecodeMailingLists maps the ReturnInfo of a get_mailinglists response
 // (an Array of Maps) into the typed MailingListList.
 func DecodeMailingLists(returnInfo soap.Value) (MailingListList, error) {
-	if returnInfo.Kind != soap.KindArray {
-		return nil, fmt.Errorf("mailinglist: expected ReturnInfo array, got kind %d", returnInfo.Kind)
-	}
-	out := make(MailingListList, 0, len(returnInfo.Array))
-	for i, item := range returnInfo.Array {
-		if item.Kind != soap.KindMap {
-			return nil, fmt.Errorf("mailinglist: ReturnInfo[%d] is not a Map", i)
-		}
-		out = append(out, MailingList{
+	out, err := soap.DecodeArray(returnInfo, "mailinglist", func(item soap.Value) MailingList {
+		return MailingList{
 			Name:       item.MapString("mailinglist_name"),
 			Admin:      item.MapString("mailinglist_admin"),
 			URL:        item.MapString("mailinglist_url"),
 			InProgress: item.MapString("in_progress"),
-		})
+		}
+	})
+	if err != nil {
+		return nil, err
 	}
-	return out, nil
+	return MailingListList(out), nil
 }
 
 // TableHeaders returns the columns used by --output=table for

--- a/internal/sambauser/sambauser.go
+++ b/internal/sambauser/sambauser.go
@@ -80,23 +80,19 @@ func (c *Client) Get(ctx context.Context, login string) (SambaUser, error) {
 // DecodeSambaUsers maps the ReturnInfo of a get_sambausers response
 // (an Array of Maps) into the typed SambaUserList.
 func DecodeSambaUsers(returnInfo soap.Value) (SambaUserList, error) {
-	if returnInfo.Kind != soap.KindArray {
-		return nil, fmt.Errorf("sambauser: expected ReturnInfo array, got kind %d", returnInfo.Kind)
-	}
-	out := make(SambaUserList, 0, len(returnInfo.Array))
-	for i, item := range returnInfo.Array {
-		if item.Kind != soap.KindMap {
-			return nil, fmt.Errorf("sambauser: ReturnInfo[%d] is not a Map", i)
-		}
-		out = append(out, SambaUser{
+	out, err := soap.DecodeArray(returnInfo, "sambauser", func(item soap.Value) SambaUser {
+		return SambaUser{
 			Login:      item.MapString("samba_login"),
 			Password:   item.MapString("samba_password"),
 			Path:       item.MapString("samba_path"),
 			Comment:    item.MapString("samba_comment"),
 			InProgress: item.MapString("in_progress"),
-		})
+		}
+	})
+	if err != nil {
+		return nil, err
 	}
-	return out, nil
+	return SambaUserList(out), nil
 }
 
 // TableHeaders returns the columns used by --output=table for

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -55,24 +55,20 @@ func (c *Client) Information(ctx context.Context) (ServiceList, error) {
 // DecodeServices maps ReturnInfo (an array of Maps) into the typed
 // ServiceList.
 func DecodeServices(returnInfo soap.Value) (ServiceList, error) {
-	if returnInfo.Kind != soap.KindArray {
-		return nil, fmt.Errorf("server: expected ReturnInfo array, got kind %d", returnInfo.Kind)
-	}
-	out := make(ServiceList, 0, len(returnInfo.Array))
-	for i, item := range returnInfo.Array {
-		if item.Kind != soap.KindMap {
-			return nil, fmt.Errorf("server: ReturnInfo[%d] is not a Map", i)
-		}
-		out = append(out, Service{
+	out, err := soap.DecodeArray(returnInfo, "server", func(item soap.Value) Service {
+		return Service{
 			Service:       item.MapString("service"),
 			Version:       item.MapString("version"),
 			VersionType:   item.MapString("version_type"),
 			Interface:     item.MapString("interface"),
 			FileExtension: item.MapString("file_extension"),
 			Distribution:  item.MapString("distribution"),
-		})
+		}
+	})
+	if err != nil {
+		return nil, err
 	}
-	return out, nil
+	return ServiceList(out), nil
 }
 
 // TableHeaders returns the columns used by --output=table.

--- a/internal/soap/decode.go
+++ b/internal/soap/decode.go
@@ -1,0 +1,30 @@
+package soap
+
+import "fmt"
+
+// DecodeArray decodes a KAS ReturnInfo "Array of Maps" into a typed
+// slice. Read modules build their typed list (e.g. DDNSUserList) by
+// converting the returned []T at the call site.
+//
+// label is the module-name prefix used in error messages (e.g.
+// "ddns", "softwareinstall"). mapper converts a single Map-valued
+// Value into T; it is invoked once per item after this function has
+// already verified that the item is a Map, so mappers do not need to
+// re-check the kind.
+//
+// An error is returned when v is not an Array, or when any item is
+// not a Map. The returned slice has capacity len(v.Array), so the
+// typed conversion at the call site is allocation-free.
+func DecodeArray[T any](v Value, label string, mapper func(Value) T) ([]T, error) {
+	if v.Kind != KindArray {
+		return nil, fmt.Errorf("%s: expected ReturnInfo array, got kind %d", label, v.Kind)
+	}
+	out := make([]T, 0, len(v.Array))
+	for i, item := range v.Array {
+		if item.Kind != KindMap {
+			return nil, fmt.Errorf("%s: ReturnInfo[%d] is not a Map", label, i)
+		}
+		out = append(out, mapper(item))
+	}
+	return out, nil
+}

--- a/internal/soap/decode_test.go
+++ b/internal/soap/decode_test.go
@@ -1,0 +1,99 @@
+package soap_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/chmmou/kasapi-cli/internal/soap"
+)
+
+type testItem struct {
+	Name string
+	Age  int
+}
+
+func mapItem(v soap.Value) testItem {
+	return testItem{
+		Name: v.MapString("name"),
+		Age:  v.MapInt("age"),
+	}
+}
+
+func mapValue(name string, age int) soap.Value {
+	return soap.Value{
+		Kind: soap.KindMap,
+		Map: []soap.KV{
+			{Key: "name", Value: soap.Value{Kind: soap.KindString, String: name}},
+			{Key: "age", Value: soap.Value{Kind: soap.KindInt, Int: int64(age)}},
+		},
+	}
+}
+
+func TestDecodeArrayHappyPath(t *testing.T) {
+	v := soap.Value{
+		Kind: soap.KindArray,
+		Array: []soap.Value{
+			mapValue("alice", 30),
+			mapValue("bob", 25),
+		},
+	}
+
+	out, err := soap.DecodeArray(v, "test", mapItem)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(out) != 2 {
+		t.Fatalf("len = %d, want 2", len(out))
+	}
+	if out[0] != (testItem{Name: "alice", Age: 30}) {
+		t.Errorf("out[0] = %+v, want {alice 30}", out[0])
+	}
+	if out[1] != (testItem{Name: "bob", Age: 25}) {
+		t.Errorf("out[1] = %+v, want {bob 25}", out[1])
+	}
+}
+
+func TestDecodeArrayEmpty(t *testing.T) {
+	v := soap.Value{Kind: soap.KindArray}
+	out, err := soap.DecodeArray(v, "test", mapItem)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(out) != 0 {
+		t.Errorf("len = %d, want 0", len(out))
+	}
+	if out == nil {
+		t.Error("out should be a non-nil empty slice (KAS-empty != Go-nil)")
+	}
+}
+
+func TestDecodeArrayWrongKind(t *testing.T) {
+	v := soap.Value{Kind: soap.KindMap}
+	_, err := soap.DecodeArray(v, "test", mapItem)
+	if err == nil {
+		t.Fatal("expected error for non-Array kind, got nil")
+	}
+	if !strings.Contains(err.Error(), "test:") {
+		t.Errorf("error %q missing label prefix", err)
+	}
+	if !strings.Contains(err.Error(), "expected ReturnInfo array") {
+		t.Errorf("error %q missing kind hint", err)
+	}
+}
+
+func TestDecodeArrayItemNotMap(t *testing.T) {
+	v := soap.Value{
+		Kind: soap.KindArray,
+		Array: []soap.Value{
+			mapValue("alice", 30),
+			{Kind: soap.KindString, String: "not-a-map"},
+		},
+	}
+	_, err := soap.DecodeArray(v, "test", mapItem)
+	if err == nil {
+		t.Fatal("expected error for non-Map item, got nil")
+	}
+	if !strings.Contains(err.Error(), "ReturnInfo[1]") {
+		t.Errorf("error %q missing item index", err)
+	}
+}

--- a/internal/softwareinstall/softwareinstall.go
+++ b/internal/softwareinstall/softwareinstall.go
@@ -104,15 +104,8 @@ func (c *Client) Get(ctx context.Context, id string) (SoftwareInstall, error) {
 // DecodeSoftwareInstalls maps the ReturnInfo of a get_softwareinstall
 // response (an Array of Maps) into the typed SoftwareInstallList.
 func DecodeSoftwareInstalls(returnInfo soap.Value) (SoftwareInstallList, error) {
-	if returnInfo.Kind != soap.KindArray {
-		return nil, fmt.Errorf("softwareinstall: expected ReturnInfo array, got kind %d", returnInfo.Kind)
-	}
-	out := make(SoftwareInstallList, 0, len(returnInfo.Array))
-	for i, item := range returnInfo.Array {
-		if item.Kind != soap.KindMap {
-			return nil, fmt.Errorf("softwareinstall: ReturnInfo[%d] is not a Map", i)
-		}
-		out = append(out, SoftwareInstall{
+	out, err := soap.DecodeArray(returnInfo, "softwareinstall", func(item soap.Value) SoftwareInstall {
+		return SoftwareInstall{
 			ID:                 item.MapString("software_id"),
 			Name:               item.MapString("software_name"),
 			Category:           item.MapString("software_category"),
@@ -131,9 +124,12 @@ func DecodeSoftwareInstalls(returnInfo soap.Value) (SoftwareInstallList, error) 
 			MariaDBVersionUpto: item.MapString("software_version_mariadb_upto"),
 			CanBeInstalled:     item.MapString("software_can_be_installed"),
 			CanBeMessage:       item.MapString("software_can_be_message"),
-		})
+		}
+	})
+	if err != nil {
+		return nil, err
 	}
-	return out, nil
+	return SoftwareInstallList(out), nil
 }
 
 // TableHeaders returns the columns used by --output=table for

--- a/internal/subdomain/subdomain.go
+++ b/internal/subdomain/subdomain.go
@@ -112,15 +112,8 @@ func (c *Client) Get(ctx context.Context, name string) (Subdomain, error) {
 // DecodeSubdomains maps the ReturnInfo of a get_subdomains response
 // (an Array of Maps) into the typed SubdomainList.
 func DecodeSubdomains(returnInfo soap.Value) (SubdomainList, error) {
-	if returnInfo.Kind != soap.KindArray {
-		return nil, fmt.Errorf("subdomain: expected ReturnInfo array, got kind %d", returnInfo.Kind)
-	}
-	out := make(SubdomainList, 0, len(returnInfo.Array))
-	for i, item := range returnInfo.Array {
-		if item.Kind != soap.KindMap {
-			return nil, fmt.Errorf("subdomain: ReturnInfo[%d] is not a Map", i)
-		}
-		out = append(out, Subdomain{
+	out, err := soap.DecodeArray(returnInfo, "subdomain", func(item soap.Value) Subdomain {
+		return Subdomain{
 			Name:           item.MapString("subdomain_name"),
 			RedirectStatus: item.MapInt("subdomain_redirect_status"),
 			Path:           item.MapString("subdomain_path"),
@@ -150,9 +143,12 @@ func DecodeSubdomains(returnInfo soap.Value) (SubdomainList, error) {
 				SNIForceHTTPS: item.MapString("ssl_certificate_sni_force_https"),
 				SNIHSTSMaxAge: item.MapString("ssl_certificate_sni_hsts_max_age"),
 			},
-		})
+		}
+	})
+	if err != nil {
+		return nil, err
 	}
-	return out, nil
+	return SubdomainList(out), nil
 }
 
 // TableHeaders returns the columns used by --output=table for

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -154,15 +154,8 @@ func (c *Client) Traffic(ctx context.Context, year, month int) (TrafficList, err
 // DecodeSpace maps the ReturnInfo of a get_space response (an Array of
 // Maps) into the typed SpaceList.
 func DecodeSpace(returnInfo soap.Value) (SpaceList, error) {
-	if returnInfo.Kind != soap.KindArray {
-		return nil, fmt.Errorf("usage: expected ReturnInfo array, got kind %d", returnInfo.Kind)
-	}
-	out := make(SpaceList, 0, len(returnInfo.Array))
-	for i, item := range returnInfo.Array {
-		if item.Kind != soap.KindMap {
-			return nil, fmt.Errorf("usage: ReturnInfo[%d] is not a Map", i)
-		}
-		out = append(out, Space{
+	out, err := soap.DecodeArray(returnInfo, "usage", func(item soap.Value) Space {
+		return Space{
 			AccountLogin:         item.MapString("account_login"),
 			LastCalculation:      item.MapInt64("last_calculation"),
 			UsedHTDocsSpace:      item.MapInt64("used_htdocs_space"),
@@ -171,31 +164,30 @@ func DecodeSpace(returnInfo soap.Value) (SpaceList, error) {
 			UsedMailaccountSpace: item.MapInt64("used_mailaccount_space"),
 			UsedWebspace:         item.MapInt64("used_webspace"),
 			MaxWebspace:          item.MapInt64("max_webspace"),
-		})
+		}
+	})
+	if err != nil {
+		return nil, err
 	}
-	return out, nil
+	return SpaceList(out), nil
 }
 
 // DecodeSpaceUsage maps the ReturnInfo of a get_space_usage response
 // (an Array of Maps) into the typed SpaceUsageList.
 func DecodeSpaceUsage(returnInfo soap.Value) (SpaceUsageList, error) {
-	if returnInfo.Kind != soap.KindArray {
-		return nil, fmt.Errorf("usage: expected ReturnInfo array, got kind %d", returnInfo.Kind)
-	}
-	out := make(SpaceUsageList, 0, len(returnInfo.Array))
-	for i, item := range returnInfo.Array {
-		if item.Kind != soap.KindMap {
-			return nil, fmt.Errorf("usage: ReturnInfo[%d] is not a Map", i)
-		}
-		out = append(out, SpaceUsage{
+	out, err := soap.DecodeArray(returnInfo, "usage", func(item soap.Value) SpaceUsage {
+		return SpaceUsage{
 			Directory:       item.MapString("directory"),
 			Count:           item.MapInt64("count"),
 			Bytes:           item.MapInt64("bytes"),
 			LastCalculation: item.MapInt64("last_calculation"),
 			HasSubDirs:      getYN(item, "has_sub_dirs"),
-		})
+		}
+	})
+	if err != nil {
+		return nil, err
 	}
-	return out, nil
+	return SpaceUsageList(out), nil
 }
 
 // DecodeTraffic maps the ReturnInfo of a get_traffic response (a Map of


### PR DESCRIPTION
## Summary

Extract the duplicated `Array<Map>` decoder boilerplate from 19 read decoders into a single generic helper `soap.DecodeArray[T]`. Net diff: -208 lines of boilerplate, +263 with helper + tests + per-call-site mapper.

Behaviour is unchanged — same error messages (`"<label>: expected ReturnInfo array, got kind %d"` and `"<label>: ReturnInfo[%d] is not a Map"`), same successful output, all existing per-module mapping tests stay green without modification.

Migrated: account, cronjob, database, ddns, directoryprotection, dns, domain (Domains + TLDs), ftpuser, mailaccount, mailfilter, mailforward, mailinglist, sambauser, server, softwareinstall, subdomain, usage (Space + SpaceUsage).

Part one of the cross-module-duplication clean-up bundle tracked in #73.

Refs #73