### PR TITLE
refactor(cli): collapse RunE bodies into runListE / runGetE factories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Replaced the duplicated `cobra.RunE` bodies in 14 CLI files
+  (account, cronjobs, databases, ddnsusers, directoryprotection,
+  domains, ftpusers, mail, sambausers, server, softwareinstalls,
+  subdomains, tlds, usage) with two generic factories
+  `runListE[T]` / `runGetE[T]` in `internal/cli/run.go`. Each
+  subcommand now passes a one-line closure that owns its module
+  client construction and the actual call; the factory handles
+  `BuildAPIClient`, `APIError(action)` wrapping, and `Render`. 28
+  RunE bodies migrated; behaviour and exit codes are unchanged.
+  Part three of the cross-module-duplication clean-up bundle
+  tracked in issue #73.
 - Replaced the duplicated `Client.List` / `Client.Get` boilerplate
   in 12 read modules (account, cronjob, database, ddns, domain,
   ftpuser, mailaccount, mailforward, mailinglist, sambauser,

--- a/internal/cli/account.go
+++ b/internal/cli/account.go
@@ -1,9 +1,12 @@
 package cli
 
 import (
+	"context"
+
 	"github.com/spf13/cobra"
 
 	"github.com/chmmou/kasapi-cli/internal/account"
+	"github.com/chmmou/kasapi-cli/internal/api"
 )
 
 // NewAccountCmd returns the "kasapi-cli accounts" subcommand tree:
@@ -29,20 +32,10 @@ func newAccountsListCmd(opts *RootOptions) *cobra.Command {
 		Use:   "list",
 		Short: "List accounts visible to the login (get_accounts, no filter)",
 		Args:  cobra.NoArgs,
-		RunE: func(cmd *cobra.Command, _ []string) error {
-			api, err := BuildAPIClient(opts)
-			if err != nil {
-				return err
-			}
-			accs, err := account.NewClient(api).List(cmd.Context())
-			if err != nil {
-				return APIError(err, "get_accounts")
-			}
-			if err := Render(cmd.OutOrStdout(), opts.Output, account.AccountList(accs)); err != nil {
-				return UserError(err, "render")
-			}
-			return nil
-		},
+		RunE: runListE(opts, "get_accounts", func(c *api.Client, ctx context.Context) (account.AccountList, error) {
+			accs, err := account.NewClient(c).List(ctx)
+			return account.AccountList(accs), err
+		}),
 	}
 }
 
@@ -51,20 +44,9 @@ func newAccountsGetCmd(opts *RootOptions) *cobra.Command {
 		Use:   "get <account-login>",
 		Short: "Show details for a single account (get_accounts with account_login)",
 		Args:  cobra.ExactArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			api, err := BuildAPIClient(opts)
-			if err != nil {
-				return err
-			}
-			a, err := account.NewClient(api).Get(cmd.Context(), args[0])
-			if err != nil {
-				return APIError(err, "get_accounts")
-			}
-			if err := Render(cmd.OutOrStdout(), opts.Output, a); err != nil {
-				return UserError(err, "render")
-			}
-			return nil
-		},
+		RunE: runGetE(opts, "get_accounts", func(c *api.Client, ctx context.Context, arg string) (account.Account, error) {
+			return account.NewClient(c).Get(ctx, arg)
+		}),
 	}
 }
 
@@ -73,20 +55,9 @@ func newAccountsSettingsCmd(opts *RootOptions) *cobra.Command {
 		Use:   "settings",
 		Short: "Show settings for the authenticated account (get_accountsettings)",
 		Args:  cobra.NoArgs,
-		RunE: func(cmd *cobra.Command, _ []string) error {
-			api, err := BuildAPIClient(opts)
-			if err != nil {
-				return err
-			}
-			s, err := account.NewClient(api).Settings(cmd.Context())
-			if err != nil {
-				return APIError(err, "get_accountsettings")
-			}
-			if err := Render(cmd.OutOrStdout(), opts.Output, s); err != nil {
-				return UserError(err, "render")
-			}
-			return nil
-		},
+		RunE: runListE(opts, "get_accountsettings", func(c *api.Client, ctx context.Context) (account.AccountSettings, error) {
+			return account.NewClient(c).Settings(ctx)
+		}),
 	}
 }
 
@@ -95,19 +66,8 @@ func newAccountsResourcesCmd(opts *RootOptions) *cobra.Command {
 		Use:   "resources",
 		Short: "Show quota counters for the authenticated account (get_accountresources)",
 		Args:  cobra.NoArgs,
-		RunE: func(cmd *cobra.Command, _ []string) error {
-			api, err := BuildAPIClient(opts)
-			if err != nil {
-				return err
-			}
-			r, err := account.NewClient(api).Resources(cmd.Context())
-			if err != nil {
-				return APIError(err, "get_accountresources")
-			}
-			if err := Render(cmd.OutOrStdout(), opts.Output, r); err != nil {
-				return UserError(err, "render")
-			}
-			return nil
-		},
+		RunE: runListE(opts, "get_accountresources", func(c *api.Client, ctx context.Context) (account.AccountResources, error) {
+			return account.NewClient(c).Resources(ctx)
+		}),
 	}
 }

