### PR TITLE
chore: lift test coverage and correct mail filters description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `docs/usage/mail.md`: corrected the description of `mail filters list`.
+  The previous text claimed `get_mailstandardfilter` returns "server-side
+  filter rules (Sieve-style: condition + action)"; the endpoint actually
+  returns the catalog of pre-defined spam/virus filter presets that an
+  account can attach via the `mail_spamfilter` setting on a mailaccount
+  or forward.
+
+### Tests
+
+- `internal/account`: added unit tests for `Client.Settings`,
+  `Client.Resources`, plus the previously-unexercised `TableHeaders`
+  on `AccountResources` and `AccountSettings` (and the `TableRows` of
+  `AccountSettings`). Lifts package coverage from 69.9% to 85.4%.
+- `internal/cli`: added help-output tests for the `dns`, `domains`,
+  `subdomains`, `tlds`, and `mail` (incl. `accounts` / `forwards` /
+  `filters` / `lists` subgroups) command factories, mirroring the
+  pattern already used for the cronjobs/databases/... factories.
+  Lifts package coverage from 60.0% to 69.9%.
+- `internal/auth`: added negative-path and nil-input tests for the
+  `IsLoginFailed`, `IsLoginLocked`, `IsUnknownSession`, `IsOTPPinIncorrect`,
+  `IsCode`, and `AsError` sentinel helpers.
+
 ## [0.1.0-alpha.1] - 2026-05-10
 
 First public pre-release. Scope: the **read-only** KAS API surface

--- a/docs/usage/mail.md
+++ b/docs/usage/mail.md
@@ -34,7 +34,7 @@ The `TARGETS` column flattens `mail_forward_target_*` into one comma-joined list
 
 ## Mail filters
 
-`mail filters list` calls `get_mailstandardfilter` and returns the server-side filter rules (Sieve-style: condition + action). The filter view is read-only — write paths are part of the v0.2.0 backlog.
+`mail filters list` calls `get_mailstandardfilter` and returns the **catalog of pre-defined filter presets** an account can attach via the `mail_spamfilter` setting on a mailaccount or forward — `rspamd`, the SpamAssassin variants, the virus scanner modes, and the configured spam-database lookups. Each row carries the preset id, its category (`rspamd`, `content`, `spamc`, `virus`, `reject`), a human-readable title, and the All-Inkl `recommended` flag. The KAS endpoint takes no parameters and is read-only — adding a preset to a mailbox happens via the (not-yet-implemented) `add_mailstandardfilter` write endpoint, tracked in the v0.2.0 backlog.
 
 ## Mailing lists
 

