### PR TITLE
docs(roadmap): track CLI write-safety prerequisites (#109, #131, #132)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `ROADMAP.md`: added a new `CLI write safety` section listing the
+  cross-cutting prerequisites that gate every destructive subcommand —
+  the destructive-write confirmation infrastructure (#109), the
+  structured write-action audit log (#131), and `--dry-run` for write
+  commands (#132). These are not KAS-API endpoints but block the entire
+  v0.2.0 write phase; tracking them on the roadmap keeps the contributor
+  view of "what is still pending" honest.
 - `ROADMAP.md`: corrected the mail standard filter write entry from the
   non-existent `update_mailstandardfilter` to the actual KAS actions
   `add_mailstandardfilter` and `delete_mailstandardfilter` (the captured

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -19,6 +19,14 @@ The list is kept in sync with the code on `main`. To claim an unchecked item, pl
 - [x] Environment overrides (`KAS_LOGIN`, `KAS_AUTHDATA`, `KAS_AUTHTYPE`, `KAS_PROFILE`)
 - [x] Secrets are never echoed in `--help` or default log output
 
+## CLI write safety
+
+Cross-cutting prerequisites for the v0.2.0 write phase — these are not KAS-API endpoints themselves but gate every destructive subcommand.
+
+- [ ] Destructive-write confirmation infrastructure (`--yes` / interactive `[y/N]` prompt, see #109)
+- [ ] Structured write-action audit log (`--audit-log <path>` / `KAS_AUDIT_LOG`, see #131)
+- [ ] `--dry-run` for write commands (preview KAS action + parameters without dispatching, see #132)
+
 ## Accounts & server
 
 - [x] `accounts list` / `accounts get <account-login>` (`get_accounts`, with `account_login` filter)


### PR DESCRIPTION
## Summary

Add a `CLI write safety` section to `ROADMAP.md` listing the cross-cutting prerequisites that gate every destructive subcommand in the v0.2.0 write phase:

- destructive-write confirmation infrastructure (#109)
- structured write-action audit log (#131)
- `--dry-run` for write commands (#132)

These are not KAS-API endpoints themselves, so they didn't fit any of the existing per-resource sections — but they block the entire write phase, so tracking them on the roadmap keeps the contributor view of "what is still pending" honest.