--- a/internal/cli/cronjobs.go
+++ b/internal/cli/cronjobs.go
@@ -1,8 +1,11 @@
 package cli
 
 import (
+	"context"
+
 	"github.com/spf13/cobra"
 
+	"github.com/chmmou/kasapi-cli/internal/api"
 	"github.com/chmmou/kasapi-cli/internal/cronjob"
 )
 
@@ -26,20 +29,9 @@ func newCronjobsListCmd(opts *RootOptions) *cobra.Command {
 		Use:   "list",
 		Short: "List all cronjobs (get_cronjobs, no filter)",
 		Args:  cobra.NoArgs,
-		RunE: func(cmd *cobra.Command, _ []string) error {
-			api, err := BuildAPIClient(opts)
-			if err != nil {
-				return err
-			}
-			list, err := cronjob.NewClient(api).List(cmd.Context())
-			if err != nil {
-				return APIError(err, "get_cronjobs")
-			}
-			if err := Render(cmd.OutOrStdout(), opts.Output, list); err != nil {
-				return UserError(err, "render")
-			}
-			return nil
-		},
+		RunE: runListE(opts, "get_cronjobs", func(c *api.Client, ctx context.Context) (cronjob.CronjobList, error) {
+			return cronjob.NewClient(c).List(ctx)
+		}),
 	}
 }
 
@@ -48,19 +40,8 @@ func newCronjobsGetCmd(opts *RootOptions) *cobra.Command {
 		Use:   "get <cronjob-id>",
 		Short: "Show details for a single cronjob (get_cronjobs with cronjob_id)",
 		Args:  cobra.ExactArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			api, err := BuildAPIClient(opts)
-			if err != nil {
-				return err
-			}
-			c, err := cronjob.NewClient(api).Get(cmd.Context(), args[0])
-			if err != nil {
-				return APIError(err, "get_cronjobs")
-			}
-			if err := Render(cmd.OutOrStdout(), opts.Output, c); err != nil {
-				return UserError(err, "render")
-			}
-			return nil
-		},
+		RunE: runGetE(opts, "get_cronjobs", func(c *api.Client, ctx context.Context, arg string) (cronjob.Cronjob, error) {
+			return cronjob.NewClient(c).Get(ctx, arg)
+		}),
 	}
 }

--- a/internal/cli/databases.go
+++ b/internal/cli/databases.go
@@ -1,8 +1,11 @@
 package cli
 
 import (
+	"context"
+
 	"github.com/spf13/cobra"
 
+	"github.com/chmmou/kasapi-cli/internal/api"
 	"github.com/chmmou/kasapi-cli/internal/database"
 )
 
@@ -26,20 +29,9 @@ func newDatabasesListCmd(opts *RootOptions) *cobra.Command {
 		Use:   "list",
 		Short: "List all databases (get_databases, no filter)",
 		Args:  cobra.NoArgs,
-		RunE: func(cmd *cobra.Command, _ []string) error {
-			api, err := BuildAPIClient(opts)
-			if err != nil {
-				return err
-			}
-			list, err := database.NewClient(api).List(cmd.Context())
-			if err != nil {
-				return APIError(err, "get_databases")
-			}
-			if err := Render(cmd.OutOrStdout(), opts.Output, list); err != nil {
-				return UserError(err, "render")
-			}
-			return nil
-		},
+		RunE: runListE(opts, "get_databases", func(c *api.Client, ctx context.Context) (database.DatabaseList, error) {
+			return database.NewClient(c).List(ctx)
+		}),
 	}
 }
 
@@ -48,19 +40,8 @@ func newDatabasesGetCmd(opts *RootOptions) *cobra.Command {
 		Use:   "get <database-login>",
 		Short: "Show details for a single database (get_databases with database_login)",
 		Args:  cobra.ExactArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			api, err := BuildAPIClient(opts)
-			if err != nil {
-				return err
-			}
-			d, err := database.NewClient(api).Get(cmd.Context(), args[0])
-			if err != nil {
-				return APIError(err, "get_databases")
-			}
-			if err := Render(cmd.OutOrStdout(), opts.Output, d); err != nil {
-				return UserError(err, "render")
-			}
-			return nil
-		},
+		RunE: runGetE(opts, "get_databases", func(c *api.Client, ctx context.Context, arg string) (database.Database, error) {
+			return database.NewClient(c).Get(ctx, arg)
+		}),
 	}
 }

--- a/internal/cli/ddnsusers.go
+++ b/internal/cli/ddnsusers.go
@@ -1,8 +1,11 @@
 package cli
 
 import (
+	"context"
+
 	"github.com/spf13/cobra"
 
+	"github.com/chmmou/kasapi-cli/internal/api"
 	"github.com/chmmou/kasapi-cli/internal/ddns"
 )
 