--- a/internal/account/account_test.go
+++ b/internal/account/account_test.go
@@ -224,6 +224,16 @@ func TestAccountResourcesTabular(t *testing.T) {
 	t.Parallel()
 	resp := testutil.DecodeFixture(t, "account/get_accountresources_response_success.xml")
 	r, _ := account.DecodeAccountResources(resp.Body.ReturnInfo)
+	headers := r.TableHeaders()
+	wantHeaders := []string{"RESOURCE", "MAX", "USED", "FREE", "RESERVED", "EXCEEDED"}
+	if len(headers) != len(wantHeaders) {
+		t.Fatalf("len(headers) = %d, want %d", len(headers), len(wantHeaders))
+	}
+	for i, h := range wantHeaders {
+		if headers[i] != h {
+			t.Errorf("headers[%d] = %q, want %q", i, headers[i], h)
+		}
+	}
 	rows := r.TableRows()
 	if len(rows) != 12 {
 		t.Errorf("rows = %d, want 12", len(rows))
@@ -233,5 +243,91 @@ func TestAccountResourcesTabular(t *testing.T) {
 		if row[0] == "max_domain" && row[1] != "∞" {
 			t.Errorf("max_domain.Max = %q, want ∞", row[1])
 		}
+	}
+}
+
+func TestAccountSettingsTabular(t *testing.T) {
+	t.Parallel()
+	resp := testutil.DecodeFixture(t, "account/get_accountsettings_response_success.xml")
+	s, err := account.DecodeAccountSettings(resp.Body.ReturnInfo)
+	if err != nil {
+		t.Fatalf("DecodeAccountSettings: %v", err)
+	}
+	headers := s.TableHeaders()
+	if len(headers) != 2 || headers[0] != "FIELD" || headers[1] != "VALUE" {
+		t.Errorf("headers = %v, want [FIELD VALUE]", headers)
+	}
+	rows := s.TableRows()
+	if len(rows) == 0 {
+		t.Fatal("rows = 0, want at least one")
+	}
+	want := map[string]string{
+		"account_login": "w0000000",
+		"is_superuser":  "Y",
+	}
+	got := make(map[string]string, len(rows))
+	for _, r := range rows {
+		got[r[0]] = r[1]
+	}
+	for k, v := range want {
+		if got[k] != v {
+			t.Errorf("rows[%q] = %q, want %q", k, got[k], v)
+		}
+	}
+}
+
+func TestClientSettings(t *testing.T) {
+	t.Parallel()
+	resp := testutil.DecodeFixture(t, "account/get_accountsettings_response_success.xml")
+	fc := &testutil.FakeCaller{Resp: resp}
+	got, err := account.NewClient(fc).Settings(context.Background())
+	if err != nil {
+		t.Fatalf("Settings: %v", err)
+	}
+	if fc.GotAction != "get_accountsettings" {
+		t.Errorf("action = %q, want get_accountsettings", fc.GotAction)
+	}
+	if fc.GotParams != nil {
+		t.Errorf("params = %v, want nil", fc.GotParams)
+	}
+	if got.Login != "w0000000" {
+		t.Errorf("Login = %q, want w0000000", got.Login)
+	}
+}
+
+func TestClientSettingsPropagatesError(t *testing.T) {
+	t.Parallel()
+	want := errors.New("boom")
+	c := account.NewClient(&testutil.FakeCaller{Err: want})
+	if _, err := c.Settings(context.Background()); !errors.Is(err, want) {
+		t.Errorf("Settings err = %v, want %v wrapped", err, want)
+	}
+}
+
+func TestClientResources(t *testing.T) {
+	t.Parallel()
+	resp := testutil.DecodeFixture(t, "account/get_accountresources_response_success.xml")
+	fc := &testutil.FakeCaller{Resp: resp}
+	got, err := account.NewClient(fc).Resources(context.Background())
+	if err != nil {
+		t.Fatalf("Resources: %v", err)
+	}
+	if fc.GotAction != "get_accountresources" {
+		t.Errorf("action = %q, want get_accountresources", fc.GotAction)
+	}
+	if fc.GotParams != nil {
+		t.Errorf("params = %v, want nil", fc.GotParams)
+	}
+	if got.MaxSubdomain.Max != 500 {
+		t.Errorf("MaxSubdomain.Max = %d, want 500", got.MaxSubdomain.Max)
+	}
+}
+
+func TestClientResourcesPropagatesError(t *testing.T) {
+	t.Parallel()
+	want := errors.New("boom")
+	c := account.NewClient(&testutil.FakeCaller{Err: want})
+	if _, err := c.Resources(context.Background()); !errors.Is(err, want) {
+		t.Errorf("Resources err = %v, want %v wrapped", err, want)
 	}
 }

--- a/internal/auth/errors_test.go
+++ b/internal/auth/errors_test.go
@@ -1,0 +1,62 @@
+package auth_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/chmmou/kasapi-cli/internal/auth"
+)
+
+// The positive-path coverage for IsOTPPinIncorrect runs through
+// TestGetCredentialTokenOTPRejected in client_test.go (a real auth
+// fault is produced by the fixture-backed httptest server, so the
+// *auth.Error path through IsCode is exercised end-to-end).
+//
+// IsLoginFailed, IsLoginLocked, and IsUnknownSession do not yet have
+// captured fault fixtures, so the positive-path tests will be added
+// alongside the corresponding fixtures. The negative-path tests below
+// pin the public sentinel API: any non-auth error (including nil) must
+// not match.
+
+func TestSentinelHelpersOnNonAuthError(t *testing.T) {
+	t.Parallel()
+	plain := errors.New("not an auth error")
+	if auth.IsLoginFailed(plain) {
+		t.Error("IsLoginFailed(plain) = true, want false")
+	}
+	if auth.IsLoginLocked(plain) {
+		t.Error("IsLoginLocked(plain) = true, want false")
+	}
+	if auth.IsUnknownSession(plain) {
+		t.Error("IsUnknownSession(plain) = true, want false")
+	}
+	if auth.IsOTPPinIncorrect(plain) {
+		t.Error("IsOTPPinIncorrect(plain) = true, want false")
+	}
+	if got := auth.AsError(plain); got != nil {
+		t.Errorf("AsError(plain) = %v, want nil", got)
+	}
+}
+
+func TestSentinelHelpersOnNilError(t *testing.T) {
+	t.Parallel()
+	if auth.IsLoginFailed(nil) {
+		t.Error("IsLoginFailed(nil) = true, want false")
+	}
+	if auth.IsLoginLocked(nil) {
+		t.Error("IsLoginLocked(nil) = true, want false")
+	}
+	if auth.IsUnknownSession(nil) {
+		t.Error("IsUnknownSession(nil) = true, want false")
+	}
+	if got := auth.AsError(nil); got != nil {
+		t.Errorf("AsError(nil) = %v, want nil", got)
+	}
+}
+
+func TestIsCodeOnUnknownCode(t *testing.T) {
+	t.Parallel()
+	if auth.IsCode(errors.New("boom"), auth.CodeLoginFailed) {
+		t.Error("IsCode on plain error matched a known code")
+	}
+}

