### PR TITLE
fix(cli): correct exit codes and align account.List return type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `usage traffic --year` / `--month` range-validation errors now exit
+  with code 1 (user error) instead of code 2 (API error). The
+  `PreRunE` previously returned a plain `fmt.Errorf` which fell
+  through `cli.CodeFor`'s default branch.
+- `dns list --domain ""` now reports `required flag --domain not
+  provided` without the redundant `--domain:` prefix and exits with
+  code 1; the validation moved into a dedicated `PreRunE` so the
+  body can use the canonical `runListE` shape.
+
 ### Changed
+
+- `account.Client.List` now returns `account.AccountList` directly,
+  matching every other read module. The CLI no longer needs to
+  convert `[]Account` to the named list type, and the
+  `kasread.ListGet` field is parameterised on `AccountList`.
 
 - Collapsed the four remaining stand-alone `Caller interface`
   declarations in `internal/directoryprotection`, `internal/dns`,

--- a/internal/account/client.go
+++ b/internal/account/client.go
@@ -16,7 +16,7 @@ type Caller = kasread.Caller
 // get_accountsettings, get_accountresources.
 type Client struct {
 	api Caller
-	lg  kasread.ListGet[[]Account, Account]
+	lg  kasread.ListGet[AccountList, Account]
 }
 
 // NewClient returns a Client backed by the given Caller. It does not
@@ -24,7 +24,7 @@ type Client struct {
 func NewClient(c Caller) *Client {
 	return &Client{
 		api: c,
-		lg: kasread.ListGet[[]Account, Account]{
+		lg: kasread.ListGet[AccountList, Account]{
 			Caller:    c,
 			Action:    "get_accounts",
 			Label:     "account",
@@ -36,10 +36,10 @@ func NewClient(c Caller) *Client {
 }
 
 // List calls get_accounts without a filter and decodes the response
-// into a slice of Account values. For a main login this returns every
+// into an AccountList. For a main login this returns every
 // sub-account; for a sub-login it returns just the authenticated
 // account.
-func (c *Client) List(ctx context.Context) ([]Account, error) { return c.lg.List(ctx) }
+func (c *Client) List(ctx context.Context) (AccountList, error) { return c.lg.List(ctx) }
 
 // Get calls get_accounts with an account_login filter and returns the
 // single matching Account. The KAS API still wraps the result in an

--- a/internal/account/decode.go
+++ b/internal/account/decode.go
@@ -8,10 +8,14 @@ import (
 )
 
 // DecodeAccounts maps the ReturnInfo of a get_accounts response into
-// the typed slice. ReturnInfo must be a Map[]; each entry is itself a
-// Map carrying the documented fields.
-func DecodeAccounts(returnInfo soap.Value) ([]Account, error) {
-	return soap.DecodeArray(returnInfo, "account", decodeAccount)
+// the typed AccountList. ReturnInfo must be a Map[]; each entry is
+// itself a Map carrying the documented fields.
+func DecodeAccounts(returnInfo soap.Value) (AccountList, error) {
+	out, err := soap.DecodeArray(returnInfo, "account", decodeAccount)
+	if err != nil {
+		return nil, err
+	}
+	return AccountList(out), nil
 }
 
 // DecodeAccountSettings maps the ReturnInfo of a get_accountsettings

--- a/internal/cli/account.go
+++ b/internal/cli/account.go
@@ -33,8 +33,7 @@ func newAccountsListCmd(opts *RootOptions) *cobra.Command {
 		Short: "List accounts visible to the login (get_accounts, no filter)",
 		Args:  cobra.NoArgs,
 		RunE: runListE(opts, "get_accounts", func(c *api.Client, ctx context.Context) (account.AccountList, error) {
-			accs, err := account.NewClient(c).List(ctx)
-			return account.AccountList(accs), err
+			return account.NewClient(c).List(ctx)
 		}),
 	}
 }

--- a/internal/cli/dns.go
+++ b/internal/cli/dns.go
@@ -1,10 +1,12 @@
 package cli
 
 import (
+	"context"
 	"errors"
 
 	"github.com/spf13/cobra"
 
+	"github.com/chmmou/kasapi-cli/internal/api"
 	"github.com/chmmou/kasapi-cli/internal/dns"
 )
 
@@ -25,23 +27,20 @@ func newDNSListCmd(opts *RootOptions) *cobra.Command {
 		Use:   "list",
 		Short: "List DNS records for a zone (get_dns_settings)",
 		Args:  cobra.NoArgs,
-		RunE: func(cmd *cobra.Command, _ []string) error {
+		// Validate the required flag in PreRunE so the missing-flag
+		// path produces ExitUserError (1) rather than the
+		// cli.CodeFor default of ExitAPIError (2). Cobra's own
+		// MarkFlagRequired returns a plain error that would fall
+		// through to the API-error code.
+		PreRunE: func(_ *cobra.Command, _ []string) error {
 			if domainName == "" {
-				return UserError(errors.New("required flag --domain not provided"), "--domain")
-			}
-			api, err := BuildAPIClient(opts)
-			if err != nil {
-				return err
-			}
-			list, err := dns.NewClient(api).Settings(cmd.Context(), domainName, nameserver)
-			if err != nil {
-				return APIError(err, "get_dns_settings")
-			}
-			if err := Render(cmd.OutOrStdout(), opts.Output, list); err != nil {
-				return UserError(err, "render")
+				return UserError(errors.New("required flag --domain not provided"), "")
 			}
 			return nil
 		},
+		RunE: runListE(opts, "get_dns_settings", func(c *api.Client, ctx context.Context) (dns.RecordList, error) {
+			return dns.NewClient(c).Settings(ctx, domainName, nameserver)
+		}),
 	}
 	cmd.Flags().StringVar(&domainName, "domain", "", "zone host (required, e.g. example.com)")
 	cmd.Flags().StringVar(&nameserver, "nameserver", "",

--- a/internal/cli/usage.go
+++ b/internal/cli/usage.go
@@ -68,11 +68,11 @@ func newUsageTrafficCmd(opts *RootOptions) *cobra.Command {
 		PreRunE: func(_ *cobra.Command, _ []string) error {
 			maxYear := time.Now().Year() + 1
 			if year != 0 && (year < minTrafficYear || year > maxYear) {
-				return fmt.Errorf("--year must be between %d and %d, got %d",
-					minTrafficYear, maxYear, year)
+				return UserError(fmt.Errorf("--year must be between %d and %d, got %d",
+					minTrafficYear, maxYear, year), "")
 			}
 			if month != 0 && (month < 1 || month > 12) {
-				return fmt.Errorf("--month must be between 1 and 12, got %d", month)
+				return UserError(fmt.Errorf("--month must be between 1 and 12, got %d", month), "")
 			}
 			return nil
 		},


### PR DESCRIPTION
## Summary

Three Should-findings from the fresh-eyes whole-project review:

- `usage traffic --year` / `--month` range errors now exit 1 (user error) — were falling through to `CodeFor`'s default of 2.
- `dns list --domain` validation moved to a dedicated `PreRunE` (wraps via `UserError`, drops the redundant `--domain:` prefix), body migrated to the canonical `runListE` shape.
- `account.Client.List` returns `AccountList` directly, matching every other read module. Removes the `account.AccountList(accs)` cast at the CLI call site.