@@ -29,20 +32,9 @@ func newDDNSUsersListCmd(opts *RootOptions) *cobra.Command {
 		Use:   "list",
 		Short: "List all DDNS users (get_ddnsusers, no filter)",
 		Args:  cobra.NoArgs,
-		RunE: func(cmd *cobra.Command, _ []string) error {
-			api, err := BuildAPIClient(opts)
-			if err != nil {
-				return err
-			}
-			list, err := ddns.NewClient(api).List(cmd.Context())
-			if err != nil {
-				return APIError(err, "get_ddnsusers")
-			}
-			if err := Render(cmd.OutOrStdout(), opts.Output, list); err != nil {
-				return UserError(err, "render")
-			}
-			return nil
-		},
+		RunE: runListE(opts, "get_ddnsusers", func(c *api.Client, ctx context.Context) (ddns.DDNSUserList, error) {
+			return ddns.NewClient(c).List(ctx)
+		}),
 	}
 }
 
@@ -51,19 +43,8 @@ func newDDNSUsersGetCmd(opts *RootOptions) *cobra.Command {
 		Use:   "get <dyndns-login>",
 		Short: "Show details for a single DDNS user (get_ddnsusers with ddns_login)",
 		Args:  cobra.ExactArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			api, err := BuildAPIClient(opts)
-			if err != nil {
-				return err
-			}
-			u, err := ddns.NewClient(api).Get(cmd.Context(), args[0])
-			if err != nil {
-				return APIError(err, "get_ddnsusers")
-			}
-			if err := Render(cmd.OutOrStdout(), opts.Output, u); err != nil {
-				return UserError(err, "render")
-			}
-			return nil
-		},
+		RunE: runGetE(opts, "get_ddnsusers", func(c *api.Client, ctx context.Context, arg string) (ddns.DDNSUser, error) {
+			return ddns.NewClient(c).Get(ctx, arg)
+		}),
 	}
 }

--- a/internal/cli/directoryprotection.go
+++ b/internal/cli/directoryprotection.go
@@ -1,8 +1,11 @@
 package cli
 
 import (
+	"context"
+
 	"github.com/spf13/cobra"
 
+	"github.com/chmmou/kasapi-cli/internal/api"
 	"github.com/chmmou/kasapi-cli/internal/directoryprotection"
 )
 
@@ -27,20 +30,9 @@ func newDirectoryProtectionListCmd(opts *RootOptions) *cobra.Command {
 		Use:   "list",
 		Short: "List directory protections, optionally filtered by --path",
 		Args:  cobra.NoArgs,
-		RunE: func(cmd *cobra.Command, _ []string) error {
-			api, err := BuildAPIClient(opts)
-			if err != nil {
-				return err
-			}
-			list, err := directoryprotection.NewClient(api).List(cmd.Context(), path)
-			if err != nil {
-				return APIError(err, "get_directoryprotection")
-			}
-			if err := Render(cmd.OutOrStdout(), opts.Output, list); err != nil {
-				return UserError(err, "render")
-			}
-			return nil
-		},
+		RunE: runListE(opts, "get_directoryprotection", func(c *api.Client, ctx context.Context) (directoryprotection.DirectoryProtectionList, error) {
+			return directoryprotection.NewClient(c).List(ctx, path)
+		}),
 	}
 	cmd.Flags().StringVar(&path, "path", "",
 		"directory path to filter on (e.g. /protected/directory/); empty returns every protection")

--- a/internal/cli/domains.go
+++ b/internal/cli/domains.go
@@ -1,8 +1,11 @@
 package cli
 
 import (
+	"context"
+
 	"github.com/spf13/cobra"
 
+	"github.com/chmmou/kasapi-cli/internal/api"
 	"github.com/chmmou/kasapi-cli/internal/domain"
 )
 
@@ -25,20 +28,9 @@ func newDomainsListCmd(opts *RootOptions) *cobra.Command {
 		Use:   "list",
 		Short: "List all domains (get_domains)",
 		Args:  cobra.NoArgs,
-		RunE: func(cmd *cobra.Command, _ []string) error {
-			api, err := BuildAPIClient(opts)
-			if err != nil {
-				return err
-			}
-			list, err := domain.NewClient(api).List(cmd.Context())
-			if err != nil {
-				return APIError(err, "get_domains")
-			}
-			if err := Render(cmd.OutOrStdout(), opts.Output, list); err != nil {
-				return UserError(err, "render")
-			}
-			return nil
-		},
+		RunE: runListE(opts, "get_domains", func(c *api.Client, ctx context.Context) (domain.DomainList, error) {
+			return domain.NewClient(c).List(ctx)
+		}),
 	}
 }
 
@@ -47,19 +39,8 @@ func newDomainsGetCmd(opts *RootOptions) *cobra.Command {
 		Use:   "get <domain>",
 		Short: "Show details for a single domain (get_domains with domain_name)",
 		Args:  cobra.ExactArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			api, err := BuildAPIClient(opts)
-			if err != nil {
-				return err
-			}
-			d, err := domain.NewClient(api).Get(cmd.Context(), args[0])
-			if err != nil {
-				return APIError(err, "get_domains")
-			}
-			if err := Render(cmd.OutOrStdout(), opts.Output, d); err != nil {
-				return UserError(err, "render")
-			}
-			return nil
-		},
+		RunE: runGetE(opts, "get_domains", func(c *api.Client, ctx context.Context, arg string) (domain.Domain, error) {
+			return domain.NewClient(c).Get(ctx, arg)
+		}),
 	}
 }

