### PR TITLE
chore: address re-review findings on PR #135 (NTH bundle)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `internal/auth/source.go` + `auth/client.go` + `api/client.go` +
+  `transport/client.go`: consolidated the `slog.New(slog.NewTextHandler(io.Discard, nil))`
+  discard-logger pattern. Each of the three packages now has a single
+  package-level `var discardLogger` built once at init; previously the
+  same expression was inline-duplicated across constructors and
+  `logger()` helpers (and `transport` had a `discardLogger()` function
+  that re-allocated per call). `NewSessionTokenSource` now seeds
+  `Logger` to that discard logger in its constructor, matching the
+  pattern already used by `auth.New`, `api.New`, and `transport.New`.
+- `internal/cli/output.go` + `cli/root.go`: `formatNames` is now a
+  package-level `var` (built once at init) instead of a function that
+  re-built the `[]string` on every call. `ParseFormat`'s error message
+  and `joinFormats` consume it as a value; both call sites are
+  read-only, so sharing the backing array is safe.
+- `internal/cli/output.go`: tightened the `ErrTableNotSupported`
+  message to a single phrase per Go error-style guidance — same
+  meaning, but easier to skim in logs.
+- `internal/soap/value.go`: `KindUnknown`'s doc now explains why the
+  sentinel value is exactly 255 (max of `Kind`'s underlying `uint8`,
+  giving the iota block room to grow without collision).
+
+### Changed
+
 - `internal/cli/wire.go`: documented why the `auth.New(... soap.AuthPlain, authOpts)`
   call inside the `auth_type=session` branch hardcodes `AuthPlain` — KasAuth
   always bootstraps in plain mode regardless of session mode, and the

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -78,6 +78,11 @@ type Client struct {
 	Logger *slog.Logger
 }
 
+// discardLogger is the shared no-op logger used as the package default
+// so callers can invoke Logger / logger() unconditionally. Built once
+// at package init.
+var discardLogger = slog.New(slog.NewTextHandler(io.Discard, nil))
+
 // New returns a Client wired with the given transport and token source.
 // Endpoint defaults to DefaultEndpoint.
 func New(t *transport.Client, ts TokenSource) *Client {
@@ -85,7 +90,7 @@ func New(t *transport.Client, ts TokenSource) *Client {
 		Transport: t,
 		Tokens:    ts,
 		Endpoint:  DefaultEndpoint,
-		Logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Logger:    discardLogger,
 	}
 }
 
@@ -93,7 +98,7 @@ func (c *Client) logger() *slog.Logger {
 	if c.Logger != nil {
 		return c.Logger
 	}
-	return slog.New(slog.NewTextHandler(io.Discard, nil))
+	return discardLogger
 }
 
 // Call posts one KasApi action with the given parameters and returns

--- a/internal/auth/client.go
+++ b/internal/auth/client.go
@@ -45,6 +45,11 @@ type Client struct {
 	Logger *slog.Logger
 }
 
+// discardLogger is the shared no-op logger used as the package default
+// so callers can invoke Logger / logger() unconditionally. Built once
+// at package init.
+var discardLogger = slog.New(slog.NewTextHandler(io.Discard, nil))
+
 // New returns a Client configured for the given credentials and options.
 // Endpoint defaults to DefaultEndpoint.
 func New(t *transport.Client, login, authData string, authType soap.AuthType, opts Options) *Client {
@@ -55,7 +60,7 @@ func New(t *transport.Client, login, authData string, authType soap.AuthType, op
 		AuthType:  authType,
 		Options:   opts,
 		Endpoint:  DefaultEndpoint,
-		Logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Logger:    discardLogger,
 	}
 }
 
@@ -63,7 +68,7 @@ func (c *Client) logger() *slog.Logger {
 	if c.Logger != nil {
 		return c.Logger
 	}
-	return slog.New(slog.NewTextHandler(io.Discard, nil))
+	return discardLogger
 }
 
 // GetCredentialToken posts the KasAuth request and returns the

--- a/internal/auth/source.go
+++ b/internal/auth/source.go
@@ -2,7 +2,6 @@ package auth
 
 import (
 	"context"
-	"io"
 	"log/slog"
 	"sync"
 	"time"
@@ -67,9 +66,11 @@ type SessionTokenSource struct {
 // NewSessionTokenSource returns a source that lazily fetches the token
 // on first use and does not persist it. Set Store, Lifetime, and
 // UpdateLifetime on the returned value to enable cross-invocation
-// caching.
+// caching. Logger is seeded with the package discard logger so callers
+// may write to it unconditionally; replace it (e.g. with a stderr
+// handler) to surface persist/delete failures from the field.
 func NewSessionTokenSource(c *Client) *SessionTokenSource {
-	return &SessionTokenSource{Client: c}
+	return &SessionTokenSource{Client: c, Logger: discardLogger}
 }
 
 // Credentials returns the cached token. Order of preference:
@@ -179,13 +180,13 @@ func (s *SessionTokenSource) Heartbeat() {
 	}
 }
 
-// logger returns the configured Logger or a discard logger so call sites
-// may invoke s.logger().Warn unconditionally.
+// logger returns the configured Logger or the package discard logger
+// so call sites may invoke s.logger().Warn unconditionally.
 func (s *SessionTokenSource) logger() *slog.Logger {
 	if s.Logger != nil {
 		return s.Logger
 	}
-	return slog.New(slog.NewTextHandler(io.Discard, nil))
+	return discardLogger
 }
 
 func (s *SessionTokenSource) cachedValid() bool {

--- a/internal/cli/output.go
+++ b/internal/cli/output.go
@@ -29,17 +29,18 @@ const DefaultFormat = FormatTable
 // Used by the root command help text and validation.
 var AllFormats = []Format{FormatJSON, FormatYAML, FormatTable}
 
-// formatNames returns AllFormats as a []string in the same order.
-// Single source of truth for the strings used by both the --output flag
-// help (joined with "|") and the ParseFormat error message (joined with
-// ", "); callers join with whatever separator they need.
-func formatNames() []string {
+// formatNames is the cached []string view of AllFormats. Single source
+// of truth for the strings used by both the --output flag help (joined
+// with "|") and the ParseFormat error message (joined with ", "); built
+// once at package init so callers do not re-allocate per call. Treat as
+// read-only.
+var formatNames = func() []string {
 	names := make([]string, len(AllFormats))
 	for i, f := range AllFormats {
 		names[i] = string(f)
 	}
 	return names
-}
+}()
 
 // ParseFormat returns the Format matching s or an error listing valid
 // values. The empty string maps to DefaultFormat.
@@ -52,7 +53,7 @@ func ParseFormat(s string) (Format, error) {
 			return f, nil
 		}
 	}
-	return "", fmt.Errorf("invalid output format %q (want one of %s)", s, strings.Join(formatNames(), ", "))
+	return "", fmt.Errorf("invalid output format %q (want one of %s)", s, strings.Join(formatNames, ", "))
 }
 
 // Tabular is implemented by values that can render themselves as a
