### PR TITLE
docs(changelog): merge duplicate Changed sections under [Unreleased]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,9 +29,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `internal/soap/value.go`: `KindUnknown`'s doc now explains why the
   sentinel value is exactly 255 (max of `Kind`'s underlying `uint8`,
   giving the iota block room to grow without collision).
-
-### Changed
-
 - `internal/cli/wire.go`: documented why the `auth.New(... soap.AuthPlain, authOpts)`
   call inside the `auth_type=session` branch hardcodes `AuthPlain` — KasAuth
   always bootstraps in plain mode regardless of session mode, and the


### PR DESCRIPTION
Re-review of PR #136 surfaced two `### Changed` headers in the `[Unreleased]` block — one from the NTH bundle (#135) and one appended by #136 directly above it. Keep a Changelog 1.1.0 expects a single header per change type per version, so the two are merged into one section with all bullets retained (re-review entries first, NTH-bundle entries below).