### PR TITLE
refactor(kasread): extract ListGet helper, migrate 13 read clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Replaced the duplicated `Client.List` / `Client.Get` boilerplate
+  in 12 read modules (account, cronjob, database, ddns, domain,
+  ftpuser, mailaccount, mailforward, mailinglist, sambauser,
+  softwareinstall, subdomain) plus the `List`-only mailfilter with
+  a single generic helper `kasread.ListGet[L, E]`. Each module now
+  binds the action, label, filter key and decoder once in
+  `NewClient` and exposes `List` / `Get` as one-line delegates;
+  per-module `Caller` interfaces collapse to type aliases over
+  `kasread.Caller`. Behaviour and error messages are unchanged.
+  Part two of the cross-module-duplication clean-up bundle tracked
+  in issue #73.
 - Replaced the duplicated KAS `Array` of `Map` decoder boilerplate
   in 19 read decoders with a single generic helper
   `soap.DecodeArray[T]`. Each module's `Decode<Foo>s` now delegates

--- a/internal/account/client.go
+++ b/internal/account/client.go
@@ -4,68 +4,55 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/chmmou/kasapi-cli/internal/soap"
+	"github.com/chmmou/kasapi-cli/internal/kasread"
 )
 
 // Caller is the subset of *api.Client this package depends on. The
 // indirection keeps tests free of network setup: a fake Caller can
 // return a *soap.Response decoded from a fixture.
-type Caller interface {
-	Call(ctx context.Context, action string, params map[string]any) (*soap.Response, error)
-}
+type Caller = kasread.Caller
 
 // Client groups the read endpoints for accounts: get_accounts,
 // get_accountsettings, get_accountresources.
 type Client struct {
-	API Caller
+	api Caller
+	lg  kasread.ListGet[[]Account, Account]
 }
 
 // NewClient returns a Client backed by the given Caller. It does not
 // retain ownership of c.
-func NewClient(c Caller) *Client { return &Client{API: c} }
+func NewClient(c Caller) *Client {
+	return &Client{
+		api: c,
+		lg: kasread.ListGet[[]Account, Account]{
+			Caller:    c,
+			Action:    "get_accounts",
+			Label:     "account",
+			ArgName:   "login",
+			FilterKey: "account_login",
+			Decoder:   DecodeAccounts,
+		},
+	}
+}
 
 // List calls get_accounts without a filter and decodes the response
 // into a slice of Account values. For a main login this returns every
 // sub-account; for a sub-login it returns just the authenticated
 // account.
