### PR TITLE
chore: address code-review NTH bundle from 2026-05-10 pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `internal/cli/wire.go`: documented why the `auth.New(... soap.AuthPlain, authOpts)`
+  call inside the `auth_type=session` branch hardcodes `AuthPlain` — KasAuth
+  always bootstraps in plain mode regardless of session mode, and the
+  session token is what subsequent KasApi calls use. Prevents future
+  drive-by "fixes" that would replace the constant with `AuthSession`.
+- `internal/transport/client.go`: documented why `waitGate` runs once
+  before the retry loop, not inside it. 5xx-driven retries do not decode
+  envelopes, so no fresh `KasFloodDelay` can be recorded between attempts
+  — re-checking the gate would always be a no-op.
+- `internal/auth/source.go`: `SessionTokenSource` now exposes a `Logger`
+  field; the three previously silent `s.Store.Save` / `s.Store.Delete`
+  call sites now log a `Warn` event when persistence fails so disk-full
+  or permission issues surface in `--verbose` output. The in-memory
+  cache still works in that case and the next invocation re-bootstraps
+  via KasAuth, so behaviour is unchanged for the success path. The CLI
+  wires `--verbose` into the new field via `internal/cli/wire.go`.
+- `internal/cli/output.go` + `internal/cli/root.go`: deduplicated the
+  `AllFormats → []string` conversion. A new package-internal
+  `formatNames()` is now the single source of truth used by both the
+  `--output` flag help (joined with `|`) and the `ParseFormat` error
+  message (joined with `, `).
+- `internal/soap/value.go`: replaced the magic `Kind(255)` sentinel
+  returned by `classifyType` for unknown `xsi:type` values with a named
+  `KindUnknown = 255` constant. Documented why the constant lives
+  outside the iota block (so future enum additions cannot collide).
+- `internal/cli/output.go`: clarified the `ErrTableNotSupported`
+  message. Every subcommand result type is expected to implement
+  `Tabular`, so this error always indicates a kasapi-cli bug rather than
+  a user choice; the message now says so while keeping the
+  `--output=json` / `--output=yaml` workaround hint.
+
 ### Fixed
 
 - `.claude/skills/kasapi-cli-vertical-slice/SKILL.md`: corrected two

--- a/internal/auth/source.go
+++ b/internal/auth/source.go
@@ -2,6 +2,8 @@ package auth
 
 import (
 	"context"
+	"io"
+	"log/slog"
 	"sync"
 	"time"
 
@@ -38,6 +40,13 @@ type SessionTokenSource struct {
 	Lifetime       time.Duration
 	UpdateLifetime bool
 	Now            func() time.Time
+
+	// Logger receives Warn events when persisting or deleting the session
+	// cache on disk fails. The in-memory cache still works in that case
+	// and the next invocation simply re-bootstraps via KasAuth, but
+	// surfacing disk-full / permission errors helps debug field issues.
+	// Nil is treated as a discard logger.
+	Logger *slog.Logger
 
 	mu        sync.Mutex
 	loaded    bool
@@ -114,7 +123,9 @@ func (s *SessionTokenSource) Credentials(ctx context.Context) (string, string, s
 			LifetimeSeconds: int(s.lifetime() / time.Second),
 			UpdateLifetime:  s.UpdateLifetime,
 		}
-		_ = s.Store.Save(s.Client.Login, entry)
+		if err := s.Store.Save(s.Client.Login, entry); err != nil {
+			s.logger().Warn("auth: session store save failed; cache stays in-memory", "err", err)
+		}
 	}
 	return s.Client.Login, s.token, soap.AuthSession, nil
 }
@@ -136,7 +147,9 @@ func (s *SessionTokenSource) Invalidate() {
 		s.UpdateLifetime = s.configuredUpdateLifetime
 	}
 	if s.Store != nil {
-		_ = s.Store.Delete(s.Client.Login)
+		if err := s.Store.Delete(s.Client.Login); err != nil {
+			s.logger().Warn("auth: session store delete failed; in-memory cache cleared", "err", err)
+		}
 	}
 }
 
@@ -160,8 +173,19 @@ func (s *SessionTokenSource) Heartbeat() {
 			LifetimeSeconds: int(s.lifetime() / time.Second),
 			UpdateLifetime:  true,
 		}
-		_ = s.Store.Save(s.Client.Login, entry)
+		if err := s.Store.Save(s.Client.Login, entry); err != nil {
+			s.logger().Warn("auth: session store heartbeat save failed; rolling window stays in-memory", "err", err)
+		}
 	}
+}
+
+// logger returns the configured Logger or a discard logger so call sites
+// may invoke s.logger().Warn unconditionally.
+func (s *SessionTokenSource) logger() *slog.Logger {
+	if s.Logger != nil {
+		return s.Logger
+	}
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
 }
 
 func (s *SessionTokenSource) cachedValid() bool {

--- a/internal/cli/output.go
+++ b/internal/cli/output.go
@@ -29,6 +29,18 @@ const DefaultFormat = FormatTable
 // Used by the root command help text and validation.
 var AllFormats = []Format{FormatJSON, FormatYAML, FormatTable}
 
+// formatNames returns AllFormats as a []string in the same order.
+// Single source of truth for the strings used by both the --output flag
+// help (joined with "|") and the ParseFormat error message (joined with
+// ", "); callers join with whatever separator they need.
+func formatNames() []string {
+	names := make([]string, len(AllFormats))
+	for i, f := range AllFormats {
+		names[i] = string(f)
+	}
+	return names
+}
+
 // ParseFormat returns the Format matching s or an error listing valid
 // values. The empty string maps to DefaultFormat.
 func ParseFormat(s string) (Format, error) {
@@ -40,11 +52,7 @@ func ParseFormat(s string) (Format, error) {
 			return f, nil
 		}
 	}
-	names := make([]string, len(AllFormats))
-	for i, f := range AllFormats {
-		names[i] = string(f)
-	}
-	return "", fmt.Errorf("invalid output format %q (want one of %s)", s, strings.Join(names, ", "))
+	return "", fmt.Errorf("invalid output format %q (want one of %s)", s, strings.Join(formatNames(), ", "))
 }
 
 // Tabular is implemented by values that can render themselves as a
