### PR TITLE
chore: unify Use placeholders + centralise FIELD/VALUE headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Unified the `get`-subcommand `Use:` placeholders to the
+  KAS-wire-parameter rule (filter key with hyphens):
+  `<dyndns-login>` → `<ddns-login>`, `<subdomain>` →
+  `<subdomain-name>`, `<address>` → `<mail-forward>`, `<domain>` →
+  `<domain-name>`. The 8 placeholders that already followed the
+  rule (e.g. `<ftp-login>`, `<cronjob-id>`, `<software-id>`) are
+  unchanged. `docs/cli/` regenerated. Cosmetic finalisation of the
+  cross-module-duplication clean-up bundle tracked in issue #73.
+- Centralised the singular-record `[]string{"FIELD", "VALUE"}`
+  table-header literal — duplicated 13 times across 11 read modules
+  — into the new shared `internal/tablefmt` package's
+  `FieldValueHeaders` variable. Each module's `TableHeaders()` for
+  the singular view now returns the shared variable; a future
+  rename ("KEY"/"VALUE", localisation, …) is one diff rather than
+  thirteen. Part four of the cross-module-duplication clean-up
+  bundle tracked in issue #73.
 - Replaced the duplicated `cobra.RunE` bodies in 14 CLI files
   (account, cronjobs, databases, ddnsusers, directoryprotection,
   domains, ftpusers, mail, sambausers, server, softwareinstalls,

--- a/docs/cli/kasapi-cli_ddnsusers_get.md
+++ b/docs/cli/kasapi-cli_ddnsusers_get.md
@@ -3,7 +3,7 @@
 Show details for a single DDNS user (get_ddnsusers with ddns_login)
 
 ```
-kasapi-cli ddnsusers get <dyndns-login> [flags]
+kasapi-cli ddnsusers get <ddns-login> [flags]
 ```
 
 ### Options

--- a/docs/cli/kasapi-cli_domains_get.md
+++ b/docs/cli/kasapi-cli_domains_get.md
@@ -3,7 +3,7 @@
 Show details for a single domain (get_domains with domain_name)
 
 ```
-kasapi-cli domains get <domain> [flags]
+kasapi-cli domains get <domain-name> [flags]
 ```
 
 ### Options

--- a/docs/cli/kasapi-cli_mail_forwards_get.md
+++ b/docs/cli/kasapi-cli_mail_forwards_get.md
@@ -3,7 +3,7 @@
 Show details for a single mail forward (get_mailforwards with mail_forward)
 
 ```
-kasapi-cli mail forwards get <address> [flags]
+kasapi-cli mail forwards get <mail-forward> [flags]
 ```
 
 ### Options

--- a/docs/cli/kasapi-cli_subdomains_get.md
+++ b/docs/cli/kasapi-cli_subdomains_get.md
@@ -3,7 +3,7 @@
 Show details for a single subdomain (get_subdomains with subdomain_name)
 
 ```
-kasapi-cli subdomains get <subdomain> [flags]
+kasapi-cli subdomains get <subdomain-name> [flags]
 ```
 
 ### Options

--- a/internal/account/table.go
+++ b/internal/account/table.go
@@ -1,6 +1,10 @@
 package account
 
-import "strconv"
+import (
+	"strconv"
+
+	"github.com/chmmou/kasapi-cli/internal/tablefmt"
+)
 
 // AccountList is a slice wrapper that satisfies cli.Tabular so
 // kasapi-cli accounts list --output=table works without a per-command
@@ -77,7 +81,7 @@ func (r AccountResources) TableRows() [][]string {
 // the settings record is wide and tall-format is easier to read in a
 // terminal than a 30-column row.
 func (AccountSettings) TableHeaders() []string {
-	return []string{"FIELD", "VALUE"}
+	return tablefmt.FieldValueHeaders
 }
 
 // TableRows emits one row per scalar field. SSH fingerprints and the
@@ -110,7 +114,7 @@ func (s AccountSettings) TableRows() [][]string {
 // fit the wide field set returned by get_accounts with an
 // account_login filter.
 func (Account) TableHeaders() []string {
-	return []string{"FIELD", "VALUE"}
+	return tablefmt.FieldValueHeaders
 }
 
 // TableRows emits the scalar fields. account_password is intentionally

--- a/internal/cli/ddnsusers.go
+++ b/internal/cli/ddnsusers.go
@@ -40,7 +40,7 @@ func newDDNSUsersListCmd(opts *RootOptions) *cobra.Command {
 
 func newDDNSUsersGetCmd(opts *RootOptions) *cobra.Command {
 	return &cobra.Command{
-		Use:   "get <dyndns-login>",
+		Use:   "get <ddns-login>",
 		Short: "Show details for a single DDNS user (get_ddnsusers with ddns_login)",
 		Args:  cobra.ExactArgs(1),
 		RunE: runGetE(opts, "get_ddnsusers", func(c *api.Client, ctx context.Context, arg string) (ddns.DDNSUser, error) {

--- a/internal/cli/domains.go
+++ b/internal/cli/domains.go
@@ -36,7 +36,7 @@ func newDomainsListCmd(opts *RootOptions) *cobra.Command {
 
 func newDomainsGetCmd(opts *RootOptions) *cobra.Command {
 	return &cobra.Command{
-		Use:   "get <domain>",
+		Use:   "get <domain-name>",
 		Short: "Show details for a single domain (get_domains with domain_name)",
 		Args:  cobra.ExactArgs(1),
 		RunE: runGetE(opts, "get_domains", func(c *api.Client, ctx context.Context, arg string) (domain.Domain, error) {

--- a/internal/cli/mail.go
+++ b/internal/cli/mail.go
@@ -142,7 +142,7 @@ func newMailForwardsListCmd(opts *RootOptions) *cobra.Command {
 
 func newMailForwardsGetCmd(opts *RootOptions) *cobra.Command {
 	return &cobra.Command{
-		Use:   "get <address>",
+		Use:   "get <mail-forward>",
 		Short: "Show details for a single mail forward (get_mailforwards with mail_forward)",
 		Args:  cobra.ExactArgs(1),
 		RunE: runGetE(opts, "get_mailforwards", func(c *api.Client, ctx context.Context, arg string) (mailforward.MailForward, error) {

--- a/internal/cli/subdomains.go
+++ b/internal/cli/subdomains.go
@@ -36,7 +36,7 @@ func newSubdomainsListCmd(opts *RootOptions) *cobra.Command {
 
 func newSubdomainsGetCmd(opts *RootOptions) *cobra.Command {
 	return &cobra.Command{
-		Use:   "get <subdomain>",
+		Use:   "get <subdomain-name>",
 		Short: "Show details for a single subdomain (get_subdomains with subdomain_name)",
 		Args:  cobra.ExactArgs(1),
 		RunE: runGetE(opts, "get_subdomains", func(c *api.Client, ctx context.Context, arg string) (subdomain.Subdomain, error) {

--- a/internal/cronjob/cronjob.go
+++ b/internal/cronjob/cronjob.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/chmmou/kasapi-cli/internal/kasread"
 	"github.com/chmmou/kasapi-cli/internal/soap"
+	"github.com/chmmou/kasapi-cli/internal/tablefmt"
 )
 
 // Caller is the subset of *api.Client this package depends on. The
@@ -166,7 +167,7 @@ func (l CronjobList) TableRows() [][]string {
 
 // TableHeaders for the singular Cronjob view: a key/value layout.
 func (Cronjob) TableHeaders() []string {
-	return []string{"FIELD", "VALUE"}
+	return tablefmt.FieldValueHeaders
 }
 
 // TableRows emits the scalar fields. http_password is intentionally

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/chmmou/kasapi-cli/internal/kasread"
 	"github.com/chmmou/kasapi-cli/internal/soap"
+	"github.com/chmmou/kasapi-cli/internal/tablefmt"
 )
 
 // Caller is the subset of *api.Client this package depends on. The
@@ -104,7 +105,7 @@ func (l DatabaseList) TableRows() [][]string {
 // TableHeaders for the singular Database view: a key/value layout to
 // match the rest of the singular detail commands (mail accounts, accounts).
 func (Database) TableHeaders() []string {
-	return []string{"FIELD", "VALUE"}
+	return tablefmt.FieldValueHeaders
 }
 
 // TableRows emits the scalar fields. database_password is intentionally

--- a/internal/ddns/ddns.go
+++ b/internal/ddns/ddns.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/chmmou/kasapi-cli/internal/kasread"
 	"github.com/chmmou/kasapi-cli/internal/soap"
+	"github.com/chmmou/kasapi-cli/internal/tablefmt"
 )
 
 // Caller is the subset of *api.Client this package depends on. The
@@ -150,7 +151,7 @@ func (l DDNSUserList) TableRows() [][]string {
 
 // TableHeaders for the singular DDNSUser view: a key/value layout.
 func (DDNSUser) TableHeaders() []string {
-	return []string{"FIELD", "VALUE"}
+	return tablefmt.FieldValueHeaders
 }
 
 // TableRows emits the scalar fields. dyndns_password is intentionally

--- a/internal/domain/domain.go
+++ b/internal/domain/domain.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/chmmou/kasapi-cli/internal/kasread"
 	"github.com/chmmou/kasapi-cli/internal/soap"
+	"github.com/chmmou/kasapi-cli/internal/tablefmt"
 )
 
 // Caller is the subset of *api.Client this package depends on. The
@@ -229,7 +230,7 @@ func (l TLDList) TableRows() [][]string {
 // TableHeaders for the singular Domain view: a key/value layout, since
 // the record carries the SSL cert PEM blob and is too tall for a row.
 func (Domain) TableHeaders() []string {
-	return []string{"FIELD", "VALUE"}
+	return tablefmt.FieldValueHeaders
 }
 
 // TableRows emits the scalar fields. The SSL cert PEM bodies are

--- a/internal/ftpuser/ftpuser.go
+++ b/internal/ftpuser/ftpuser.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/chmmou/kasapi-cli/internal/kasread"
 	"github.com/chmmou/kasapi-cli/internal/soap"
+	"github.com/chmmou/kasapi-cli/internal/tablefmt"
 )
 
 // Caller is the subset of *api.Client this package depends on. The
@@ -124,7 +125,7 @@ func (l FTPUserList) TableRows() [][]string {
 
 // TableHeaders for the singular FTPUser view: a key/value layout.
 func (FTPUser) TableHeaders() []string {
-	return []string{"FIELD", "VALUE"}
+	return tablefmt.FieldValueHeaders
 }
 
 // TableRows emits the scalar fields. ftp_password / ftp_passwort are

--- a/internal/mailaccount/mailaccount.go
+++ b/internal/mailaccount/mailaccount.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/chmmou/kasapi-cli/internal/kasread"
 	"github.com/chmmou/kasapi-cli/internal/soap"
+	"github.com/chmmou/kasapi-cli/internal/tablefmt"
 )
 
 // Caller is the subset of *api.Client this package depends on. The
@@ -159,7 +160,7 @@ func (l MailAccountList) TableRows() [][]string {
 // TableHeaders for the singular MailAccount view: a key/value layout
 // to fit the wider field set.
 func (MailAccount) TableHeaders() []string {
-	return []string{"FIELD", "VALUE"}
+	return tablefmt.FieldValueHeaders
 }
 
 // TableRows emits the scalar fields. The redundant mail_adresses /

--- a/internal/mailforward/mailforward.go
+++ b/internal/mailforward/mailforward.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/chmmou/kasapi-cli/internal/kasread"
 	"github.com/chmmou/kasapi-cli/internal/soap"
+	"github.com/chmmou/kasapi-cli/internal/tablefmt"
 )
 
 // Caller is the subset of *api.Client this package depends on. The
@@ -106,7 +107,7 @@ func (l MailForwardList) TableRows() [][]string {
 // TableHeaders for the singular MailForward view: a key/value layout
 // to keep multi-target lists readable.
 func (MailForward) TableHeaders() []string {
-	return []string{"FIELD", "VALUE"}
+	return tablefmt.FieldValueHeaders
 }
 
 // TableRows emits the scalar fields. The redundant mail_forward_adress

--- a/internal/mailinglist/mailinglist.go
+++ b/internal/mailinglist/mailinglist.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/chmmou/kasapi-cli/internal/kasread"
 	"github.com/chmmou/kasapi-cli/internal/soap"
+	"github.com/chmmou/kasapi-cli/internal/tablefmt"
 )
 
 // Caller is the subset of *api.Client this package depends on. The
@@ -96,7 +97,7 @@ func (l MailingListList) TableRows() [][]string {
 // TableHeaders for the singular MailingList view: a key/value layout
 // keeps the URL readable without truncation.
 func (MailingList) TableHeaders() []string {
-	return []string{"FIELD", "VALUE"}
+	return tablefmt.FieldValueHeaders
 }
 
 // TableRows emits the scalar fields of a single MailingList.

--- a/internal/sambauser/sambauser.go
+++ b/internal/sambauser/sambauser.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/chmmou/kasapi-cli/internal/kasread"
 	"github.com/chmmou/kasapi-cli/internal/soap"
+	"github.com/chmmou/kasapi-cli/internal/tablefmt"
 )
 
 // Caller is the subset of *api.Client this package depends on. The
@@ -103,7 +104,7 @@ func (l SambaUserList) TableRows() [][]string {
 // TableHeaders for the singular SambaUser view: a key/value layout
 // matches the rest of the singular detail commands.
 func (SambaUser) TableHeaders() []string {
-	return []string{"FIELD", "VALUE"}
+	return tablefmt.FieldValueHeaders
 }
 
 // TableRows emits the scalar fields. samba_password is intentionally

--- a/internal/softwareinstall/softwareinstall.go
+++ b/internal/softwareinstall/softwareinstall.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/chmmou/kasapi-cli/internal/kasread"
 	"github.com/chmmou/kasapi-cli/internal/soap"
+	"github.com/chmmou/kasapi-cli/internal/tablefmt"
 )
 
 // Caller is the subset of *api.Client this package depends on. The
@@ -174,7 +175,7 @@ func dbRange(mariaFrom, mariaTo, mysqlFrom, mysqlTo string) string {
 // output usable in a terminal — consumers that need the logo should
 // use --output=json|yaml.
 func (SoftwareInstall) TableHeaders() []string {
-	return []string{"FIELD", "VALUE"}
+	return tablefmt.FieldValueHeaders
 }
 
 // TableRows emits the scalar fields. image is omitted (see

--- a/internal/subdomain/subdomain.go
+++ b/internal/subdomain/subdomain.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/chmmou/kasapi-cli/internal/kasread"
 	"github.com/chmmou/kasapi-cli/internal/soap"
+	"github.com/chmmou/kasapi-cli/internal/tablefmt"
 )
 
 // Caller is the subset of *api.Client this package depends on. The
@@ -161,7 +162,7 @@ func (l SubdomainList) TableRows() [][]string {
 // since the record may carry an SSL cert PEM blob and is too tall for
 // a row.
 func (Subdomain) TableHeaders() []string {
-	return []string{"FIELD", "VALUE"}
+	return tablefmt.FieldValueHeaders
 }
 
 // TableRows emits the scalar fields. The SSL cert PEM bodies are

--- a/internal/tablefmt/tablefmt.go
+++ b/internal/tablefmt/tablefmt.go
@@ -1,0 +1,15 @@
+// Package tablefmt holds presentation-shaped constants and helpers
+// shared across the read-domain modules. It is a leaf package with
+// no domain dependencies, so each internal/<module> can import it
+// without inverting the cli/<-domain layering.
+package tablefmt
+
+// FieldValueHeaders is the canonical column pair returned by
+// single-record TableHeaders() implementations. The list view of a
+// resource carries per-field columns (LOGIN, NAME, ...); the
+// singular view collapses to a key/value list rendered with these
+// two fixed headers.
+//
+// Centralising the literal here means a future rename ("KEY"/"VALUE",
+// localisation, ...) is one diff rather than thirteen.
+var FieldValueHeaders = []string{"FIELD", "VALUE"}


### PR DESCRIPTION
## Summary

Two cosmetic cleanups from the #73 NTH bundle, bundled because each is too small to deserve a separate review loop:

1. **Use-placeholder unification** — apply the KAS-wire-parameter rule (filter key with hyphens) to the 4 inconsistent \`get\` subcommands: \`<dyndns-login>\` → \`<ddns-login>\`, \`<subdomain>\` → \`<subdomain-name>\`, \`<address>\` → \`<mail-forward>\`, \`<domain>\` → \`<domain-name>\`. The 8 already-canonical placeholders (\`<ftp-login>\`, \`<cronjob-id>\`, \`<software-id>\`, \`<account-login>\`, \`<samba-login>\`, \`<mail-login>\`, \`<mailinglist-name>\`, \`<database-login>\`) are unchanged. \`docs/cli/\` regenerated by \`make docs\`.

2. **\`FIELD\`/\`VALUE\` header centralisation** — the inline \`[]string{\"FIELD\", \"VALUE\"}\` literal was duplicated 13 times across 11 read modules' singular-record \`TableHeaders()\` methods. Move it into a new leaf package \`internal/tablefmt\` as \`FieldValueHeaders\` so a future rename / localisation is one diff rather than thirteen.

Behaviour and table output are unchanged. This finalises the cross-module-duplication clean-up bundle tracked in #73.

Closes #73