### PR TITLE
docs: fix ROADMAP mail-filter actions and tighten CONTRIBUTING

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `ROADMAP.md`: corrected the mail standard filter write entry from the
+  non-existent `update_mailstandardfilter` to the actual KAS actions
+  `add_mailstandardfilter` and `delete_mailstandardfilter` (the captured
+  fixtures and issue #116 are authoritative; the KAS API has no
+  `update_mailstandardfilter`).
+- `CONTRIBUTING.md`: roadmap links no longer detour through
+  `README.md#roadmap` (which is a one-line pointer with no checklist) —
+  they now point directly at `ROADMAP.md`. The CI gate description was
+  expanded to match what actually runs on every PR (`gosec`,
+  `govulncheck`, `go build`, `docs sync`, `goreleaser config check`,
+  CodeQL). The `kasapi-cli-vertical-slice` skill is now listed under
+  authoritative references alongside `kasapi-cli-git-workflow` and
+  `kasapi-cli-code-review`.
 - `README.md`: dropped the incorrect "read and write operations" claim
   from the "What it does" paragraph (writes are still pending), tightened
   the Status sentence to mention the v0.1.0 read modules instead of

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Thanks for your interest in contributing. This document collects the conventions
 ## Before you start
 
 - This project is **not affiliated with All-Inkl.com**. The KAS-API surface is reverse-engineered from the public documentation at <https://kasapi.kasserver.com/dokumentation/phpdoc/> and from real responses captured in `testdata/`.
-- The roadmap in [README.md](README.md#roadmap) shows which endpoints are already wired up. If you want to claim an unchecked item, please open an issue first so work is not duplicated.
+- The [ROADMAP.md](ROADMAP.md) tracks which KAS endpoints are already wired up end-to-end and which are still pending. If you want to claim an unchecked item, please open an issue first so work is not duplicated.
 - Bug reports and PRs that touch the KAS-API contract should reference the relevant doc page and, where possible, attach a redacted response fixture.
 
 ## Authoritative references
@@ -19,6 +19,7 @@ Read these before designing changes — do not duplicate their content into new 
 - [`docs/go/LINTING.md`](docs/go/LINTING.md) — the CI gate set.
 - [`.claude/skills/kasapi-cli-git-workflow/SKILL.md`](.claude/skills/kasapi-cli-git-workflow/SKILL.md) — git, branch, signed-commit, PR, and FF-push merge mechanics enforced for this project.
 - [`.claude/skills/kasapi-cli-code-review/SKILL.md`](.claude/skills/kasapi-cli-code-review/SKILL.md) — code-review loop (Blocker/Should/Nice classification, re-review cycle).
+- [`.claude/skills/kasapi-cli-vertical-slice/SKILL.md`](.claude/skills/kasapi-cli-vertical-slice/SKILL.md) — canonical slice anatomy and order of operations per KAS endpoint (fixture → mapping → client → CLI → docs → CHANGELOG). The summary in [Vertical-slice pattern](#vertical-slice-pattern) below is a contributor-facing recap; the skill file is authoritative.
 
 ## Repository layout
 
@@ -59,7 +60,7 @@ Each KAS endpoint is added as a single vertical slice; do not split it across mo
 4. **Fixture** in `testdata/<domain>/<kas_action>_response_success.xml` (and `_request.xml` if useful). The fixtures are real captured responses with secrets redacted — they are the source of truth for response shape.
 5. **CLI subcommand** in `internal/cli/<domain>.go`, registered in `cmd/kasapi-cli/main.go`.
 6. **CHANGELOG entry** under `## [Unreleased] / ### Added` (or `### Fixed`, etc.). One paragraph, ending with `Closes #<issue>` if applicable.
-7. **Roadmap update** in [README.md](README.md#roadmap) — flip the corresponding `- [ ]` to `- [x]`.
+7. **Roadmap update** in [ROADMAP.md](ROADMAP.md) — flip the corresponding `- [ ]` to `- [x]`.
 
 When the response shape differs between list and singular views (e.g. `get_domains` with vs. without `domain_name`), prefer one struct with `omitempty` on the view-specific fields rather than two structs.
 
@@ -86,7 +87,7 @@ git checkout -b chore/<topic>       # tooling / repo hygiene
 
 PR body: keep it short. Summary block describing *what*, not *how*. No "Test plan" section, no generated-by footer. If an issue is open, reference it with `Closes #<n>` so the project item flips to "Done" automatically on merge.
 
-CI must be green before merge. The CI workflow runs `go fmt` (check-only), `go vet`, `golangci-lint`, and `go test` (with `-race` where applicable).
+CI must be green before merge. On every PR the gate runs `go fmt` (check-only), `go vet`, `golangci-lint` (with `gosec`), `go test` (with `-race` where applicable), `go build`, `govulncheck`, a `docs sync` check (`make docs` must produce no diff against `docs/cli/`), a `goreleaser config check`, and CodeQL analysis.
 
 `main` is protected with `required_signatures` + `enforce_admins` + `linear_history`. The GitHub UI / `gh pr merge` strips signatures and is therefore **not** used for this repo. Merging is done by the maintainer via a locally-rebased, signed fast-forward push to `main`. As a contributor you do not need to do this — you only need to keep your branch rebased on `main` and your commits signed.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -48,7 +48,7 @@ The list is kept in sync with the code on `main`. To claim an unchecked item, pl
 - [x] `mail forwards list` / `mail forwards get <address>` (`get_mailforwards`, with `mail_forward` filter)
 - [ ] Mail forward write paths (`add_mailforward`, `update_mailforward`, `delete_mailforward`)
 - [x] `mail filters list` (`get_mailstandardfilter`)
-- [ ] Mail standard filter write paths (`update_mailstandardfilter`)
+- [ ] Mail standard filter write paths (`add_mailstandardfilter`, `delete_mailstandardfilter`)
 - [x] `mail lists list` (`get_mailinglists`)
 - [ ] Mailing list write paths (`add_mailinglist`, `update_mailinglist`, `delete_mailinglist`)
 


### PR DESCRIPTION
Four findings from a ROADMAP + CONTRIBUTING review pass.

**Blocker**
- `ROADMAP.md`: `update_mailstandardfilter` does not exist in the KAS API — replaced with `add_mailstandardfilter` + `delete_mailstandardfilter` (captured fixtures under `testdata/mailfilter/` and issue #116 are authoritative).
- `CONTRIBUTING.md`: the vertical-slice "Roadmap update" step pointed at `README.md#roadmap` (a one-line pointer with no checklist) and told contributors to flip a checkbox that does not exist there. Repointed at `ROADMAP.md`.

**Should**
- `CONTRIBUTING.md`: the "Before you start" roadmap link had the same one-hop detour; repointed at `ROADMAP.md`.
- `CONTRIBUTING.md`: the CI gate description listed only `go fmt`/`go vet`/`golangci-lint`/`go test`; expanded to match what actually runs (`gosec`, `govulncheck`, `go build`, `docs sync`, `goreleaser config check`, CodeQL).

**Nice-to-have**
- `CONTRIBUTING.md`: `kasapi-cli-vertical-slice` skill is now listed under authoritative references alongside `kasapi-cli-git-workflow` and `kasapi-cli-code-review`. The inline §Vertical-slice pattern remains as a contributor-facing recap of the skill.