--- a/internal/cli/ftpusers.go
+++ b/internal/cli/ftpusers.go
@@ -1,8 +1,11 @@
 package cli
 
 import (
+	"context"
+
 	"github.com/spf13/cobra"
 
+	"github.com/chmmou/kasapi-cli/internal/api"
 	"github.com/chmmou/kasapi-cli/internal/ftpuser"
 )
 
@@ -26,20 +29,9 @@ func newFTPUsersListCmd(opts *RootOptions) *cobra.Command {
 		Use:   "list",
 		Short: "List all FTP users (get_ftpusers, no filter)",
 		Args:  cobra.NoArgs,
-		RunE: func(cmd *cobra.Command, _ []string) error {
-			api, err := BuildAPIClient(opts)
-			if err != nil {
-				return err
-			}
-			list, err := ftpuser.NewClient(api).List(cmd.Context())
-			if err != nil {
-				return APIError(err, "get_ftpusers")
-			}
-			if err := Render(cmd.OutOrStdout(), opts.Output, list); err != nil {
-				return UserError(err, "render")
-			}
-			return nil
-		},
+		RunE: runListE(opts, "get_ftpusers", func(c *api.Client, ctx context.Context) (ftpuser.FTPUserList, error) {
+			return ftpuser.NewClient(c).List(ctx)
+		}),
 	}
 }
 
@@ -48,19 +40,8 @@ func newFTPUsersGetCmd(opts *RootOptions) *cobra.Command {
 		Use:   "get <ftp-login>",
 		Short: "Show details for a single FTP user (get_ftpusers with ftp_login)",
 		Args:  cobra.ExactArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			api, err := BuildAPIClient(opts)
-			if err != nil {
-				return err
-			}
-			u, err := ftpuser.NewClient(api).Get(cmd.Context(), args[0])
-			if err != nil {
-				return APIError(err, "get_ftpusers")
-			}
-			if err := Render(cmd.OutOrStdout(), opts.Output, u); err != nil {
-				return UserError(err, "render")
-			}
-			return nil
-		},
+		RunE: runGetE(opts, "get_ftpusers", func(c *api.Client, ctx context.Context, arg string) (ftpuser.FTPUser, error) {
+			return ftpuser.NewClient(c).Get(ctx, arg)
+		}),
 	}
 }

--- a/internal/cli/mail.go
+++ b/internal/cli/mail.go
@@ -1,8 +1,11 @@
 package cli
 
 import (
+	"context"
+
 	"github.com/spf13/cobra"
 
+	"github.com/chmmou/kasapi-cli/internal/api"
 	"github.com/chmmou/kasapi-cli/internal/mailaccount"
 	"github.com/chmmou/kasapi-cli/internal/mailfilter"
 	"github.com/chmmou/kasapi-cli/internal/mailforward"
@@ -43,20 +46,9 @@ func newMailListsListCmd(opts *RootOptions) *cobra.Command {
 		Use:   "list",
 		Short: "List all mailing lists (get_mailinglists)",
 		Args:  cobra.NoArgs,
-		RunE: func(cmd *cobra.Command, _ []string) error {
-			api, err := BuildAPIClient(opts)
-			if err != nil {
-				return err
-			}
-			list, err := mailinglist.NewClient(api).List(cmd.Context())
-			if err != nil {
-				return APIError(err, "get_mailinglists")
-			}
-			if err := Render(cmd.OutOrStdout(), opts.Output, list); err != nil {
-				return UserError(err, "render")
-			}
-			return nil
-		},
+		RunE: runListE(opts, "get_mailinglists", func(c *api.Client, ctx context.Context) (mailinglist.MailingListList, error) {
+			return mailinglist.NewClient(c).List(ctx)
+		}),
 	}
 }
 
@@ -65,20 +57,9 @@ func newMailListsGetCmd(opts *RootOptions) *cobra.Command {
 		Use:   "get <mailinglist-name>",
 		Short: "Show details for a single mailing list (get_mailinglists with mailinglist_name)",
 		Args:  cobra.ExactArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			api, err := BuildAPIClient(opts)
-			if err != nil {
-				return err
-			}
-			m, err := mailinglist.NewClient(api).Get(cmd.Context(), args[0])
-			if err != nil {
-				return APIError(err, "get_mailinglists")
-			}
-			if err := Render(cmd.OutOrStdout(), opts.Output, m); err != nil {
-				return UserError(err, "render")
-			}
-			return nil
-		},
+		RunE: runGetE(opts, "get_mailinglists", func(c *api.Client, ctx context.Context, arg string) (mailinglist.MailingList, error) {
+			return mailinglist.NewClient(c).Get(ctx, arg)
+		}),
 	}
 }
 
@@ -96,20 +77,9 @@ func newMailFiltersListCmd(opts *RootOptions) *cobra.Command {
 		Use:   "list",
 		Short: "List the available standard mail filters (get_mailstandardfilter)",
 		Args:  cobra.NoArgs,
-		RunE: func(cmd *cobra.Command, _ []string) error {
-			api, err := BuildAPIClient(opts)
-			if err != nil {
-				return err
-			}
-			list, err := mailfilter.NewClient(api).List(cmd.Context())
-			if err != nil {
-				return APIError(err, "get_mailstandardfilter")
-			}
-			if err := Render(cmd.OutOrStdout(), opts.Output, list); err != nil {
-				return UserError(err, "render")
-			}
-			return nil
-		},
+		RunE: runListE(opts, "get_mailstandardfilter", func(c *api.Client, ctx context.Context) (mailfilter.StandardFilterList, error) {
+			return mailfilter.NewClient(c).List(ctx)
+		}),
 	}
 }
 