@@ -100,7 +101,7 @@ func renderYAML(w io.Writer, v any) error {
 // this error means a subcommand is missing its TableHeaders/TableRows
 // pair — i.e. a kasapi-cli bug, not a user choice. The workaround hint
 // keeps the user unblocked in the meantime.
-var ErrTableNotSupported = errors.New("table output is not implemented for this command (kasapi-cli bug, please report it; workaround: --output=json or --output=yaml)")
+var ErrTableNotSupported = errors.New("table output not implemented for this command (programming bug; use --output=json or --output=yaml)")
 
 func renderTable(w io.Writer, v any) error {
 	t, ok := v.(Tabular)

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -95,5 +95,5 @@ func NewRootCmd() (*cobra.Command, *RootOptions) {
 }
 
 func joinFormats() string {
-	return strings.Join(formatNames(), "|")
+	return strings.Join(formatNames, "|")
 }

--- a/internal/soap/value.go
+++ b/internal/soap/value.go
@@ -22,9 +22,10 @@ const (
 )
 
 // KindUnknown is the sentinel classifyType returns for xsi:type values
-// that do not match any KAS-supported kind. It is intentionally placed
-// outside the iota block at 255 so it stays out of the enumerated range
-// and never collides with a future addition.
+// that do not match any KAS-supported kind. Placed outside the iota
+// block at 255 — the maximum value of Kind's underlying uint8 — so the
+// sentinel stays out of the enumerated range and any future KindFoo
+// added to the iota block cannot collide with it.
 const KindUnknown Kind = 255
 
 // KV is one entry of an ordered Map. The Apache xml-soap ns2:Map preserves

--- a/internal/transport/client.go
+++ b/internal/transport/client.go
@@ -49,6 +49,11 @@ type Client struct {
 	nextEarliest time.Time
 }
 
+// discardLogger is the shared no-op logger used as the package default
+// so callers can invoke Logger / logger() unconditionally. Built once
+// at package init.
+var discardLogger = slog.New(slog.NewTextHandler(io.Discard, nil))
+
 // New returns a Client with sensible defaults: a 30s HTTP timeout, a
 // version-stamped User-Agent, and three retries on 5xx / network errors.
 func New() *Client {
@@ -56,14 +61,10 @@ func New() *Client {
 		HTTPClient: &http.Client{Timeout: DefaultTimeout},
 		UserAgent:  DefaultUserAgent,
 		MaxRetries: DefaultMaxRetries,
-		Logger:     discardLogger(),
+		Logger:     discardLogger,
 		Now:        time.Now,
 		Sleep:      ctxSleep,
 	}
-}
-
-func discardLogger() *slog.Logger {
-	return slog.New(slog.NewTextHandler(io.Discard, nil))
 }
 
 // RecordDelay schedules a window during which subsequent calls to Do
@@ -134,7 +135,7 @@ func (c *Client) logger() *slog.Logger {
 	if c.Logger != nil {
 		return c.Logger
 	}
-	return discardLogger()
+	return discardLogger
 }
 
 func (c *Client) doOnce(ctx context.Context, endpoint string, body []byte) ([]byte, error) {


### PR DESCRIPTION
Post-merge fresh-eyes pass on commit \`11376ed\` (PR #135) surfaced one Should and four Nice-to-have items in the Go-conventions check. All five are addressed here in one branch.

- **S1** \`internal/auth/source.go\` — \`NewSessionTokenSource\` now seeds \`Logger\` to the package discard logger, matching \`auth.New\` / \`api.New\` / \`transport.New\`.
- **N1** \`internal/{auth,api,transport}\` — consolidated the \`slog.New(slog.NewTextHandler(io.Discard, nil))\` pattern behind a package-level \`var discardLogger\` built once at init (replaces three inline duplications + the per-call \`discardLogger()\` function in transport).
- **N2** \`internal/cli/output.go\` + \`cli/root.go\` — \`formatNames\` is now a package-level \`var\` (built once) instead of a function that re-built the slice per call.
- **N3** \`internal/cli/output.go\` — tightened \`ErrTableNotSupported\` to a single phrase per Go error-style guidance.
- **N4** \`internal/soap/value.go\` — \`KindUnknown\` doc explains why exactly 255 (max of \`Kind\`'s underlying \`uint8\`).

No behaviour changes. \`make fmt vet lint test build docs\` all green locally.