--- a/internal/cli/dns_test.go
+++ b/internal/cli/dns_test.go
@@ -1,0 +1,27 @@
+package cli_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/chmmou/kasapi-cli/internal/cli"
+)
+
+func TestDNSCmdHelpListsSubcommands(t *testing.T) {
+	t.Parallel()
+	root, opts := cli.NewRootCmd()
+	root.AddCommand(cli.NewDNSCmd(opts))
+
+	var buf bytes.Buffer
+	root.SetOut(&buf)
+	root.SetErr(&buf)
+	root.SetArgs([]string{"dns", "--help"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "list") {
+		t.Errorf("--help output missing %q\n%s", "list", out)
+	}
+}

--- a/internal/cli/domains_test.go
+++ b/internal/cli/domains_test.go
@@ -1,0 +1,29 @@
+package cli_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/chmmou/kasapi-cli/internal/cli"
+)
+
+func TestDomainsCmdHelpListsSubcommands(t *testing.T) {
+	t.Parallel()
+	root, opts := cli.NewRootCmd()
+	root.AddCommand(cli.NewDomainsCmd(opts))
+
+	var buf bytes.Buffer
+	root.SetOut(&buf)
+	root.SetErr(&buf)
+	root.SetArgs([]string{"domains", "--help"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{"list", "get"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("--help output missing %q\n%s", want, out)
+		}
+	}
+}

--- a/internal/cli/mail_test.go
+++ b/internal/cli/mail_test.go
@@ -1,0 +1,107 @@
+package cli_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/chmmou/kasapi-cli/internal/cli"
+)
+
+func TestMailCmdHelpListsSubcommandGroups(t *testing.T) {
+	t.Parallel()
+	root, opts := cli.NewRootCmd()
+	root.AddCommand(cli.NewMailCmd(opts))
+
+	var buf bytes.Buffer
+	root.SetOut(&buf)
+	root.SetErr(&buf)
+	root.SetArgs([]string{"mail", "--help"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{"accounts", "forwards", "filters", "lists"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("--help output missing %q\n%s", want, out)
+		}
+	}
+}
+
+func TestMailAccountsHelpListsSubcommands(t *testing.T) {
+	t.Parallel()
+	root, opts := cli.NewRootCmd()
+	root.AddCommand(cli.NewMailCmd(opts))
+
+	var buf bytes.Buffer
+	root.SetOut(&buf)
+	root.SetErr(&buf)
+	root.SetArgs([]string{"mail", "accounts", "--help"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{"list", "get"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("--help output missing %q\n%s", want, out)
+		}
+	}
+}
+
+func TestMailForwardsHelpListsSubcommands(t *testing.T) {
+	t.Parallel()
+	root, opts := cli.NewRootCmd()
+	root.AddCommand(cli.NewMailCmd(opts))
+
+	var buf bytes.Buffer
+	root.SetOut(&buf)
+	root.SetErr(&buf)
+	root.SetArgs([]string{"mail", "forwards", "--help"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{"list", "get"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("--help output missing %q\n%s", want, out)
+		}
+	}
+}
+
+func TestMailFiltersHelpListsSubcommands(t *testing.T) {
+	t.Parallel()
+	root, opts := cli.NewRootCmd()
+	root.AddCommand(cli.NewMailCmd(opts))
+
+	var buf bytes.Buffer
+	root.SetOut(&buf)
+	root.SetErr(&buf)
+	root.SetArgs([]string{"mail", "filters", "--help"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "list") {
+		t.Errorf("--help output missing %q\n%s", "list", out)
+	}
+}
+
+func TestMailListsHelpListsSubcommands(t *testing.T) {
+	t.Parallel()
+	root, opts := cli.NewRootCmd()
+	root.AddCommand(cli.NewMailCmd(opts))
+
+	var buf bytes.Buffer
+	root.SetOut(&buf)
+	root.SetErr(&buf)
+	root.SetArgs([]string{"mail", "lists", "--help"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{"list", "get"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("--help output missing %q\n%s", want, out)
+		}
+	}
+}

--- a/internal/cli/subdomains_test.go
+++ b/internal/cli/subdomains_test.go
@@ -1,0 +1,29 @@
+package cli_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/chmmou/kasapi-cli/internal/cli"
+)
+
+func TestSubdomainsCmdHelpListsSubcommands(t *testing.T) {
+	t.Parallel()
+	root, opts := cli.NewRootCmd()
+	root.AddCommand(cli.NewSubdomainsCmd(opts))
+
+	var buf bytes.Buffer
+	root.SetOut(&buf)
+	root.SetErr(&buf)
+	root.SetArgs([]string{"subdomains", "--help"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{"list", "get"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("--help output missing %q\n%s", want, out)
+		}
+	}
+}

--- a/internal/cli/tlds_test.go
+++ b/internal/cli/tlds_test.go
@@ -1,0 +1,27 @@
+package cli_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/chmmou/kasapi-cli/internal/cli"
+)
+
+func TestTLDsCmdHelpListsSubcommands(t *testing.T) {
+	t.Parallel()
+	root, opts := cli.NewRootCmd()
+	root.AddCommand(cli.NewTLDsCmd(opts))
+
+	var buf bytes.Buffer
+	root.SetOut(&buf)
+	root.SetErr(&buf)
+	root.SetArgs([]string{"tlds", "--help"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "list") {
+		t.Errorf("--help output missing %q\n%s", "list", out)
+	}
+}


### PR DESCRIPTION
Audit of the read-phase test coverage and the read-command usage docs.

## Test additions

- `internal/account`: `Client.Settings` and `Client.Resources` (both at 0% before — used by `accounts settings` / `accounts resources`); `AccountResources.TableHeaders`; `AccountSettings.TableHeaders` and `TableRows`.
- `internal/cli`: help-output tests for the `dns`, `domains`, `subdomains`, `tlds`, and `mail` (incl. `accounts` / `forwards` / `filters` / `lists` subgroups) command factories, matching the existing pattern from `cronjobs_test.go`.
- `internal/auth`: nil and non-auth-error tests for `IsLoginFailed`, `IsLoginLocked`, `IsUnknownSession`, `IsOTPPinIncorrect`, `IsCode`, and `AsError`.

Package-level coverage: `account` 69.9 → 85.4, `cli` 60.0 → 69.9, `auth` 80.2 → 83.3.

## Doc fix

`docs/usage/mail.md` described `mail filters list` as "server-side filter rules (Sieve-style: condition + action)". `get_mailstandardfilter` actually returns the catalog of pre-defined spam/virus filter presets (`rspamd`, the SpamAssassin variants, the virus-scanner modes, the spam-database lookups) attachable to a mailaccount via `mail_spamfilter`. Verified against `testdata/mailfilter/get_mailstandardfilter_response_success.xml`.

## Doc-coverage check

All read commands have both auto-generated reference (`docs/cli/`) and a hand-written usage page (`docs/usage/`). Skeleton packages without code (`chown`, `ssl`, `symlink`) and the leaf constant in `tablefmt` deliberately have no test files.