@@ -130,20 +100,9 @@ func newMailAccountsListCmd(opts *RootOptions) *cobra.Command {
 		Use:   "list",
 		Short: "List all mail accounts (get_mailaccounts)",
 		Args:  cobra.NoArgs,
-		RunE: func(cmd *cobra.Command, _ []string) error {
-			api, err := BuildAPIClient(opts)
-			if err != nil {
-				return err
-			}
-			list, err := mailaccount.NewClient(api).List(cmd.Context())
-			if err != nil {
-				return APIError(err, "get_mailaccounts")
-			}
-			if err := Render(cmd.OutOrStdout(), opts.Output, list); err != nil {
-				return UserError(err, "render")
-			}
-			return nil
-		},
+		RunE: runListE(opts, "get_mailaccounts", func(c *api.Client, ctx context.Context) (mailaccount.MailAccountList, error) {
+			return mailaccount.NewClient(c).List(ctx)
+		}),
 	}
 }
 
@@ -152,20 +111,9 @@ func newMailAccountsGetCmd(opts *RootOptions) *cobra.Command {
 		Use:   "get <mail-login>",
 		Short: "Show details for a single mail account (get_mailaccounts with mail_login)",
 		Args:  cobra.ExactArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			api, err := BuildAPIClient(opts)
-			if err != nil {
-				return err
-			}
-			a, err := mailaccount.NewClient(api).Get(cmd.Context(), args[0])
-			if err != nil {
-				return APIError(err, "get_mailaccounts")
-			}
-			if err := Render(cmd.OutOrStdout(), opts.Output, a); err != nil {
-				return UserError(err, "render")
-			}
-			return nil
-		},
+		RunE: runGetE(opts, "get_mailaccounts", func(c *api.Client, ctx context.Context, arg string) (mailaccount.MailAccount, error) {
+			return mailaccount.NewClient(c).Get(ctx, arg)
+		}),
 	}
 }
 
@@ -186,20 +134,9 @@ func newMailForwardsListCmd(opts *RootOptions) *cobra.Command {
 		Use:   "list",
 		Short: "List all mail forwards (get_mailforwards)",
 		Args:  cobra.NoArgs,
-		RunE: func(cmd *cobra.Command, _ []string) error {
-			api, err := BuildAPIClient(opts)
-			if err != nil {
-				return err
-			}
-			list, err := mailforward.NewClient(api).List(cmd.Context())
-			if err != nil {
-				return APIError(err, "get_mailforwards")
-			}
-			if err := Render(cmd.OutOrStdout(), opts.Output, list); err != nil {
-				return UserError(err, "render")
-			}
-			return nil
-		},
+		RunE: runListE(opts, "get_mailforwards", func(c *api.Client, ctx context.Context) (mailforward.MailForwardList, error) {
+			return mailforward.NewClient(c).List(ctx)
+		}),
 	}
 }
 
@@ -208,19 +145,8 @@ func newMailForwardsGetCmd(opts *RootOptions) *cobra.Command {
 		Use:   "get <address>",
 		Short: "Show details for a single mail forward (get_mailforwards with mail_forward)",
 		Args:  cobra.ExactArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			api, err := BuildAPIClient(opts)
-			if err != nil {
-				return err
-			}
-			f, err := mailforward.NewClient(api).Get(cmd.Context(), args[0])
-			if err != nil {
-				return APIError(err, "get_mailforwards")
-			}
-			if err := Render(cmd.OutOrStdout(), opts.Output, f); err != nil {
-				return UserError(err, "render")
-			}
-			return nil
-		},
+		RunE: runGetE(opts, "get_mailforwards", func(c *api.Client, ctx context.Context, arg string) (mailforward.MailForward, error) {
+			return mailforward.NewClient(c).Get(ctx, arg)
+		}),
 	}
 }

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -1,0 +1,73 @@
+package cli
+
+import (
+	"context"
+
+	"github.com/spf13/cobra"
+
+	"github.com/chmmou/kasapi-cli/internal/api"
+)
+
+// runListE returns a cobra RunE closure that follows the canonical
+// read-subcommand shape: build the API client, run the supplied
+// fetch, wrap a transport error as APIError(action), and render the
+// result. It is the no-positional-argument variant — used by `list`,
+// `info`, `space`, `space-detail`, `settings`, `resources`, and the
+// other no-arg subcommands.
+//
+// fetch owns the module client construction and the actual call;
+// callers typically pass a one-line closure such as
+//
+//	func(c *api.Client, ctx context.Context) (ddns.DDNSUserList, error) {
+//	    return ddns.NewClient(c).List(ctx)
+//	}
+//
+// Flag-derived parameters are passed in via the closure's capture.
+func runListE[T any](
+	opts *RootOptions,
+	action string,
+	fetch func(c *api.Client, ctx context.Context) (T, error),
+) func(*cobra.Command, []string) error {
+	return func(cmd *cobra.Command, _ []string) error {
+		c, err := BuildAPIClient(opts)
+		if err != nil {
+			return err
+		}
+		v, err := fetch(c, cmd.Context())
+		if err != nil {
+			return APIError(err, action)
+		}
+		if err := Render(cmd.OutOrStdout(), opts.Output, v); err != nil {
+			return UserError(err, "render")
+		}
+		return nil
+	}
+}
+
+// runGetE is the cobra.ExactArgs(1) variant of runListE — fetch
+// additionally receives args[0]. The standard caller passes the
+// module's Client.Get method curried through a closure:
+//
+//	func(c *api.Client, ctx context.Context, arg string) (ddns.DDNSUser, error) {
+//	    return ddns.NewClient(c).Get(ctx, arg)
+//	}
+func runGetE[T any](
+	opts *RootOptions,
+	action string,
+	fetch func(c *api.Client, ctx context.Context, arg string) (T, error),
+) func(*cobra.Command, []string) error {
+	return func(cmd *cobra.Command, args []string) error {
+		c, err := BuildAPIClient(opts)
+		if err != nil {
+			return err
+		}
+		v, err := fetch(c, cmd.Context(), args[0])
+		if err != nil {
+			return APIError(err, action)
+		}
+		if err := Render(cmd.OutOrStdout(), opts.Output, v); err != nil {
+			return UserError(err, "render")
+		}
+		return nil
+	}
+}

