### PR TITLE
test(ddns): cover empty-array fallback; doc(mailfilter): pin no-Get rationale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Documentation
+
+- Closed the two remaining follow-ups from issue #73's NTH bundle:
+  verified against the KAS docs that `get_mailstandardfilter`
+  accepts no filter parameter (the `mailfilter.Client` doc-comment
+  now links the spec page authoritatively, no code change needed),
+  and added `TestClientGetNotFound` for `ddns.Client.Get` to pin
+  the empty-array fallback that the prior test suite did not
+  exercise.
+
 ### Changed
 
 - Unified the `get`-subcommand `Use:` placeholders to the

--- a/internal/ddns/ddns_test.go
+++ b/internal/ddns/ddns_test.go
@@ -3,6 +3,7 @@ package ddns_test
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/chmmou/kasapi-cli/internal/ddns"
@@ -147,6 +148,27 @@ func TestClientGetEmptyLogin(t *testing.T) {
 	c := ddns.NewClient(&testutil.FakeCaller{})
 	if _, err := c.Get(context.Background(), ""); err == nil {
 		t.Errorf("Get(\"\") err = nil, want validation error")
+	}
+}
+
+// TestClientGetNotFound covers the empty-array fallback in
+// kasread.ListGet.Get. The KAS docs say a missing dyndns_login is
+// signalled via a SOAP fault (dyndns_login_not_found) rather than
+// an empty array, but ddns.Get carries a defensive len(list) == 0
+// branch for parity with the other read modules; this test pins
+// that branch's behaviour by feeding the singular fixture with the
+// array stripped down to zero entries.
+func TestClientGetNotFound(t *testing.T) {
+	t.Parallel()
+	emptyResp := testutil.DecodeFixture(t, "ddns/get_ddnsuser_response_success.xml")
+	emptyResp.Body.ReturnInfo.Array = nil
+	c := ddns.NewClient(&testutil.FakeCaller{Resp: emptyResp})
+	_, err := c.Get(context.Background(), "ghost")
+	if err == nil {
+		t.Fatal("Get on empty array returned nil, want not-found error")
+	}
+	if !strings.Contains(err.Error(), `"ghost" not found`) {
+		t.Errorf("err = %q, want it to contain '%q not found'", err, "ghost")
 	}
 }
 

--- a/internal/mailfilter/mailfilter.go
+++ b/internal/mailfilter/mailfilter.go
@@ -26,9 +26,13 @@ type StandardFilter struct {
 type StandardFilterList []StandardFilter
 
 // Client groups the read endpoint scoped to mail standard filters.
-// Get is intentionally absent — the KAS endpoint does not document a
-// filter parameter (see issue #73 NTH bundle), so only List is wired
-// up here.
+// Get is intentionally absent: the KAS docs at
+// https://kasapi.kasserver.com/dokumentation/phpdoc/files/get-mailstandardfilter-inc.html
+// list only the three standard auth parameters (kas_login,
+// kas_auth_data, kas_auth_type) — there is no filter parameter
+// for looking up a single filter, the endpoint always returns the
+// full list. Verified against the KAS docs while closing the
+// mailfilter.Get follow-up from issue #73.
 type Client struct {
 	lg kasread.ListGet[StandardFilterList, StandardFilter]
 }


### PR DESCRIPTION
## Summary

Two small follow-ups from #73's NTH bundle, picked up after the four refactor PRs landed.

- **ddns**: add \`TestClientGetNotFound\` covering the defensive \`len(list) == 0 → not-found\` branch in \`Client.Get\` (the KAS docs say a missing dyndns_login surfaces as a SOAP fault, not an empty array, but the fallback exists for parity and was untested).
- **mailfilter**: verified against the KAS docs (\`files/get-mailstandardfilter-inc.html\`) that the endpoint accepts only the three standard auth parameters — there is no filter parameter for a per-filter lookup, so \`Client.Get\` is correctly absent. Doc-comment now links the spec page as the authoritative reason.

No behaviour change; this is purely test + documentation polish that closes the last two open items from the original NTH bundle in #73.