### PR TITLE
docs(release): require local goreleaser snapshot before tag push

### DIFF
--- a/.claude/skills/kasapi-cli-git-workflow/SKILL.md
+++ b/.claude/skills/kasapi-cli-git-workflow/SKILL.md
@@ -74,6 +74,19 @@ git push origin --delete <branch>
 - **Do not skip hooks.** No `--no-verify`, no `--no-gpg-sign`. On hook failure, fix the underlying cause and create a **new** commit — do not `--amend`.
 - **Branch protection on `main`** (settings: `required_signatures`, `enforce_admins`, `required_linear_history`, `allow_force_pushes` kept on for retroactive history fixes, `allow_deletions` off). Pushes to `main` of unsigned commits will be rejected by GitHub.
 
+## Release tags
+
+Before pushing a `vX.Y.Z` tag that triggers `release.yml`, run the local goreleaser snapshot on the would-be release commit and verify the resulting archives contain everything the workflow will publish:
+
+```sh
+make release-snapshot                                       # = goreleaser release --snapshot --clean --skip=sign,publish
+tar -tzf dist/kasapi-cli_*_linux_amd64.tar.gz               # expect: LICENSE, README.md, CHANGELOG.md, docs/cli/*, docs/usage/*, kasapi-cli
+```
+
+Reason: the v0.1.0-alpha.1 cut surfaced two pipeline bugs that **the real workflow could not have caught quickly** — an `archives.files` glob (`docs/cli/**/*` matched zero entries because the directory is flat) and an action-version mismatch in `release.yml`. The snapshot reproduces every goreleaser step short of sign/publish, so silent glob failures and `goreleaser check` config errors land in your terminal instead of as a failed workflow run with a now-burned tag.
+
+How to apply: snapshot must succeed and the archive listing must include the expected docs files before you create the tag. If the runner has no `syft` installed, append `,sbom` to the `--skip` list (`--skip=sign,publish,sbom`) — that does not exercise SBOM generation but does not block the rest of the pre-check. Production SBOMs come from CI's `anchore/sbom-action/download-syft` step, which is independent.
+
 ## Post-Merge
 
 If a just-merged step has a natural follow-up (a CI flake that surfaced, feature-flag cleanup, triage routine, a "remove once X" TODO), briefly offer a `/schedule` suggestion with a concrete action and cadence. Otherwise skip — refactors, bug fixes with tests, and pure docs PRs do not need a follow-up task.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,6 +100,18 @@ Findings are classified:
 
 Corrections from review land on a dedicated `fix/<topic>` branch via a separate PR; the loop ends only when no Blocker or Should-finding remains.
 
+## Releases
+
+Before a release tag is pushed, run a local goreleaser snapshot to validate the pipeline against your branch:
+
+```sh
+make release-snapshot   # goreleaser release --snapshot --clean --skip=sign,publish
+```
+
+The snapshot exercises the same build/archive/package steps as the real release without producing signatures or publishing to GitHub. Inspect at least one of the resulting `dist/kasapi-cli_*_linux_amd64.tar.gz` archives — `tar -tzf` should list `LICENSE`, `README.md`, `CHANGELOG.md`, and the rendered docs under `docs/cli/` and `docs/usage/` alongside the binary. If the docs are missing, an `archives.files` glob in `.goreleaser.yaml` is silently failing to match (this caught a `**/*` regression on the v0.1.0-alpha.1 cut). The snapshot also catches `goreleaser check` config errors and any build-matrix mismatch.
+
+`make release-snapshot` requires `goreleaser` (and `syft`, if SBOM generation should also be exercised locally — append `,sbom` to the `--skip` list if syft is not installed).
+
 ## Reporting security issues
 
 Please do **not** open a public issue for security vulnerabilities. Use the [private vulnerability reporting flow](https://github.com/chmmou/kasapi-cli/security/advisories/new) under the repository's Security tab, or e-mail the maintainer. Full policy in [SECURITY.md](SECURITY.md).


### PR DESCRIPTION
## Summary

The v0.1.0-alpha.1 cut surfaced two pipeline bugs that a `make release-snapshot` on the same commit would have caught immediately — a silently-failing `archives.files` glob and an action-version mismatch. Capture the pre-check requirement so the next release does not repeat the lesson.

- `CONTRIBUTING.md` gets a new `Releases` section describing the snapshot run and the explicit `tar -tzf` archive check for human contributors.
- `.claude/skills/kasapi-cli-git-workflow/SKILL.md` gets a `Release tags` section with the same procedure scoped for the agent — including the rationale (which incidents motivated the rule) and the `--skip=sbom` opt-out for runners without `syft`.