--- a/internal/cli/sambausers.go
+++ b/internal/cli/sambausers.go
@@ -1,8 +1,11 @@
 package cli
 
 import (
+	"context"
+
 	"github.com/spf13/cobra"
 
+	"github.com/chmmou/kasapi-cli/internal/api"
 	"github.com/chmmou/kasapi-cli/internal/sambauser"
 )
 
@@ -26,20 +29,9 @@ func newSambaUsersListCmd(opts *RootOptions) *cobra.Command {
 		Use:   "list",
 		Short: "List all Samba users (get_sambausers, no filter)",
 		Args:  cobra.NoArgs,
-		RunE: func(cmd *cobra.Command, _ []string) error {
-			api, err := BuildAPIClient(opts)
-			if err != nil {
-				return err
-			}
-			list, err := sambauser.NewClient(api).List(cmd.Context())
-			if err != nil {
-				return APIError(err, "get_sambausers")
-			}
-			if err := Render(cmd.OutOrStdout(), opts.Output, list); err != nil {
-				return UserError(err, "render")
-			}
-			return nil
-		},
+		RunE: runListE(opts, "get_sambausers", func(c *api.Client, ctx context.Context) (sambauser.SambaUserList, error) {
+			return sambauser.NewClient(c).List(ctx)
+		}),
 	}
 }
 
@@ -48,19 +40,8 @@ func newSambaUsersGetCmd(opts *RootOptions) *cobra.Command {
 		Use:   "get <samba-login>",
 		Short: "Show details for a single Samba user (get_sambausers with samba_login)",
 		Args:  cobra.ExactArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			api, err := BuildAPIClient(opts)
-			if err != nil {
-				return err
-			}
-			u, err := sambauser.NewClient(api).Get(cmd.Context(), args[0])
-			if err != nil {
-				return APIError(err, "get_sambausers")
-			}
-			if err := Render(cmd.OutOrStdout(), opts.Output, u); err != nil {
-				return UserError(err, "render")
-			}
-			return nil
-		},
+		RunE: runGetE(opts, "get_sambausers", func(c *api.Client, ctx context.Context, arg string) (sambauser.SambaUser, error) {
+			return sambauser.NewClient(c).Get(ctx, arg)
+		}),
 	}
 }

--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -1,8 +1,11 @@
 package cli
 
 import (
+	"context"
+
 	"github.com/spf13/cobra"
 
+	"github.com/chmmou/kasapi-cli/internal/api"
 	"github.com/chmmou/kasapi-cli/internal/server"
 )
 
@@ -22,19 +25,8 @@ func newServerInfoCmd(opts *RootOptions) *cobra.Command {
 		Use:   "info",
 		Short: "List installed services and versions (get_server_information)",
 		Args:  cobra.NoArgs,
-		RunE: func(cmd *cobra.Command, _ []string) error {
-			api, err := BuildAPIClient(opts)
-			if err != nil {
-				return err
-			}
-			list, err := server.NewClient(api).Information(cmd.Context())
-			if err != nil {
-				return APIError(err, "get_server_information")
-			}
-			if err := Render(cmd.OutOrStdout(), opts.Output, list); err != nil {
-				return UserError(err, "render")
-			}
-			return nil
-		},
+		RunE: runListE(opts, "get_server_information", func(c *api.Client, ctx context.Context) (server.ServiceList, error) {
+			return server.NewClient(c).Information(ctx)
+		}),
 	}
 }

--- a/internal/cli/softwareinstalls.go
+++ b/internal/cli/softwareinstalls.go
@@ -1,8 +1,11 @@
 package cli
 
 import (
+	"context"
+
 	"github.com/spf13/cobra"
 
+	"github.com/chmmou/kasapi-cli/internal/api"
 	"github.com/chmmou/kasapi-cli/internal/softwareinstall"
 )
 