@@ -87,8 +95,12 @@ func renderYAML(w io.Writer, v any) error {
 }
 
 // ErrTableNotSupported is returned by Render when --output=table is
-// requested for a value that does not implement Tabular.
-var ErrTableNotSupported = errors.New("table output not supported for this command (try --output=json or --output=yaml)")
+// requested for a value that does not implement Tabular. Every
+// subcommand result type is expected to implement Tabular, so reaching
+// this error means a subcommand is missing its TableHeaders/TableRows
+// pair — i.e. a kasapi-cli bug, not a user choice. The workaround hint
+// keeps the user unblocked in the meantime.
+var ErrTableNotSupported = errors.New("table output is not implemented for this command (kasapi-cli bug, please report it; workaround: --output=json or --output=yaml)")
 
 func renderTable(w io.Writer, v any) error {
 	t, ok := v.(Tabular)

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -94,12 +95,5 @@ func NewRootCmd() (*cobra.Command, *RootOptions) {
 }
 
 func joinFormats() string {
-	out := ""
-	for i, f := range AllFormats {
-		if i > 0 {
-			out += "|"
-		}
-		out += string(f)
-	}
-	return out
+	return strings.Join(formatNames(), "|")
 }

--- a/internal/cli/wire.go
+++ b/internal/cli/wire.go
@@ -116,9 +116,12 @@ func tokenSource(tr *transport.Client, creds config.Credentials, s sessionOpts, 
 		if err != nil {
 			return nil, err
 		}
+		// KasAuth bootstrap is always plain regardless of session mode; the
+		// session token returned by KasAuth is what subsequent KasApi calls use.
 		authClient := auth.New(tr, creds.Login, creds.AuthData, soap.AuthPlain, authOpts)
 		authClient.Logger = logger
 		src := auth.NewSessionTokenSource(authClient)
+		src.Logger = logger
 		storePath, serr := session.PathFor(s.ConfigPath)
 		if serr != nil {
 			return nil, fmt.Errorf("session store: %w", serr)

--- a/internal/soap/value.go
+++ b/internal/soap/value.go
@@ -21,6 +21,12 @@ const (
 	KindArray
 )
 
+// KindUnknown is the sentinel classifyType returns for xsi:type values
+// that do not match any KAS-supported kind. It is intentionally placed
+// outside the iota block at 255 so it stays out of the enumerated range
+// and never collides with a future addition.
+const KindUnknown Kind = 255
+
 // KV is one entry of an ordered Map. The Apache xml-soap ns2:Map preserves
 // insertion order; we keep that order so callers can render or compare
 // without surprise.
@@ -258,7 +264,7 @@ func classifyType(t string) Kind {
 	case "Array":
 		return KindArray
 	}
-	return Kind(255)
+	return KindUnknown
 }
 
 // Get looks up a key in a Map Value. It returns the zero Value and false if

--- a/internal/transport/client.go
+++ b/internal/transport/client.go
@@ -88,6 +88,10 @@ func (c *Client) Do(ctx context.Context, endpoint string, body []byte) ([]byte, 
 		return nil, err
 	}
 
+	// Gate is checked once before the loop, not inside it. 5xx-driven
+	// retries do not decode envelopes, so no fresh KasFloodDelay can be
+	// recorded between attempts — re-checking the gate would always be a
+	// no-op.
 	backoff := defaultBackoff
 	var lastErr error
 	for attempt := 0; attempt <= c.MaxRetries; attempt++ {


### PR DESCRIPTION
Closes #104. Addresses all six Nice-to-have findings from the 2026-05-10 fresh-eyes whole-project code-review pass.

- `internal/cli/wire.go`: one-line comment explaining why `soap.AuthPlain` is hardcoded inside the `auth_type=session` branch.
- `internal/transport/client.go`: comment at the retry-loop entry explaining why `waitGate` runs once before the loop, not inside it.
- `internal/auth/source.go`: `SessionTokenSource` gains a `Logger` field; the three previously silent `Store.Save` / `Store.Delete` sites now `Warn` on failure. Wired from `internal/cli/wire.go`.
- `internal/cli/output.go` + `internal/cli/root.go`: deduplicate the `AllFormats → []string` conversion behind a package-internal `formatNames()` helper.
- `internal/soap/value.go`: replace the magic `Kind(255)` sentinel with a named `KindUnknown` constant.
- `internal/cli/output.go`: clarify `ErrTableNotSupported` — missing `Tabular` is a kasapi-cli bug, not a user choice; workaround hint kept.

No behaviour changes on success paths; failure paths now emit `Warn` events instead of dropping errors. Lint, tests, build, and docs sync all green locally.