### PR TITLE
fix(release): drop cosign-installer pin so goreleaser-action self-verify works

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,9 +25,13 @@ jobs:
           cache: true
 
       - name: install cosign
+        # Do not pin cosign-release: goreleaser-action verifies its own
+        # download with the cosign installed here, and newer
+        # goreleaser releases ship a bundle format that cosign 2.4.1
+        # cannot read ("bundle does not contain cert for
+        # verification"). Letting cosign-installer pick its current
+        # default keeps it in step with goreleaser-action.
         uses: sigstore/cosign-installer@v3
-        with:
-          cosign-release: "v2.4.1"
 
       - name: "install syft (used by goreleaser sboms: block)"
         uses: anchore/sbom-action/download-syft@v0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,13 @@ frozen.
 
 ### Fixed
 
+- `.github/workflows/release.yml` cosign pin: `sigstore/cosign-installer@v3`
+  was pinned to `v2.4.1`, which cannot read the bundle format that
+  newer `goreleaser-action@v7` releases ship. The release workflow
+  failed during `goreleaser-action`'s self-verification with
+  `bundle does not contain cert for verification, please provide
+  public key`. The pin is dropped so the installer picks its current
+  default; goreleaser-action keeps in step with it.
 - `.goreleaser.yaml` `archives.files` glob: `docs/cli/**/*` and
   `docs/usage/**/*` matched nothing (both directories are flat) so
   the rendered docs were missing from the release archives. Switched


### PR DESCRIPTION
## Summary

The v0.1.0-alpha.1 release workflow run [25622735301](https://github.com/chmmou/kasapi-cli/actions/runs/25622735301) failed during `goreleaser-action@v7`'s self-verification step with:

> `Error: bundle does not contain cert for verification, please provide public key`

`goreleaser-action` verifies its own download with the cosign installed in the prior workflow step. Newer goreleaser releases ship a sigstore bundle format that cosign 2.4.1 cannot parse.

Dropping the `cosign-release: "v2.4.1"` pin lets `sigstore/cosign-installer@v3` use its current default, which is in step with `goreleaser-action`. Inline comment explains the rationale so the next maintainer does not re-pin.

The v0.1.0-alpha.1 tag was deleted (no GitHub Release was created); a fresh tag will be pushed once this lands on main.