@@ -27,20 +30,9 @@ func newSoftwareInstallsListCmd(opts *RootOptions) *cobra.Command {
 		Use:   "list",
 		Short: "List all installable software templates (get_softwareinstall, no filter)",
 		Args:  cobra.NoArgs,
-		RunE: func(cmd *cobra.Command, _ []string) error {
-			api, err := BuildAPIClient(opts)
-			if err != nil {
-				return err
-			}
-			list, err := softwareinstall.NewClient(api).List(cmd.Context())
-			if err != nil {
-				return APIError(err, "get_softwareinstall")
-			}
-			if err := Render(cmd.OutOrStdout(), opts.Output, list); err != nil {
-				return UserError(err, "render")
-			}
-			return nil
-		},
+		RunE: runListE(opts, "get_softwareinstall", func(c *api.Client, ctx context.Context) (softwareinstall.SoftwareInstallList, error) {
+			return softwareinstall.NewClient(c).List(ctx)
+		}),
 	}
 }
 
@@ -49,19 +41,8 @@ func newSoftwareInstallsGetCmd(opts *RootOptions) *cobra.Command {
 		Use:   "get <software-id>",
 		Short: "Show details for a single software template (get_softwareinstall with software_id)",
 		Args:  cobra.ExactArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			api, err := BuildAPIClient(opts)
-			if err != nil {
-				return err
-			}
-			s, err := softwareinstall.NewClient(api).Get(cmd.Context(), args[0])
-			if err != nil {
-				return APIError(err, "get_softwareinstall")
-			}
-			if err := Render(cmd.OutOrStdout(), opts.Output, s); err != nil {
-				return UserError(err, "render")
-			}
-			return nil
-		},
+		RunE: runGetE(opts, "get_softwareinstall", func(c *api.Client, ctx context.Context, arg string) (softwareinstall.SoftwareInstall, error) {
+			return softwareinstall.NewClient(c).Get(ctx, arg)
+		}),
 	}
 }

--- a/internal/cli/subdomains.go
+++ b/internal/cli/subdomains.go
@@ -1,8 +1,11 @@
 package cli
 
 import (
+	"context"
+
 	"github.com/spf13/cobra"
 
+	"github.com/chmmou/kasapi-cli/internal/api"
 	"github.com/chmmou/kasapi-cli/internal/subdomain"
 )
 
@@ -25,20 +28,9 @@ func newSubdomainsListCmd(opts *RootOptions) *cobra.Command {
 		Use:   "list",
 		Short: "List all subdomains (get_subdomains)",
 		Args:  cobra.NoArgs,
-		RunE: func(cmd *cobra.Command, _ []string) error {
-			api, err := BuildAPIClient(opts)
-			if err != nil {
-				return err
-			}
-			list, err := subdomain.NewClient(api).List(cmd.Context())
-			if err != nil {
-				return APIError(err, "get_subdomains")
-			}
-			if err := Render(cmd.OutOrStdout(), opts.Output, list); err != nil {
-				return UserError(err, "render")
-			}
-			return nil
-		},
+		RunE: runListE(opts, "get_subdomains", func(c *api.Client, ctx context.Context) (subdomain.SubdomainList, error) {
+			return subdomain.NewClient(c).List(ctx)
+		}),
 	}
 }
 
@@ -47,19 +39,8 @@ func newSubdomainsGetCmd(opts *RootOptions) *cobra.Command {
 		Use:   "get <subdomain>",
 		Short: "Show details for a single subdomain (get_subdomains with subdomain_name)",
 		Args:  cobra.ExactArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			api, err := BuildAPIClient(opts)
-			if err != nil {
-				return err
-			}
-			s, err := subdomain.NewClient(api).Get(cmd.Context(), args[0])
-			if err != nil {
-				return APIError(err, "get_subdomains")
-			}
-			if err := Render(cmd.OutOrStdout(), opts.Output, s); err != nil {
-				return UserError(err, "render")
-			}
-			return nil
-		},
+		RunE: runGetE(opts, "get_subdomains", func(c *api.Client, ctx context.Context, arg string) (subdomain.Subdomain, error) {
+			return subdomain.NewClient(c).Get(ctx, arg)
+		}),
 	}
 }

--- a/internal/cli/tlds.go
+++ b/internal/cli/tlds.go
@@ -1,8 +1,11 @@
 package cli
 
 import (
+	"context"
+
 	"github.com/spf13/cobra"
 
+	"github.com/chmmou/kasapi-cli/internal/api"
 	"github.com/chmmou/kasapi-cli/internal/domain"
 )
 
