### PR TITLE
refactor: collapse remaining Caller interfaces to kasread.Caller alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Collapsed the four remaining stand-alone `Caller interface`
+  declarations in `internal/directoryprotection`, `internal/dns`,
+  `internal/server`, and `internal/usage` to `type Caller =
+  kasread.Caller`, matching the nine modules that were already
+  aliased after issue #73's PR B. The shape was identical in all
+  four cases; the alias removes the last bit of duplicated
+  interface boilerplate and ensures a future change to the
+  `Caller` contract is a single-file diff in `internal/kasread`.
+
 ### Documentation
 
 - Closed the two remaining follow-ups from issue #73's NTH bundle:

--- a/internal/directoryprotection/directoryprotection.go
+++ b/internal/directoryprotection/directoryprotection.go
@@ -4,15 +4,14 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/chmmou/kasapi-cli/internal/kasread"
 	"github.com/chmmou/kasapi-cli/internal/soap"
 )
 
 // Caller is the subset of *api.Client this package depends on. The
 // indirection keeps tests free of network setup: a fake Caller can
 // return a *soap.Response decoded from a fixture.
-type Caller interface {
-	Call(ctx context.Context, action string, params map[string]any) (*soap.Response, error)
-}
+type Caller = kasread.Caller
 
 // DirectoryProtection is one (path, user) tuple of the KAS htaccess /
 // directory-protection table. The KAS API returns one entry per user

--- a/internal/dns/dns.go
+++ b/internal/dns/dns.go
@@ -5,15 +5,14 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/chmmou/kasapi-cli/internal/kasread"
 	"github.com/chmmou/kasapi-cli/internal/soap"
 )
 
 // Caller is the subset of *api.Client this package depends on. The
 // indirection keeps tests free of network setup: a fake Caller can
 // return a *soap.Response decoded from a fixture.
-type Caller interface {
-	Call(ctx context.Context, action string, params map[string]any) (*soap.Response, error)
-}
+type Caller = kasread.Caller
 
 // Record is one DNS resource record returned by get_dns_settings.
 // record_id is xsd:string in the wire format and we keep it as a

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -4,13 +4,12 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/chmmou/kasapi-cli/internal/kasread"
 	"github.com/chmmou/kasapi-cli/internal/soap"
 )
 
 // Caller is the subset of *api.Client this package depends on.
-type Caller interface {
-	Call(ctx context.Context, action string, params map[string]any) (*soap.Response, error)
-}
+type Caller = kasread.Caller
 
 // Service is one entry from get_server_information. The KAS API
 // returns a heterogeneous list: mysql carries a version_type, php

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -6,15 +6,14 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/chmmou/kasapi-cli/internal/kasread"
 	"github.com/chmmou/kasapi-cli/internal/soap"
 )
 
 // Caller is the subset of *api.Client this package depends on. The
 // indirection keeps tests free of network setup: a fake Caller can
 // return a *soap.Response decoded from a fixture.
-type Caller interface {
-	Call(ctx context.Context, action string, params map[string]any) (*soap.Response, error)
-}
+type Caller = kasread.Caller
 
 // Space is one entry of get_space. Each entry covers an account-login
 // (the main account and each sub-account) with byte counts split by


### PR DESCRIPTION
## Summary

Four read modules (`directoryprotection`, `dns`, `server`, `usage`)
still carried a stand-alone `Caller interface` with the exact same
`Call(ctx, action, params) (*soap.Response, error)` signature as
`kasread.Caller`. Each is now `type Caller = kasread.Caller`,
matching the nine modules already aliased after issue #73's PR B,
so the contract lives in one place.

No behaviour change; the alias keeps each package's local `Caller`
name as a re-export, so `NewClient` signatures and existing test
fixtures remain untouched.