-func (c *Client) List(ctx context.Context) ([]Account, error) {
-	resp, err := c.API.Call(ctx, "get_accounts", nil)
-	if err != nil {
-		return nil, err
-	}
-	accs, err := DecodeAccounts(resp.Body.ReturnInfo)
-	if err != nil {
-		return nil, fmt.Errorf("account: get_accounts: %w", err)
-	}
-	return accs, nil
-}
+func (c *Client) List(ctx context.Context) ([]Account, error) { return c.lg.List(ctx) }
 
 // Get calls get_accounts with an account_login filter and returns the
 // single matching Account. The KAS API still wraps the result in an
 // array; we unwrap it here so callers do not have to. An empty array
 // surfaces as a not-found error.
 func (c *Client) Get(ctx context.Context, login string) (Account, error) {
-	if login == "" {
-		return Account{}, fmt.Errorf("account: login is required")
-	}
-	resp, err := c.API.Call(ctx, "get_accounts", map[string]any{"account_login": login})
-	if err != nil {
-		return Account{}, err
-	}
-	accs, err := DecodeAccounts(resp.Body.ReturnInfo)
-	if err != nil {
-		return Account{}, fmt.Errorf("account: get_accounts: %w", err)
-	}
-	if len(accs) == 0 {
-		return Account{}, fmt.Errorf("account: %q not found", login)
-	}
-	return accs[0], nil
+	return c.lg.Get(ctx, login)
 }
 
 // Settings calls get_accountsettings and decodes the response into the
 // AccountSettings struct for the authenticated login.
 func (c *Client) Settings(ctx context.Context) (AccountSettings, error) {
-	resp, err := c.API.Call(ctx, "get_accountsettings", nil)
+	resp, err := c.api.Call(ctx, "get_accountsettings", nil)
 	if err != nil {
 		return AccountSettings{}, err
 	}
@@ -79,7 +66,7 @@ func (c *Client) Settings(ctx context.Context) (AccountSettings, error) {
 // Resources calls get_accountresources and decodes the response into
 // the AccountResources struct.
 func (c *Client) Resources(ctx context.Context) (AccountResources, error) {
-	resp, err := c.API.Call(ctx, "get_accountresources", nil)
+	resp, err := c.api.Call(ctx, "get_accountresources", nil)
 	if err != nil {
 		return AccountResources{}, err
 	}

--- a/internal/cronjob/cronjob.go
+++ b/internal/cronjob/cronjob.go
@@ -2,19 +2,17 @@ package cronjob
 
 import (
 	"context"
-	"fmt"
 	"strconv"
 	"strings"
 
+	"github.com/chmmou/kasapi-cli/internal/kasread"
 	"github.com/chmmou/kasapi-cli/internal/soap"
 )
 
 // Caller is the subset of *api.Client this package depends on. The
 // indirection keeps tests free of network setup: a fake Caller can
 // return a *soap.Response decoded from a fixture.
-type Caller interface {
-	Call(ctx context.Context, action string, params map[string]any) (*soap.Response, error)
-}
+type Caller = kasread.Caller
 
 // Cronjob is one entry of get_cronjobs. The list and singular views
 // (the latter being get_cronjobs called with a cronjob_id filter)
@@ -84,46 +82,31 @@ type CronjobList []Cronjob
 // Client groups the read endpoints scoped to cronjobs:
 // get_cronjobs (list and singular).
 type Client struct {
-	API Caller
+	lg kasread.ListGet[CronjobList, Cronjob]
 }
 
 // NewClient returns a Client backed by the given Caller.
-func NewClient(c Caller) *Client { return &Client{API: c} }
+func NewClient(c Caller) *Client {
+	return &Client{lg: kasread.ListGet[CronjobList, Cronjob]{
+		Caller:    c,
+		Action:    "get_cronjobs",
+		Label:     "cronjob",
+		ArgName:   "id",
+		FilterKey: "cronjob_id",
+		Decoder:   DecodeCronjobs,
+	}}
+}
 
 // List calls get_cronjobs without parameters and decodes the response
 // into a CronjobList covering every cronjob visible to the login.
-func (c *Client) List(ctx context.Context) (CronjobList, error) {
-	resp, err := c.API.Call(ctx, "get_cronjobs", nil)
-	if err != nil {
-		return nil, err
-	}
-	list, err := DecodeCronjobs(resp.Body.ReturnInfo)
-	if err != nil {
-		return nil, fmt.Errorf("cronjob: get_cronjobs: %w", err)
-	}
-	return list, nil
-}
+func (c *Client) List(ctx context.Context) (CronjobList, error) { return c.lg.List(ctx) }
 
 // Get calls get_cronjobs with a cronjob_id filter and returns the
 // single matching Cronjob. The KAS API still wraps the result in an
 // array; we unwrap it here so callers do not have to. An empty array
 // surfaces as a not-found error.
 func (c *Client) Get(ctx context.Context, id string) (Cronjob, error) {
-	if id == "" {
-		return Cronjob{}, fmt.Errorf("cronjob: id is required")
-	}
-	resp, err := c.API.Call(ctx, "get_cronjobs", map[string]any{"cronjob_id": id})
-	if err != nil {
-		return Cronjob{}, err
-	}
-	list, err := DecodeCronjobs(resp.Body.ReturnInfo)
-	if err != nil {
-		return Cronjob{}, fmt.Errorf("cronjob: get_cronjobs: %w", err)
-	}
-	if len(list) == 0 {
-		return Cronjob{}, fmt.Errorf("cronjob: %q not found", id)
-	}
-	return list[0], nil
+	return c.lg.Get(ctx, id)
 }
 
 // DecodeCronjobs maps the ReturnInfo of a get_cronjobs response (an

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -2,18 +2,16 @@ package database
 
 import (
 	"context"
-	"fmt"
 	"strconv"
 
+	"github.com/chmmou/kasapi-cli/internal/kasread"
 	"github.com/chmmou/kasapi-cli/internal/soap"
 )
 
 // Caller is the subset of *api.Client this package depends on. The
 // indirection keeps tests free of network setup: a fake Caller can
 // return a *soap.Response decoded from a fixture.
-type Caller interface {
-	Call(ctx context.Context, action string, params map[string]any) (*soap.Response, error)
-}
+type Caller = kasread.Caller
 
 // Database is one entry of get_databases. The list and singular views
 // (the latter being get_databases called with a database_login filter)
@@ -34,46 +32,31 @@ type DatabaseList []Database
 // Client groups the read endpoints scoped to databases:
 // get_databases (list and singular).
 type Client struct {
-	API Caller
+	lg kasread.ListGet[DatabaseList, Database]
 }
 
 // NewClient returns a Client backed by the given Caller.
-func NewClient(c Caller) *Client { return &Client{API: c} }
+func NewClient(c Caller) *Client {
+	return &Client{lg: kasread.ListGet[DatabaseList, Database]{
+		Caller:    c,
+		Action:    "get_databases",
+		Label:     "database",
+		ArgName:   "login",
+		FilterKey: "database_login",
+		Decoder:   DecodeDatabases,
+	}}
+}
 
 // List calls get_databases without parameters and decodes the response
 // into a DatabaseList covering every database visible to the login.
-func (c *Client) List(ctx context.Context) (DatabaseList, error) {
-	resp, err := c.API.Call(ctx, "get_databases", nil)
-	if err != nil {
-		return nil, err
-	}
-	list, err := DecodeDatabases(resp.Body.ReturnInfo)
-	if err != nil {
-		return nil, fmt.Errorf("database: get_databases: %w", err)
-	}
-	return list, nil
-}
+func (c *Client) List(ctx context.Context) (DatabaseList, error) { return c.lg.List(ctx) }
 
 // Get calls get_databases with a database_login filter and returns the
 // single matching Database. The KAS API still wraps the result in an
 // array; we unwrap it here so callers do not have to. An empty array
 // surfaces as a not-found error.
 func (c *Client) Get(ctx context.Context, login string) (Database, error) {
-	if login == "" {
-		return Database{}, fmt.Errorf("database: login is required")
-	}
-	resp, err := c.API.Call(ctx, "get_databases", map[string]any{"database_login": login})
-	if err != nil {
-		return Database{}, err
-	}
-	list, err := DecodeDatabases(resp.Body.ReturnInfo)
-	if err != nil {
-		return Database{}, fmt.Errorf("database: get_databases: %w", err)
-	}
-	if len(list) == 0 {
-		return Database{}, fmt.Errorf("database: %q not found", login)
-	}
-	return list[0], nil
+	return c.lg.Get(ctx, login)
 }
 
 // DecodeDatabases maps the ReturnInfo of a get_databases response (an

--- a/internal/ddns/ddns.go
+++ b/internal/ddns/ddns.go
@@ -2,17 +2,15 @@ package ddns
 
 import (
 	"context"
-	"fmt"
 
+	"github.com/chmmou/kasapi-cli/internal/kasread"
 	"github.com/chmmou/kasapi-cli/internal/soap"
 )
 
 // Caller is the subset of *api.Client this package depends on. The
 // indirection keeps tests free of network setup: a fake Caller can
 // return a *soap.Response decoded from a fixture.
-type Caller interface {
-	Call(ctx context.Context, action string, params map[string]any) (*soap.Response, error)
-}
+type Caller = kasread.Caller
 
 // DDNSUser is one entry of get_ddnsusers. The list and singular
 // views (the latter being get_ddnsusers called with a `ddns_login`
@@ -71,26 +69,25 @@ type DDNSUserList []DDNSUser
 // `api.IsNotFound`, so this client does not need a separate
 // not-found path.
 type Client struct {
-	API Caller
+	lg kasread.ListGet[DDNSUserList, DDNSUser]
 }
 
 // NewClient returns a Client backed by the given Caller.
-func NewClient(c Caller) *Client { return &Client{API: c} }
+func NewClient(c Caller) *Client {
+	return &Client{lg: kasread.ListGet[DDNSUserList, DDNSUser]{
+		Caller:    c,
+		Action:    "get_ddnsusers",
+		Label:     "ddns",
+		ArgName:   "login",
+		FilterKey: "ddns_login",
+		Decoder:   DecodeDDNSUsers,
+	}}
+}
 
 // List calls get_ddnsusers without parameters and decodes the
 // response into a DDNSUserList covering every DDNS user visible to
 // the login.
-func (c *Client) List(ctx context.Context) (DDNSUserList, error) {
-	resp, err := c.API.Call(ctx, "get_ddnsusers", nil)
-	if err != nil {
-		return nil, err
-	}
-	list, err := DecodeDDNSUsers(resp.Body.ReturnInfo)
-	if err != nil {
-		return nil, fmt.Errorf("ddns: get_ddnsusers: %w", err)
-	}
-	return list, nil
-}
+func (c *Client) List(ctx context.Context) (DDNSUserList, error) { return c.lg.List(ctx) }
 
 // Get calls get_ddnsusers with a ddns_login filter and returns the
 // single matching DDNSUser. The KAS API still wraps the result in an
@@ -99,21 +96,7 @@ func (c *Client) List(ctx context.Context) (DDNSUserList, error) {
 // other read modules even though the documented behaviour is a
 // `dyndns_login_not_found` SOAP fault.
 func (c *Client) Get(ctx context.Context, login string) (DDNSUser, error) {
-	if login == "" {
-		return DDNSUser{}, fmt.Errorf("ddns: login is required")
-	}
-	resp, err := c.API.Call(ctx, "get_ddnsusers", map[string]any{"ddns_login": login})
-	if err != nil {
-		return DDNSUser{}, err
-	}
-	list, err := DecodeDDNSUsers(resp.Body.ReturnInfo)
-	if err != nil {
-		return DDNSUser{}, fmt.Errorf("ddns: get_ddnsusers: %w", err)
-	}
-	if len(list) == 0 {
-		return DDNSUser{}, fmt.Errorf("ddns: %q not found", login)
-	}
-	return list[0], nil
+	return c.lg.Get(ctx, login)
 }
 
 // DecodeDDNSUsers maps the ReturnInfo of a get_ddnsusers response

--- a/internal/domain/domain.go
+++ b/internal/domain/domain.go
@@ -6,15 +6,14 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/chmmou/kasapi-cli/internal/kasread"
 	"github.com/chmmou/kasapi-cli/internal/soap"
 )
 
 // Caller is the subset of *api.Client this package depends on. The
 // indirection keeps tests free of network setup: a fake Caller can
 // return a *soap.Response decoded from a fixture.
-type Caller interface {
-	Call(ctx context.Context, action string, params map[string]any) (*soap.Response, error)
-}
+type Caller = kasread.Caller
 
 // Domain is one entry of get_domains. The KAS list view exposes the
 // account/server placement and a flattened SSL summary; the singular
@@ -80,51 +79,40 @@ type TLDList []TLD
 // Client groups the read endpoints scoped to domains:
 // get_domains (list and singular) plus get_topleveldomains.
 type Client struct {
-	API Caller
+	api Caller
+	lg  kasread.ListGet[DomainList, Domain]
 }
 
 // NewClient returns a Client backed by the given Caller.
-func NewClient(c Caller) *Client { return &Client{API: c} }
+func NewClient(c Caller) *Client {
+	return &Client{
+		api: c,
+		lg: kasread.ListGet[DomainList, Domain]{
+			Caller:    c,
+			Action:    "get_domains",
+			Label:     "domain",
+			ArgName:   "name",
+			FilterKey: "domain_name",
+			Decoder:   DecodeDomains,
+		},
+	}
+}
 
 // List calls get_domains without parameters and decodes the response
 // into a DomainList covering every domain visible to the login.
-func (c *Client) List(ctx context.Context) (DomainList, error) {
-	resp, err := c.API.Call(ctx, "get_domains", nil)
-	if err != nil {
-		return nil, err
-	}
-	list, err := DecodeDomains(resp.Body.ReturnInfo)
-	if err != nil {
-		return nil, fmt.Errorf("domain: get_domains: %w", err)
-	}
-	return list, nil
-}
+func (c *Client) List(ctx context.Context) (DomainList, error) { return c.lg.List(ctx) }
 
 // Get calls get_domains with a domain_name filter and returns the
 // single matching Domain. The KAS API still wraps the result in an
 // array; we unwrap it here so callers do not have to. An empty array
 // surfaces as a not-found error.
 func (c *Client) Get(ctx context.Context, name string) (Domain, error) {
-	if name == "" {
-		return Domain{}, fmt.Errorf("domain: name is required")
-	}
-	resp, err := c.API.Call(ctx, "get_domains", map[string]any{"domain_name": name})
-	if err != nil {
-		return Domain{}, err
-	}
-	list, err := DecodeDomains(resp.Body.ReturnInfo)
-	if err != nil {
-		return Domain{}, fmt.Errorf("domain: get_domains: %w", err)
-	}
-	if len(list) == 0 {
-		return Domain{}, fmt.Errorf("domain: %q not found", name)
-	}
-	return list[0], nil
+	return c.lg.Get(ctx, name)
 }
 
 // TopLevelDomains calls get_topleveldomains and decodes the response.
 func (c *Client) TopLevelDomains(ctx context.Context) (TLDList, error) {
-	resp, err := c.API.Call(ctx, "get_topleveldomains", nil)
+	resp, err := c.api.Call(ctx, "get_topleveldomains", nil)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/ftpuser/ftpuser.go
+++ b/internal/ftpuser/ftpuser.go
@@ -2,17 +2,15 @@ package ftpuser
 
 import (
 	"context"
-	"fmt"
 
+	"github.com/chmmou/kasapi-cli/internal/kasread"
 	"github.com/chmmou/kasapi-cli/internal/soap"
 )
 
 // Caller is the subset of *api.Client this package depends on. The
 // indirection keeps tests free of network setup: a fake Caller can
 // return a *soap.Response decoded from a fixture.
-type Caller interface {
-	Call(ctx context.Context, action string, params map[string]any) (*soap.Response, error)
-}
+type Caller = kasread.Caller
 
 // FTPUser is one entry of get_ftpusers. List and singular views (the
 // latter being get_ftpusers called with an ftp_login filter) return
@@ -46,46 +44,31 @@ type FTPUserList []FTPUser
 // Client groups the read endpoints scoped to FTP users:
 // get_ftpusers (list and singular).
 type Client struct {
-	API Caller
+	lg kasread.ListGet[FTPUserList, FTPUser]
 }
 
 // NewClient returns a Client backed by the given Caller.
-func NewClient(c Caller) *Client { return &Client{API: c} }
+func NewClient(c Caller) *Client {
+	return &Client{lg: kasread.ListGet[FTPUserList, FTPUser]{
+		Caller:    c,
+		Action:    "get_ftpusers",
+		Label:     "ftpuser",
+		ArgName:   "login",
+		FilterKey: "ftp_login",
+		Decoder:   DecodeFTPUsers,
+	}}
+}
 
 // List calls get_ftpusers without parameters and decodes the response
 // into an FTPUserList covering every FTP user visible to the login.
-func (c *Client) List(ctx context.Context) (FTPUserList, error) {
-	resp, err := c.API.Call(ctx, "get_ftpusers", nil)
-	if err != nil {
-		return nil, err
-	}
-	list, err := DecodeFTPUsers(resp.Body.ReturnInfo)
-	if err != nil {
-		return nil, fmt.Errorf("ftpuser: get_ftpusers: %w", err)
-	}
-	return list, nil
-}
+func (c *Client) List(ctx context.Context) (FTPUserList, error) { return c.lg.List(ctx) }
 
 // Get calls get_ftpusers with an ftp_login filter and returns the
 // single matching FTPUser. The KAS API still wraps the result in an
 // array; we unwrap it here so callers do not have to. An empty array
 // surfaces as a not-found error.
 func (c *Client) Get(ctx context.Context, login string) (FTPUser, error) {
-	if login == "" {
-		return FTPUser{}, fmt.Errorf("ftpuser: login is required")
-	}
-	resp, err := c.API.Call(ctx, "get_ftpusers", map[string]any{"ftp_login": login})
-	if err != nil {
-		return FTPUser{}, err
-	}
-	list, err := DecodeFTPUsers(resp.Body.ReturnInfo)
-	if err != nil {
-		return FTPUser{}, fmt.Errorf("ftpuser: get_ftpusers: %w", err)
-	}
-	if len(list) == 0 {
-		return FTPUser{}, fmt.Errorf("ftpuser: %q not found", login)
-	}
-	return list[0], nil
+	return c.lg.Get(ctx, login)
 }
 
 // DecodeFTPUsers maps the ReturnInfo of a get_ftpusers response (an

--- a/internal/kasread/kasread.go
+++ b/internal/kasread/kasread.go
@@ -1,0 +1,81 @@
+// Package kasread provides shared scaffolding for the read endpoints
+// of the KAS API. The scaffolding captures the canonical "fetch a
+// list, or a singular variant filtered by one field" shape that the
+// majority of internal/<module>.Client types need; modules consume
+// it from their own NewClient and expose List/Get methods that
+// delegate one-line.
+package kasread
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/chmmou/kasapi-cli/internal/soap"
+)
+
+// Caller is the subset of *api.Client that the read scaffolding
+// depends on. Each domain module previously redefined this same
+// interface; collecting it here removes the duplication while
+// keeping the dependency-inversion property — modules and tests
+// pass any value with a matching Call method (e.g. the shared
+// testutil.FakeCaller).
+type Caller interface {
+	Call(ctx context.Context, action string, params map[string]any) (*soap.Response, error)
+}
+
+// ListGet binds a KAS read action to its singular-variant filter
+// parameter and a typed decoder. The List/Get methods then drive
+// the canonical fetch + decode + first-or-not-found pipeline that
+// nearly every module's Client repeated by hand.
+//
+// L is the named list type (e.g. ddns.DDNSUserList); E is the
+// element type (e.g. ddns.DDNSUser). Decoder is the module's
+// existing Decode<Foo>s function — its signature already matches
+// the field, so callers pass it directly.
+type ListGet[L ~[]E, E any] struct {
+	Caller    Caller
+	Action    string // KAS action, e.g. "get_ddnsusers".
+	Label     string // module-name prefix used in error messages, e.g. "ddns".
+	ArgName   string // input name in the empty-input error, e.g. "login".
+	FilterKey string // KAS wire parameter name for Get, e.g. "ddns_login".
+	Decoder   func(soap.Value) (L, error)
+}
+
+// List calls Action with no parameters and returns the decoded
+// list. Decode errors are wrapped as "<Label>: <Action>: <err>".
+// Transport errors propagate verbatim so callers can keep using
+// api.IsNotFound and the other transport-error helpers.
+func (lg ListGet[L, E]) List(ctx context.Context) (L, error) {
+	resp, err := lg.Caller.Call(ctx, lg.Action, nil)
+	if err != nil {
+		return nil, err
+	}
+	list, err := lg.Decoder(resp.Body.ReturnInfo)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %s: %w", lg.Label, lg.Action, err)
+	}
+	return list, nil
+}
+
+// Get calls Action with {FilterKey: value} and returns the first
+// matching entry, or a "<Label>: %q not found" error if the response
+// carried an empty list. An empty value yields "<Label>: <ArgName>
+// is required" without performing the call.
+func (lg ListGet[L, E]) Get(ctx context.Context, value string) (E, error) {
+	var zero E
+	if value == "" {
+		return zero, fmt.Errorf("%s: %s is required", lg.Label, lg.ArgName)
+	}
+	resp, err := lg.Caller.Call(ctx, lg.Action, map[string]any{lg.FilterKey: value})
+	if err != nil {
+		return zero, err
+	}
+	list, err := lg.Decoder(resp.Body.ReturnInfo)
+	if err != nil {
+		return zero, fmt.Errorf("%s: %s: %w", lg.Label, lg.Action, err)
+	}
+	if len(list) == 0 {
+		return zero, fmt.Errorf("%s: %q not found", lg.Label, value)
+	}
+	return list[0], nil
+}

--- a/internal/kasread/kasread_test.go
+++ b/internal/kasread/kasread_test.go
@@ -1,0 +1,138 @@
+package kasread_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/chmmou/kasapi-cli/internal/kasread"
+	"github.com/chmmou/kasapi-cli/internal/soap"
+	"github.com/chmmou/kasapi-cli/internal/testutil"
+)
+
+type widget struct {
+	Name string
+}
+
+type widgetList []widget
+
+func decodeWidgets(v soap.Value) (widgetList, error) {
+	if v.Kind != soap.KindArray {
+		return nil, errors.New("not an array")
+	}
+	out := make(widgetList, 0, len(v.Array))
+	for _, item := range v.Array {
+		out = append(out, widget{Name: item.MapString("name")})
+	}
+	return out, nil
+}
+
+func arrayResp(names ...string) *soap.Response {
+	arr := make([]soap.Value, 0, len(names))
+	for _, n := range names {
+		arr = append(arr, soap.Value{
+			Kind: soap.KindMap,
+			Map:  []soap.KV{{Key: "name", Value: soap.Value{Kind: soap.KindString, String: n}}},
+		})
+	}
+	return &soap.Response{
+		Body: soap.ResponseBody{
+			ReturnInfo: soap.Value{Kind: soap.KindArray, Array: arr},
+		},
+	}
+}
+
+func newLG(fc *testutil.FakeCaller) kasread.ListGet[widgetList, widget] {
+	return kasread.ListGet[widgetList, widget]{
+		Caller:    fc,
+		Action:    "get_widgets",
+		Label:     "widget",
+		ArgName:   "name",
+		FilterKey: "widget_name",
+		Decoder:   decodeWidgets,
+	}
+}
+
+func TestListHappyPath(t *testing.T) {
+	fc := &testutil.FakeCaller{Resp: arrayResp("alice", "bob")}
+	got, err := newLG(fc).List(context.Background())
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if fc.GotAction != "get_widgets" {
+		t.Errorf("action = %q, want get_widgets", fc.GotAction)
+	}
+	if fc.GotParams != nil {
+		t.Errorf("params = %v, want nil", fc.GotParams)
+	}
+	if len(got) != 2 || got[0].Name != "alice" {
+		t.Errorf("got = %+v", got)
+	}
+}
+
+func TestListPropagatesTransportError(t *testing.T) {
+	want := errors.New("boom")
+	fc := &testutil.FakeCaller{Err: want}
+	if _, err := newLG(fc).List(context.Background()); !errors.Is(err, want) {
+		t.Errorf("err = %v, want errors.Is == %v", err, want)
+	}
+}
+
+func TestListWrapsDecodeError(t *testing.T) {
+	fc := &testutil.FakeCaller{Resp: &soap.Response{Body: soap.ResponseBody{ReturnInfo: soap.Value{Kind: soap.KindMap}}}}
+	_, err := newLG(fc).List(context.Background())
+	if err == nil {
+		t.Fatal("expected decode error, got nil")
+	}
+	if !strings.HasPrefix(err.Error(), "widget: get_widgets:") {
+		t.Errorf("err = %q, want prefix 'widget: get_widgets:'", err)
+	}
+}
+
+func TestGetHappyPath(t *testing.T) {
+	fc := &testutil.FakeCaller{Resp: arrayResp("alice")}
+	got, err := newLG(fc).Get(context.Background(), "alice")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if v, ok := fc.GotParams["widget_name"]; !ok || v != "alice" {
+		t.Errorf("widget_name param = %v (ok=%v), want alice", v, ok)
+	}
+	if got.Name != "alice" {
+		t.Errorf("got.Name = %q, want alice", got.Name)
+	}
+}
+
+func TestGetEmptyValue(t *testing.T) {
+	fc := &testutil.FakeCaller{}
+	_, err := newLG(fc).Get(context.Background(), "")
+	if err == nil {
+		t.Fatal("expected required-arg error, got nil")
+	}
+	if err.Error() != "widget: name is required" {
+		t.Errorf("err = %q, want exact 'widget: name is required'", err)
+	}
+	if fc.GotAction != "" {
+		t.Errorf("FakeCaller was called for empty input: action=%q", fc.GotAction)
+	}
+}
+
+func TestGetNotFound(t *testing.T) {
+	fc := &testutil.FakeCaller{Resp: arrayResp()}
+	_, err := newLG(fc).Get(context.Background(), "ghost")
+	if err == nil {
+		t.Fatal("expected not-found error, got nil")
+	}
+	if !strings.Contains(err.Error(), `"ghost" not found`) {
+		t.Errorf("err = %q, want it to contain '%q not found'", err, "ghost")
+	}
+}
+
+func TestGetPropagatesTransportError(t *testing.T) {
+	want := errors.New("boom")
+	fc := &testutil.FakeCaller{Err: want}
+	if _, err := newLG(fc).Get(context.Background(), "alice"); !errors.Is(err, want) {
+		t.Errorf("err = %v, want errors.Is == %v", err, want)
+	}
+}

--- a/internal/mailaccount/mailaccount.go
+++ b/internal/mailaccount/mailaccount.go
@@ -2,18 +2,16 @@ package mailaccount
 
 import (
 	"context"
-	"fmt"
 	"strconv"
 
+	"github.com/chmmou/kasapi-cli/internal/kasread"
 	"github.com/chmmou/kasapi-cli/internal/soap"
 )
 
 // Caller is the subset of *api.Client this package depends on. The
 // indirection keeps tests free of network setup: a fake Caller can
 // return a *soap.Response decoded from a fixture.
-type Caller interface {
-	Call(ctx context.Context, action string, params map[string]any) (*soap.Response, error)
-}
+type Caller = kasread.Caller
 
 // MailAccount is one entry of get_mailaccounts. The list and singular
 // views (the latter being get_mailaccounts called with a mail_login
@@ -68,47 +66,32 @@ type MailAccountList []MailAccount
 // Client groups the read endpoints scoped to mail accounts:
 // get_mailaccounts (list and singular).
 type Client struct {
-	API Caller
+	lg kasread.ListGet[MailAccountList, MailAccount]
 }
 
 // NewClient returns a Client backed by the given Caller.
-func NewClient(c Caller) *Client { return &Client{API: c} }
+func NewClient(c Caller) *Client {
+	return &Client{lg: kasread.ListGet[MailAccountList, MailAccount]{
+		Caller:    c,
+		Action:    "get_mailaccounts",
+		Label:     "mailaccount",
+		ArgName:   "login",
+		FilterKey: "mail_login",
+		Decoder:   DecodeMailAccounts,
+	}}
+}
 
 // List calls get_mailaccounts without parameters and decodes the
 // response into a MailAccountList covering every mail account visible
 // to the login.
-func (c *Client) List(ctx context.Context) (MailAccountList, error) {
-	resp, err := c.API.Call(ctx, "get_mailaccounts", nil)
-	if err != nil {
-		return nil, err
-	}
-	list, err := DecodeMailAccounts(resp.Body.ReturnInfo)
-	if err != nil {
-		return nil, fmt.Errorf("mailaccount: get_mailaccounts: %w", err)
-	}
-	return list, nil
-}
+func (c *Client) List(ctx context.Context) (MailAccountList, error) { return c.lg.List(ctx) }
 
 // Get calls get_mailaccounts with a mail_login filter and returns the
 // single matching MailAccount. The KAS API still wraps the result in
 // an array; we unwrap it here so callers do not have to. An empty
 // array surfaces as a not-found error.
 func (c *Client) Get(ctx context.Context, login string) (MailAccount, error) {
-	if login == "" {
-		return MailAccount{}, fmt.Errorf("mailaccount: login is required")
-	}
-	resp, err := c.API.Call(ctx, "get_mailaccounts", map[string]any{"mail_login": login})
-	if err != nil {
-		return MailAccount{}, err
-	}
-	list, err := DecodeMailAccounts(resp.Body.ReturnInfo)
-	if err != nil {
-		return MailAccount{}, fmt.Errorf("mailaccount: get_mailaccounts: %w", err)
-	}
-	if len(list) == 0 {
-		return MailAccount{}, fmt.Errorf("mailaccount: %q not found", login)
-	}
-	return list[0], nil
+	return c.lg.Get(ctx, login)
 }
 
 // DecodeMailAccounts maps the ReturnInfo of a get_mailaccounts response

--- a/internal/mailfilter/mailfilter.go
+++ b/internal/mailfilter/mailfilter.go
@@ -2,16 +2,14 @@ package mailfilter
 
 import (
 	"context"
-	"fmt"
 
+	"github.com/chmmou/kasapi-cli/internal/kasread"
 	"github.com/chmmou/kasapi-cli/internal/soap"
 )
 
 // Caller is the subset of *api.Client this package depends on. The
 // indirection keeps tests free of network setup.
-type Caller interface {
-	Call(ctx context.Context, action string, params map[string]any) (*soap.Response, error)
-}
+type Caller = kasread.Caller
 
 // StandardFilter is one entry of get_mailstandardfilter, describing a
 // preset spam/virus filter that can be referenced by `mail_spamfilter`
@@ -28,26 +26,26 @@ type StandardFilter struct {
 type StandardFilterList []StandardFilter
 
 // Client groups the read endpoint scoped to mail standard filters.
+// Get is intentionally absent — the KAS endpoint does not document a
+// filter parameter (see issue #73 NTH bundle), so only List is wired
+// up here.
 type Client struct {
-	API Caller
+	lg kasread.ListGet[StandardFilterList, StandardFilter]
 }
 
 // NewClient returns a Client backed by the given Caller.
-func NewClient(c Caller) *Client { return &Client{API: c} }
+func NewClient(c Caller) *Client {
+	return &Client{lg: kasread.ListGet[StandardFilterList, StandardFilter]{
+		Caller:  c,
+		Action:  "get_mailstandardfilter",
+		Label:   "mailfilter",
+		Decoder: DecodeStandardFilters,
+	}}
+}
 
 // List calls get_mailstandardfilter and decodes the response into a
 // StandardFilterList. The endpoint takes no parameters.
-func (c *Client) List(ctx context.Context) (StandardFilterList, error) {
-	resp, err := c.API.Call(ctx, "get_mailstandardfilter", nil)
-	if err != nil {
-		return nil, err
-	}
-	list, err := DecodeStandardFilters(resp.Body.ReturnInfo)
-	if err != nil {
-		return nil, fmt.Errorf("mailfilter: get_mailstandardfilter: %w", err)
-	}
-	return list, nil
-}
+func (c *Client) List(ctx context.Context) (StandardFilterList, error) { return c.lg.List(ctx) }
 
 // DecodeStandardFilters maps the ReturnInfo of a get_mailstandardfilter
 // response (an Array of Maps) into the typed StandardFilterList.

--- a/internal/mailforward/mailforward.go
+++ b/internal/mailforward/mailforward.go
@@ -2,16 +2,14 @@ package mailforward
 
 import (
 	"context"
-	"fmt"
 
+	"github.com/chmmou/kasapi-cli/internal/kasread"
 	"github.com/chmmou/kasapi-cli/internal/soap"
 )
 
 // Caller is the subset of *api.Client this package depends on. The
 // indirection keeps tests free of network setup.
-type Caller interface {
-	Call(ctx context.Context, action string, params map[string]any) (*soap.Response, error)
-}
+type Caller = kasread.Caller
 
 // MailForward is one entry of get_mailforwards. The list and singular
 // views (the latter being get_mailforwards called with a mail_forward
@@ -37,47 +35,32 @@ type MailForwardList []MailForward
 // Client groups the read endpoints scoped to mail forwards:
 // get_mailforwards (list and singular).
 type Client struct {
-	API Caller
+	lg kasread.ListGet[MailForwardList, MailForward]
 }
 
 // NewClient returns a Client backed by the given Caller.
-func NewClient(c Caller) *Client { return &Client{API: c} }
+func NewClient(c Caller) *Client {
+	return &Client{lg: kasread.ListGet[MailForwardList, MailForward]{
+		Caller:    c,
+		Action:    "get_mailforwards",
+		Label:     "mailforward",
+		ArgName:   "address",
+		FilterKey: "mail_forward",
+		Decoder:   DecodeMailForwards,
+	}}
+}
 
 // List calls get_mailforwards without parameters and decodes the
 // response into a MailForwardList covering every mail forward visible
 // to the login.
-func (c *Client) List(ctx context.Context) (MailForwardList, error) {
-	resp, err := c.API.Call(ctx, "get_mailforwards", nil)
-	if err != nil {
-		return nil, err
-	}
-	list, err := DecodeMailForwards(resp.Body.ReturnInfo)
-	if err != nil {
-		return nil, fmt.Errorf("mailforward: get_mailforwards: %w", err)
-	}
-	return list, nil
-}
+func (c *Client) List(ctx context.Context) (MailForwardList, error) { return c.lg.List(ctx) }
 
 // Get calls get_mailforwards with a mail_forward filter (the source
 // address) and returns the single matching MailForward. The KAS API
 // still wraps the result in an array; we unwrap it so callers do not
 // have to. An empty array surfaces as a not-found error.
 func (c *Client) Get(ctx context.Context, address string) (MailForward, error) {
-	if address == "" {
-		return MailForward{}, fmt.Errorf("mailforward: address is required")
-	}
-	resp, err := c.API.Call(ctx, "get_mailforwards", map[string]any{"mail_forward": address})
-	if err != nil {
-		return MailForward{}, err
-	}
-	list, err := DecodeMailForwards(resp.Body.ReturnInfo)
-	if err != nil {
-		return MailForward{}, fmt.Errorf("mailforward: get_mailforwards: %w", err)
-	}
-	if len(list) == 0 {
-		return MailForward{}, fmt.Errorf("mailforward: %q not found", address)
-	}
-	return list[0], nil
+	return c.lg.Get(ctx, address)
 }
 
 // DecodeMailForwards maps the ReturnInfo of a get_mailforwards response

--- a/internal/mailinglist/mailinglist.go
+++ b/internal/mailinglist/mailinglist.go
@@ -2,16 +2,14 @@ package mailinglist
 
 import (
 	"context"
-	"fmt"
 
+	"github.com/chmmou/kasapi-cli/internal/kasread"
 	"github.com/chmmou/kasapi-cli/internal/soap"
 )
 
 // Caller is the subset of *api.Client this package depends on. The
 // indirection keeps tests free of network setup.
-type Caller interface {
-	Call(ctx context.Context, action string, params map[string]any) (*soap.Response, error)
-}
+type Caller = kasread.Caller
 
 // MailingList is one entry of get_mailinglists. The list and singular
 // views (the latter being get_mailinglists called with a mailinglist_name
@@ -30,47 +28,32 @@ type MailingListList []MailingList
 // Client groups the read endpoints scoped to mailing lists:
 // get_mailinglists (list and singular).
 type Client struct {
-	API Caller
+	lg kasread.ListGet[MailingListList, MailingList]
 }
 
 // NewClient returns a Client backed by the given Caller.
-func NewClient(c Caller) *Client { return &Client{API: c} }
+func NewClient(c Caller) *Client {
+	return &Client{lg: kasread.ListGet[MailingListList, MailingList]{
+		Caller:    c,
+		Action:    "get_mailinglists",
+		Label:     "mailinglist",
+		ArgName:   "name",
+		FilterKey: "mailinglist_name",
+		Decoder:   DecodeMailingLists,
+	}}
+}
 
 // List calls get_mailinglists without parameters and decodes the
 // response into a MailingListList covering every mailing list visible
 // to the login.
-func (c *Client) List(ctx context.Context) (MailingListList, error) {
-	resp, err := c.API.Call(ctx, "get_mailinglists", nil)
-	if err != nil {
-		return nil, err
-	}
-	list, err := DecodeMailingLists(resp.Body.ReturnInfo)
-	if err != nil {
-		return nil, fmt.Errorf("mailinglist: get_mailinglists: %w", err)
-	}
-	return list, nil
-}
+func (c *Client) List(ctx context.Context) (MailingListList, error) { return c.lg.List(ctx) }
 
 // Get calls get_mailinglists with a mailinglist_name filter and returns
 // the single matching MailingList. The KAS API still wraps the result
 // in an array; we unwrap it so callers do not have to. An empty array
 // surfaces as a not-found error.
 func (c *Client) Get(ctx context.Context, name string) (MailingList, error) {
-	if name == "" {
-		return MailingList{}, fmt.Errorf("mailinglist: name is required")
-	}
-	resp, err := c.API.Call(ctx, "get_mailinglists", map[string]any{"mailinglist_name": name})
-	if err != nil {
-		return MailingList{}, err
-	}
-	list, err := DecodeMailingLists(resp.Body.ReturnInfo)
-	if err != nil {
-		return MailingList{}, fmt.Errorf("mailinglist: get_mailinglists: %w", err)
-	}
-	if len(list) == 0 {
-		return MailingList{}, fmt.Errorf("mailinglist: %q not found", name)
-	}
-	return list[0], nil
+	return c.lg.Get(ctx, name)
 }
 
 // DecodeMailingLists maps the ReturnInfo of a get_mailinglists response

--- a/internal/sambauser/sambauser.go
+++ b/internal/sambauser/sambauser.go
@@ -2,17 +2,15 @@ package sambauser
 
 import (
 	"context"
-	"fmt"
 
+	"github.com/chmmou/kasapi-cli/internal/kasread"
 	"github.com/chmmou/kasapi-cli/internal/soap"
 )
 
 // Caller is the subset of *api.Client this package depends on. The
 // indirection keeps tests free of network setup: a fake Caller can
 // return a *soap.Response decoded from a fixture.
-type Caller interface {
-	Call(ctx context.Context, action string, params map[string]any) (*soap.Response, error)
-}
+type Caller = kasread.Caller
 
 // SambaUser is one entry of get_sambausers. The list and singular
 // views (the latter being get_sambausers called with a samba_login
@@ -34,47 +32,32 @@ type SambaUserList []SambaUser
 // Client groups the read endpoints scoped to Samba users:
 // get_sambausers (list and singular).
 type Client struct {
-	API Caller
+	lg kasread.ListGet[SambaUserList, SambaUser]
 }
 
 // NewClient returns a Client backed by the given Caller.
-func NewClient(c Caller) *Client { return &Client{API: c} }
+func NewClient(c Caller) *Client {
+	return &Client{lg: kasread.ListGet[SambaUserList, SambaUser]{
+		Caller:    c,
+		Action:    "get_sambausers",
+		Label:     "sambauser",
+		ArgName:   "login",
+		FilterKey: "samba_login",
+		Decoder:   DecodeSambaUsers,
+	}}
+}
 
 // List calls get_sambausers without parameters and decodes the
 // response into a SambaUserList covering every Samba user visible to
 // the login.
-func (c *Client) List(ctx context.Context) (SambaUserList, error) {
-	resp, err := c.API.Call(ctx, "get_sambausers", nil)
-	if err != nil {
-		return nil, err
-	}
-	list, err := DecodeSambaUsers(resp.Body.ReturnInfo)
-	if err != nil {
-		return nil, fmt.Errorf("sambauser: get_sambausers: %w", err)
-	}
-	return list, nil
-}
+func (c *Client) List(ctx context.Context) (SambaUserList, error) { return c.lg.List(ctx) }
 
 // Get calls get_sambausers with a samba_login filter and returns the
 // single matching SambaUser. The KAS API still wraps the result in
 // an array; we unwrap it here so callers do not have to. An empty
 // array surfaces as a not-found error.
 func (c *Client) Get(ctx context.Context, login string) (SambaUser, error) {
-	if login == "" {
-		return SambaUser{}, fmt.Errorf("sambauser: login is required")
-	}
-	resp, err := c.API.Call(ctx, "get_sambausers", map[string]any{"samba_login": login})
-	if err != nil {
-		return SambaUser{}, err
-	}
-	list, err := DecodeSambaUsers(resp.Body.ReturnInfo)
-	if err != nil {
-		return SambaUser{}, fmt.Errorf("sambauser: get_sambausers: %w", err)
-	}
-	if len(list) == 0 {
-		return SambaUser{}, fmt.Errorf("sambauser: %q not found", login)
-	}
-	return list[0], nil
+	return c.lg.Get(ctx, login)
 }
 
 // DecodeSambaUsers maps the ReturnInfo of a get_sambausers response

--- a/internal/softwareinstall/softwareinstall.go
+++ b/internal/softwareinstall/softwareinstall.go
@@ -2,17 +2,15 @@ package softwareinstall
 
 import (
 	"context"
-	"fmt"
 
+	"github.com/chmmou/kasapi-cli/internal/kasread"
 	"github.com/chmmou/kasapi-cli/internal/soap"
 )
 
 // Caller is the subset of *api.Client this package depends on. The
 // indirection keeps tests free of network setup: a fake Caller can
 // return a *soap.Response decoded from a fixture.
-type Caller interface {
-	Call(ctx context.Context, action string, params map[string]any) (*soap.Response, error)
-}
+type Caller = kasread.Caller
 
 // SoftwareInstall is one entry of get_softwareinstall (note: the KAS
 // action name is singular for both the list and the filtered variant).
@@ -58,47 +56,32 @@ type SoftwareInstallList []SoftwareInstall
 // Client groups the read endpoint scoped to software-install
 // templates: get_softwareinstall (list and singular).
 type Client struct {
-	API Caller
+	lg kasread.ListGet[SoftwareInstallList, SoftwareInstall]
 }
 
 // NewClient returns a Client backed by the given Caller.
-func NewClient(c Caller) *Client { return &Client{API: c} }
+func NewClient(c Caller) *Client {
+	return &Client{lg: kasread.ListGet[SoftwareInstallList, SoftwareInstall]{
+		Caller:    c,
+		Action:    "get_softwareinstall",
+		Label:     "softwareinstall",
+		ArgName:   "id",
+		FilterKey: "software_id",
+		Decoder:   DecodeSoftwareInstalls,
+	}}
+}
 
 // List calls get_softwareinstall without parameters and decodes the
 // response into a SoftwareInstallList covering every installable
 // software package visible to the login.
-func (c *Client) List(ctx context.Context) (SoftwareInstallList, error) {
-	resp, err := c.API.Call(ctx, "get_softwareinstall", nil)
-	if err != nil {
-		return nil, err
-	}
-	list, err := DecodeSoftwareInstalls(resp.Body.ReturnInfo)
-	if err != nil {
-		return nil, fmt.Errorf("softwareinstall: get_softwareinstall: %w", err)
-	}
-	return list, nil
-}
+func (c *Client) List(ctx context.Context) (SoftwareInstallList, error) { return c.lg.List(ctx) }
 
 // Get calls get_softwareinstall with a software_id filter and returns
 // the single matching SoftwareInstall. The KAS API still wraps the
 // result in an array; we unwrap it here so callers do not have to.
 // An empty array surfaces as a not-found error.
 func (c *Client) Get(ctx context.Context, id string) (SoftwareInstall, error) {
-	if id == "" {
-		return SoftwareInstall{}, fmt.Errorf("softwareinstall: id is required")
-	}
-	resp, err := c.API.Call(ctx, "get_softwareinstall", map[string]any{"software_id": id})
-	if err != nil {
-		return SoftwareInstall{}, err
-	}
-	list, err := DecodeSoftwareInstalls(resp.Body.ReturnInfo)
-	if err != nil {
-		return SoftwareInstall{}, fmt.Errorf("softwareinstall: get_softwareinstall: %w", err)
-	}
-	if len(list) == 0 {
-		return SoftwareInstall{}, fmt.Errorf("softwareinstall: %q not found", id)
-	}
-	return list[0], nil
+	return c.lg.Get(ctx, id)
 }
 
 // DecodeSoftwareInstalls maps the ReturnInfo of a get_softwareinstall

--- a/internal/subdomain/subdomain.go
+++ b/internal/subdomain/subdomain.go
@@ -6,15 +6,14 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/chmmou/kasapi-cli/internal/kasread"
 	"github.com/chmmou/kasapi-cli/internal/soap"
 )
 
 // Caller is the subset of *api.Client this package depends on. The
 // indirection keeps tests free of network setup: a fake Caller can
 // return a *soap.Response decoded from a fixture.
-type Caller interface {
-	Call(ctx context.Context, action string, params map[string]any) (*soap.Response, error)
-}
+type Caller = kasread.Caller
 
 // Subdomain is one entry of get_subdomains. The KAS list view exposes
 // the account/server placement and a flattened SSL summary; the
@@ -66,47 +65,32 @@ type SubdomainList []Subdomain
 // Client groups the read endpoints scoped to subdomains:
 // get_subdomains (list and singular).
 type Client struct {
-	API Caller
+	lg kasread.ListGet[SubdomainList, Subdomain]
 }
 
 // NewClient returns a Client backed by the given Caller.
-func NewClient(c Caller) *Client { return &Client{API: c} }
+func NewClient(c Caller) *Client {
+	return &Client{lg: kasread.ListGet[SubdomainList, Subdomain]{
+		Caller:    c,
+		Action:    "get_subdomains",
+		Label:     "subdomain",
+		ArgName:   "name",
+		FilterKey: "subdomain_name",
+		Decoder:   DecodeSubdomains,
+	}}
+}
 
 // List calls get_subdomains without parameters and decodes the
 // response into a SubdomainList covering every subdomain visible to
 // the login.
-func (c *Client) List(ctx context.Context) (SubdomainList, error) {
-	resp, err := c.API.Call(ctx, "get_subdomains", nil)
-	if err != nil {
-		return nil, err
-	}
-	list, err := DecodeSubdomains(resp.Body.ReturnInfo)
-	if err != nil {
-		return nil, fmt.Errorf("subdomain: get_subdomains: %w", err)
-	}
-	return list, nil
-}
+func (c *Client) List(ctx context.Context) (SubdomainList, error) { return c.lg.List(ctx) }
 
 // Get calls get_subdomains with a subdomain_name filter and returns
 // the single matching Subdomain. The KAS API still wraps the result
 // in an array; we unwrap it here so callers do not have to. An empty
 // array surfaces as a not-found error.
 func (c *Client) Get(ctx context.Context, name string) (Subdomain, error) {
-	if name == "" {
-		return Subdomain{}, fmt.Errorf("subdomain: name is required")
-	}
-	resp, err := c.API.Call(ctx, "get_subdomains", map[string]any{"subdomain_name": name})
-	if err != nil {
-		return Subdomain{}, err
-	}
-	list, err := DecodeSubdomains(resp.Body.ReturnInfo)
-	if err != nil {
-		return Subdomain{}, fmt.Errorf("subdomain: get_subdomains: %w", err)
-	}
-	if len(list) == 0 {
-		return Subdomain{}, fmt.Errorf("subdomain: %q not found", name)
-	}
-	return list[0], nil
+	return c.lg.Get(ctx, name)
 }
 
 // DecodeSubdomains maps the ReturnInfo of a get_subdomains response


### PR DESCRIPTION
## Summary

Extract the duplicated `Client.List` / `Client.Get` boilerplate into a single generic helper `kasread.ListGet[L, E]`. The helper captures action / label / arg-name / filter-key / decoder once and drives the canonical fetch + decode + first-or-not-found pipeline.

12 modules with both List + Get (account, cronjob, database, ddns, domain, ftpuser, mailaccount, mailforward, mailinglist, sambauser, softwareinstall, subdomain) plus mailfilter (List only) now configure one ListGet in NewClient and expose `List` / `Get` as one-line delegates. The 13 duplicate per-module `Caller` interface definitions collapse to type aliases over `kasread.Caller`.

Behaviour is unchanged — same error messages (`"<label>: <argname> is required"`, `"<label>: %q not found"`, `"<label>: <action>: %w"`), same successful output, all existing per-module Client tests stay green without modification (the shared `testutil.FakeCaller` satisfies `kasread.Caller` structurally).

Part two of the cross-module-duplication clean-up bundle tracked in #73.

Refs #73