@@ -22,19 +25,8 @@ func newTLDsListCmd(opts *RootOptions) *cobra.Command {
 		Use:   "list",
 		Short: "List all registrable TLDs (get_topleveldomains)",
 		Args:  cobra.NoArgs,
-		RunE: func(cmd *cobra.Command, _ []string) error {
-			api, err := BuildAPIClient(opts)
-			if err != nil {
-				return err
-			}
-			list, err := domain.NewClient(api).TopLevelDomains(cmd.Context())
-			if err != nil {
-				return APIError(err, "get_topleveldomains")
-			}
-			if err := Render(cmd.OutOrStdout(), opts.Output, list); err != nil {
-				return UserError(err, "render")
-			}
-			return nil
-		},
+		RunE: runListE(opts, "get_topleveldomains", func(c *api.Client, ctx context.Context) (domain.TLDList, error) {
+			return domain.NewClient(c).TopLevelDomains(ctx)
+		}),
 	}
 }

--- a/internal/cli/usage.go
+++ b/internal/cli/usage.go
@@ -1,11 +1,13 @@
 package cli
 
 import (
+	"context"
 	"fmt"
 	"time"
 
 	"github.com/spf13/cobra"
 
+	"github.com/chmmou/kasapi-cli/internal/api"
 	"github.com/chmmou/kasapi-cli/internal/usage"
 )
 
@@ -36,20 +38,9 @@ func newUsageSpaceCmd(opts *RootOptions) *cobra.Command {
 		Use:   "space",
 		Short: "Show webspace totals per account (get_space)",
 		Args:  cobra.NoArgs,
-		RunE: func(cmd *cobra.Command, _ []string) error {
-			api, err := BuildAPIClient(opts)
-			if err != nil {
-				return err
-			}
-			list, err := usage.NewClient(api).Space(cmd.Context())
-			if err != nil {
-				return APIError(err, "get_space")
-			}
-			if err := Render(cmd.OutOrStdout(), opts.Output, list); err != nil {
-				return UserError(err, "render")
-			}
-			return nil
-		},
+		RunE: runListE(opts, "get_space", func(c *api.Client, ctx context.Context) (usage.SpaceList, error) {
+			return usage.NewClient(c).Space(ctx)
+		}),
 	}
 }
 
@@ -59,20 +50,9 @@ func newUsageSpaceDetailCmd(opts *RootOptions) *cobra.Command {
 		Use:   "space-detail",
 		Short: "Show per-directory disk usage (get_space_usage)",
 		Args:  cobra.NoArgs,
-		RunE: func(cmd *cobra.Command, _ []string) error {
-			api, err := BuildAPIClient(opts)
-			if err != nil {
-				return err
-			}
-			list, err := usage.NewClient(api).SpaceUsage(cmd.Context(), directory)
-			if err != nil {
-				return APIError(err, "get_space_usage")
-			}
-			if err := Render(cmd.OutOrStdout(), opts.Output, list); err != nil {
-				return UserError(err, "render")
-			}
-			return nil
-		},
+		RunE: runListE(opts, "get_space_usage", func(c *api.Client, ctx context.Context) (usage.SpaceUsageList, error) {
+			return usage.NewClient(c).SpaceUsage(ctx, directory)
+		}),
 	}
 	cmd.Flags().StringVar(&directory, "directory", "",
 		"directory to drill into; empty queries the document-root level")
@@ -96,20 +76,9 @@ func newUsageTrafficCmd(opts *RootOptions) *cobra.Command {
 			}
 			return nil
 		},
-		RunE: func(cmd *cobra.Command, _ []string) error {
-			api, err := BuildAPIClient(opts)
-			if err != nil {
-				return err
-			}
-			list, err := usage.NewClient(api).Traffic(cmd.Context(), year, month)
-			if err != nil {
-				return APIError(err, "get_traffic")
-			}
-			if err := Render(cmd.OutOrStdout(), opts.Output, list); err != nil {
-				return UserError(err, "render")
-			}
-			return nil
-		},
+		RunE: runListE(opts, "get_traffic", func(c *api.Client, ctx context.Context) (usage.TrafficList, error) {
+			return usage.NewClient(c).Traffic(ctx, year, month)
+		}),
 	}
 	cmd.Flags().IntVar(&year, "year", 0, "calendar year (e.g. 2026); 0 = current")
 	cmd.Flags().IntVar(&month, "month", 0, "calendar month 1..12; 0 = current")


### PR DESCRIPTION
## Summary

Extract the duplicated cobra \`RunE\` ritual (BuildAPIClient → NewClient.List/Get → APIError → Render → UserError) into two generic factories \`runListE[T]\` / \`runGetE[T]\` in \`internal/cli/run.go\`.

28 RunE bodies across 14 files (account, cronjobs, databases, ddnsusers, directoryprotection, domains, ftpusers, mail, sambausers, server, softwareinstalls, subdomains, tlds, usage) now pass a one-line closure that owns module-client construction and the actual call; the factory drives the canonical pipeline. Flag-derived parameters flow in via the closure's capture (\`directoryprotection --path\`, \`usage --directory/--year/--month\`).

\`dns.go\` is intentionally not migrated — its RunE has a manual required-flag check before BuildAPIClient that doesn't fit the helper.

Net diff: +225 / −462 (~237 lines of pure boilerplate removed). Behaviour, error messages, and exit codes are unchanged: same APIError(action) wraps same transport errors, same UserError(err, \"render\") wraps same render failures. Existing per-command \`--help\` tests + per-module Client tests cover both paths and stay green without modification.

Part three of the cross-module-duplication clean-up bundle tracked in #73.

Refs #73