### PR TITLE
refactor(session): thread context through session.Store and Heartbeater

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `internal/session/store.go` + `auth/source.go` + `api/client.go`:
+  thread the call's `context.Context` through `session.Store.Load` /
+  `Save` / `Delete` and through `api.Heartbeater.Heartbeat`. The lock
+  wait now uses `flock.TryLockContext` so a user `Ctrl-C` while
+  another `kasapi-cli` process holds the sessions-file lock aborts
+  cleanly instead of blocking forever; the synchronous toml/os calls
+  are local-FS only so a `ctx.Err()` check at the boundary is
+  sufficient. `SessionTokenSource.Invalidate` deliberately uses
+  `context.Background` for the delete so a cancelled run still clears
+  the stale on-disk token, matching the "cleanup is finalisation"
+  pattern. Tests updated; behaviour for non-cancelled calls is
+  unchanged.
+
 - `internal/auth/source.go` + `auth/client.go` + `api/client.go` +
   `transport/client.go`: consolidated the `slog.New(slog.NewTextHandler(io.Discard, nil))`
   discard-logger pattern. Each of the three packages now has a single

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -34,9 +34,11 @@ type TokenSource interface {
 // Heartbeater is an optional TokenSource extension. After every
 // successful Call, Client invokes Heartbeat so a session-token source
 // configured with session_update_lifetime=Y can extend its locally
-// cached expiry to mirror the rolling window the server applies.
+// cached expiry to mirror the rolling window the server applies. The
+// call's context is forwarded so a slow disk write during Heartbeat
+// honours user cancellation.
 type Heartbeater interface {
-	Heartbeat()
+	Heartbeat(ctx context.Context)
 }
 
 // StaticTokenSource is a TokenSource that returns the same credentials
@@ -122,7 +124,7 @@ func (c *Client) Call(ctx context.Context, action string, params map[string]any)
 	}
 	if err == nil {
 		if hb, ok := c.Tokens.(Heartbeater); ok {
-			hb.Heartbeat()
+			hb.Heartbeat(ctx)
 		}
 		return resp, nil
 	}

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -302,5 +302,5 @@ type beatingTokens struct {
 func (b *beatingTokens) Credentials(_ context.Context) (string, string, soap.AuthType, error) {
 	return b.login, b.data, b.typ, nil
 }
-func (b *beatingTokens) Invalidate() {}
-func (b *beatingTokens) Heartbeat()  { b.heartbeats++ }
+func (b *beatingTokens) Invalidate()                 {}
+func (b *beatingTokens) Heartbeat(_ context.Context) { b.heartbeats++ }

--- a/internal/auth/client_test.go
+++ b/internal/auth/client_test.go
@@ -157,7 +157,7 @@ func TestSessionTokenSourceLoadsFromStore(t *testing.T) {
 
 	now := time.Date(2026, 5, 3, 12, 0, 0, 0, time.UTC)
 	store := newStore(t, now)
-	if err := store.Save("w0", session.Entry{
+	if err := store.Save(t.Context(), "w0", session.Entry{
 		Token:           "cached-tok",
 		ExpiresAt:       now.Add(time.Hour),
 		LifetimeSeconds: 3600,
@@ -189,7 +189,7 @@ func TestSessionTokenSourceFetchesWhenStoredEntryExpired(t *testing.T) {
 
 	now := time.Date(2026, 5, 3, 12, 0, 0, 0, time.UTC)
 	store := newStore(t, now)
-	if err := store.Save("w0", session.Entry{
+	if err := store.Save(t.Context(), "w0", session.Entry{
 		Token:     "stale",
 		ExpiresAt: now.Add(-time.Second),
 	}); err != nil {
@@ -211,7 +211,7 @@ func TestSessionTokenSourceFetchesWhenStoredEntryExpired(t *testing.T) {
 	if calls.Load() != 1 {
 		t.Errorf("KasAuth calls = %d, want 1", calls.Load())
 	}
-	saved, err := store.Load("w0")
+	saved, err := store.Load(t.Context(), "w0")
 	if err != nil || saved == nil {
 		t.Fatalf("expected fresh entry persisted, got %v %v", saved, err)
 	}
@@ -237,11 +237,11 @@ func TestSessionTokenSourceInvalidateDeletesPersisted(t *testing.T) {
 	if _, _, _, err := src.Credentials(context.Background()); err != nil {
 		t.Fatalf("Credentials: %v", err)
 	}
-	if got, _ := store.Load("w0"); got == nil {
+	if got, _ := store.Load(t.Context(), "w0"); got == nil {
 		t.Fatal("expected entry persisted after fresh fetch")
 	}
 	src.Invalidate()
-	if got, _ := store.Load("w0"); got != nil {
+	if got, _ := store.Load(t.Context(), "w0"); got != nil {
 		t.Errorf("expected entry deleted after Invalidate, got %+v", got)
 	}
 }
@@ -264,16 +264,16 @@ func TestSessionTokenSourceHeartbeatExtendsExpiry(t *testing.T) {
 	if _, _, _, err := src.Credentials(context.Background()); err != nil {
 		t.Fatalf("Credentials: %v", err)
 	}
-	first, _ := store.Load("w0")
+	first, _ := store.Load(t.Context(), "w0")
 	if first == nil {
 		t.Fatal("expected initial entry")
 	}
 
 	tNow = tNow.Add(15 * time.Minute)
 	store.Now = func() time.Time { return tNow }
-	src.Heartbeat()
+	src.Heartbeat(t.Context())
 
-	got, _ := store.Load("w0")
+	got, _ := store.Load(t.Context(), "w0")
 	if got == nil {
 		t.Fatal("expected entry after Heartbeat")
 	}
@@ -295,7 +295,7 @@ func TestSessionTokenSourceAdoptsLifetimeFromCachedEntry(t *testing.T) {
 
 	tNow := time.Date(2026, 5, 3, 12, 0, 0, 0, time.UTC)
 	store := newStore(t, tNow)
-	if err := store.Save("w0", session.Entry{
+	if err := store.Save(t.Context(), "w0", session.Entry{
 		Token:           "cached",
 		ExpiresAt:       tNow.Add(time.Hour),
 		LifetimeSeconds: 3600,
@@ -314,9 +314,9 @@ func TestSessionTokenSourceAdoptsLifetimeFromCachedEntry(t *testing.T) {
 
 	tNow = tNow.Add(15 * time.Minute)
 	store.Now = func() time.Time { return tNow }
-	src.Heartbeat()
+	src.Heartbeat(t.Context())
 
-	got, _ := store.Load("w0")
+	got, _ := store.Load(t.Context(), "w0")
 	if got == nil {
 		t.Fatal("expected entry after Heartbeat")
 	}
@@ -342,7 +342,7 @@ func TestSessionTokenSourceInvalidateRestoresConfiguredAfterAdopt(t *testing.T) 
 
 	tNow := time.Date(2026, 5, 9, 12, 0, 0, 0, time.UTC)
 	store := newStore(t, tNow)
-	if err := store.Save("w0", session.Entry{
+	if err := store.Save(t.Context(), "w0", session.Entry{
 		Token:           "stale-but-locally-valid",
 		ExpiresAt:       tNow.Add(30 * time.Minute),
 		LifetimeSeconds: 1800,
@@ -370,7 +370,7 @@ func TestSessionTokenSourceInvalidateRestoresConfiguredAfterAdopt(t *testing.T) 
 		t.Fatalf("Credentials after invalidate: %v", err)
 	}
 
-	got, _ := store.Load("w0")
+	got, _ := store.Load(t.Context(), "w0")
 	if got == nil {
 		t.Fatal("expected fresh entry persisted after invalidate")
 	}
@@ -399,15 +399,15 @@ func TestSessionTokenSourceHeartbeatNoopWithoutUpdateLifetime(t *testing.T) {
 	if _, _, _, err := src.Credentials(context.Background()); err != nil {
 		t.Fatalf("Credentials: %v", err)
 	}
-	original, _ := store.Load("w0")
+	original, _ := store.Load(t.Context(), "w0")
 	if original == nil {
 		t.Fatal("expected initial entry")
 	}
 
 	tNow = tNow.Add(15 * time.Minute)
-	src.Heartbeat()
+	src.Heartbeat(t.Context())
 
-	got, _ := store.Load("w0")
+	got, _ := store.Load(t.Context(), "w0")
 	if got == nil || !got.ExpiresAt.Equal(original.ExpiresAt) {
 		t.Errorf("ExpiresAt changed without UpdateLifetime: %+v", got)
 	}

--- a/internal/auth/source.go
+++ b/internal/auth/source.go
@@ -92,7 +92,7 @@ func (s *SessionTokenSource) Credentials(ctx context.Context) (string, string, s
 	}
 	if !s.loaded && s.Store != nil {
 		s.loaded = true
-		if e, err := s.Store.Load(s.Client.Login); err == nil && e != nil {
+		if e, err := s.Store.Load(ctx, s.Client.Login); err == nil && e != nil {
 			s.token = e.Token
 			s.expiresAt = e.ExpiresAt
 			if s.cachedValid() {
@@ -124,7 +124,7 @@ func (s *SessionTokenSource) Credentials(ctx context.Context) (string, string, s
 			LifetimeSeconds: int(s.lifetime() / time.Second),
 			UpdateLifetime:  s.UpdateLifetime,
 		}
-		if err := s.Store.Save(s.Client.Login, entry); err != nil {
+		if err := s.Store.Save(ctx, s.Client.Login, entry); err != nil {
 			s.logger().Warn("auth: session store save failed; cache stays in-memory", "err", err)
 		}
 	}
@@ -137,6 +137,12 @@ func (s *SessionTokenSource) Credentials(ctx context.Context) (string, string, s
 // reset to the user-configured values so the fresh session created by
 // the next Credentials call respects the current CLI flags rather than
 // the now-discarded session's properties.
+//
+// Invalidate is called by api.Client on auth-failure paths where the
+// caller's ctx may already be cancelled; the disk delete therefore uses
+// context.Background so a successful invalidation cannot be lost just
+// because the user pressed Ctrl-C between the API failure and the
+// cleanup. The in-memory clear happens unconditionally either way.
 func (s *SessionTokenSource) Invalidate() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -148,7 +154,7 @@ func (s *SessionTokenSource) Invalidate() {
 		s.UpdateLifetime = s.configuredUpdateLifetime
 	}
 	if s.Store != nil {
-		if err := s.Store.Delete(s.Client.Login); err != nil {
+		if err := s.Store.Delete(context.Background(), s.Client.Login); err != nil {
 			s.logger().Warn("auth: session store delete failed; in-memory cache cleared", "err", err)
 		}
 	}
@@ -159,8 +165,9 @@ func (s *SessionTokenSource) Invalidate() {
 // window. It is a no-op when UpdateLifetime is false or no token is
 // cached; when a Store is wired up the refreshed expiry is also
 // persisted, otherwise the rolling window stays in-memory only.
-// Called by api.Client after every successful KasApi call.
-func (s *SessionTokenSource) Heartbeat() {
+// Called by api.Client after every successful KasApi call; ctx is the
+// call's context so cancellation cuts off the persistence write too.
+func (s *SessionTokenSource) Heartbeat(ctx context.Context) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if !s.UpdateLifetime || s.token == "" {
@@ -174,7 +181,7 @@ func (s *SessionTokenSource) Heartbeat() {
 			LifetimeSeconds: int(s.lifetime() / time.Second),
 			UpdateLifetime:  true,
 		}
-		if err := s.Store.Save(s.Client.Login, entry); err != nil {
+		if err := s.Store.Save(ctx, s.Client.Login, entry); err != nil {
 			s.logger().Warn("auth: session store heartbeat save failed; rolling window stays in-memory", "err", err)
 		}
 	}

--- a/internal/session/store.go
+++ b/internal/session/store.go
@@ -12,6 +12,7 @@
 package session
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -22,6 +23,11 @@ import (
 	"github.com/BurntSushi/toml"
 	"github.com/gofrs/flock"
 )
+
+// lockRetry is the polling interval used by flock.LockContext while
+// waiting for a contended lock. Small enough to feel responsive when
+// another process drops the lock, large enough not to spin on syscalls.
+const lockRetry = 50 * time.Millisecond
 
 // DefaultLifetime is applied when an Entry is saved without a
 // LifetimeSeconds value. It matches the documented KasAuth default
@@ -101,14 +107,23 @@ func (s *Store) LockPath() string {
 // withLock runs fn while holding an exclusive advisory lock on
 // LockPath. The lock file is created next to sessions.toml so its
 // permissions inherit from the same parent directory (created 0700
-// by write). The lock is released even if fn panics.
-func (s *Store) withLock(fn func() error) error {
+// by write). The lock is released even if fn panics. ctx cancels both
+// the wait for the lock (via flock.LockContext) and the body via the
+// caller's pre-I/O ctx.Err() checks.
+func (s *Store) withLock(ctx context.Context, fn func() error) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	if err := os.MkdirAll(filepath.Dir(s.Path), 0o700); err != nil {
 		return fmt.Errorf("session: create lock dir: %w", err)
 	}
 	lock := flock.New(s.LockPath())
-	if err := lock.Lock(); err != nil {
+	locked, err := lock.TryLockContext(ctx, lockRetry)
+	if err != nil {
 		return fmt.Errorf("session: acquire lock %s: %w", s.LockPath(), err)
+	}
+	if !locked {
+		return fmt.Errorf("session: acquire lock %s: %w", s.LockPath(), ctx.Err())
 	}
 	defer func() { _ = lock.Unlock() }()
 	return fn()
@@ -121,13 +136,15 @@ func (s *Store) withLock(fn func() error) error {
 // Load serialises with concurrent Save / Delete calls (including from
 // other kasapi-cli processes) via an advisory file lock at LockPath so
 // a concurrent write cannot tear the read-modify-write of an expiry
-// cleanup.
-func (s *Store) Load(login string) (*Entry, error) {
+// cleanup. ctx cancels the wait for the lock and short-circuits the
+// pre-I/O entry; the underlying toml/os calls are synchronous and not
+// further interruptible, but the file is local so blocking is bounded.
+func (s *Store) Load(ctx context.Context, login string) (*Entry, error) {
 	if login == "" {
 		return nil, errors.New("session: Load requires login")
 	}
 	var out *Entry
-	err := s.withLock(func() error {
+	err := s.withLock(ctx, func() error {
 		file, err := s.read()
 		if err != nil {
 			return err
@@ -152,8 +169,8 @@ func (s *Store) Load(login string) (*Entry, error) {
 // Save serialises with concurrent Load / Delete / Save calls (including
 // from other kasapi-cli processes) via an advisory file lock at
 // LockPath so a Heartbeat from one process cannot lose another
-// process's update.
-func (s *Store) Save(login string, e Entry) error {
+// process's update. ctx cancels the wait for the lock.
+func (s *Store) Save(ctx context.Context, login string, e Entry) error {
 	if login == "" {
 		return errors.New("session: Save requires login")
 	}
@@ -163,7 +180,7 @@ func (s *Store) Save(login string, e Entry) error {
 	if e.ExpiresAt.IsZero() {
 		e.ExpiresAt = s.now().Add(s.lifetime(e))
 	}
-	return s.withLock(func() error {
+	return s.withLock(ctx, func() error {
 		file, err := s.read()
 		if err != nil {
 			return err
@@ -181,12 +198,12 @@ func (s *Store) Save(login string, e Entry) error {
 // entry is taken out so the on-disk state matches "no sessions".
 //
 // Delete serialises with concurrent Load / Save / Delete calls via the
-// advisory file lock at LockPath.
-func (s *Store) Delete(login string) error {
+// advisory file lock at LockPath. ctx cancels the wait for the lock.
+func (s *Store) Delete(ctx context.Context, login string) error {
 	if login == "" {
 		return errors.New("session: Delete requires login")
 	}
-	return s.withLock(func() error { return s.deleteLocked(login) })
+	return s.withLock(ctx, func() error { return s.deleteLocked(login) })
 }
 
 // deleteLocked is the un-locked Delete body, callable from inside a

--- a/internal/session/store_test.go
+++ b/internal/session/store_test.go
@@ -30,10 +30,10 @@ func TestSaveLoadRoundTrip(t *testing.T) {
 		LifetimeSeconds: 3600,
 		UpdateLifetime:  true,
 	}
-	if err := s.Save("w0000000", want); err != nil {
+	if err := s.Save(t.Context(), "w0000000", want); err != nil {
 		t.Fatalf("Save: %v", err)
 	}
-	got, err := s.Load("w0000000")
+	got, err := s.Load(t.Context(), "w0000000")
 	if err != nil {
 		t.Fatalf("Load: %v", err)
 	}
@@ -49,10 +49,10 @@ func TestSaveLoadRoundTrip(t *testing.T) {
 func TestSaveComputesExpiresAtFromLifetime(t *testing.T) {
 	now := time.Date(2026, 5, 3, 12, 0, 0, 0, time.UTC)
 	s := newStore(t, now)
-	if err := s.Save("w0", session.Entry{Token: "t", LifetimeSeconds: 600}); err != nil {
+	if err := s.Save(t.Context(), "w0", session.Entry{Token: "t", LifetimeSeconds: 600}); err != nil {
 		t.Fatalf("Save: %v", err)
 	}
-	got, err := s.Load("w0")
+	got, err := s.Load(t.Context(), "w0")
 	if err != nil || got == nil {
 		t.Fatalf("Load: %v %v", got, err)
 	}
@@ -65,10 +65,10 @@ func TestSaveComputesExpiresAtFromLifetime(t *testing.T) {
 func TestSaveFallsBackToDefaultLifetime(t *testing.T) {
 	now := time.Date(2026, 5, 3, 12, 0, 0, 0, time.UTC)
 	s := newStore(t, now)
-	if err := s.Save("w0", session.Entry{Token: "t"}); err != nil {
+	if err := s.Save(t.Context(), "w0", session.Entry{Token: "t"}); err != nil {
 		t.Fatalf("Save: %v", err)
 	}
-	got, err := s.Load("w0")
+	got, err := s.Load(t.Context(), "w0")
 	if err != nil || got == nil {
 		t.Fatalf("Load: %v %v", got, err)
 	}
@@ -80,7 +80,7 @@ func TestSaveFallsBackToDefaultLifetime(t *testing.T) {
 
 func TestLoadReturnsNilWhenFileMissing(t *testing.T) {
 	s := newStore(t, time.Now())
-	got, err := s.Load("anything")
+	got, err := s.Load(t.Context(), "anything")
 	if err != nil {
 		t.Fatalf("Load: %v", err)
 	}
@@ -91,10 +91,10 @@ func TestLoadReturnsNilWhenFileMissing(t *testing.T) {
 
 func TestLoadReturnsNilWhenLoginAbsent(t *testing.T) {
 	s := newStore(t, time.Now())
-	if err := s.Save("w0", session.Entry{Token: "t", LifetimeSeconds: 60}); err != nil {
+	if err := s.Save(t.Context(), "w0", session.Entry{Token: "t", LifetimeSeconds: 60}); err != nil {
 		t.Fatalf("Save: %v", err)
 	}
-	got, err := s.Load("other")
+	got, err := s.Load(t.Context(), "other")
 	if err != nil {
 		t.Fatalf("Load: %v", err)
 	}
@@ -106,13 +106,13 @@ func TestLoadReturnsNilWhenLoginAbsent(t *testing.T) {
 func TestLoadDropsExpiredEntry(t *testing.T) {
 	now := time.Date(2026, 5, 3, 12, 0, 0, 0, time.UTC)
 	s := newStore(t, now)
-	if err := s.Save("w0", session.Entry{
+	if err := s.Save(t.Context(), "w0", session.Entry{
 		Token:     "t",
 		ExpiresAt: now.Add(-time.Second),
 	}); err != nil {
 		t.Fatalf("Save: %v", err)
 	}
-	got, err := s.Load("w0")
+	got, err := s.Load(t.Context(), "w0")
 	if err != nil {
 		t.Fatalf("Load: %v", err)
 	}
@@ -120,7 +120,7 @@ func TestLoadDropsExpiredEntry(t *testing.T) {
 		t.Errorf("expected expired Load to return nil, got %+v", got)
 	}
 	// File should be gone since it had only one entry.
-	if _, err := s.Load("w0"); err != nil {
+	if _, err := s.Load(t.Context(), "w0"); err != nil {
 		t.Errorf("second Load on cleaned file: %v", err)
 	}
 }
@@ -128,26 +128,26 @@ func TestLoadDropsExpiredEntry(t *testing.T) {
 func TestDeleteRemovesEntryOnly(t *testing.T) {
 	now := time.Date(2026, 5, 3, 12, 0, 0, 0, time.UTC)
 	s := newStore(t, now)
-	if err := s.Save("a", session.Entry{Token: "1", LifetimeSeconds: 60}); err != nil {
+	if err := s.Save(t.Context(), "a", session.Entry{Token: "1", LifetimeSeconds: 60}); err != nil {
 		t.Fatalf("Save a: %v", err)
 	}
-	if err := s.Save("b", session.Entry{Token: "2", LifetimeSeconds: 60}); err != nil {
+	if err := s.Save(t.Context(), "b", session.Entry{Token: "2", LifetimeSeconds: 60}); err != nil {
 		t.Fatalf("Save b: %v", err)
 	}
-	if err := s.Delete("a"); err != nil {
+	if err := s.Delete(t.Context(), "a"); err != nil {
 		t.Fatalf("Delete a: %v", err)
 	}
-	if got, _ := s.Load("a"); got != nil {
+	if got, _ := s.Load(t.Context(), "a"); got != nil {
 		t.Errorf("a still present after Delete")
 	}
-	if got, _ := s.Load("b"); got == nil {
+	if got, _ := s.Load(t.Context(), "b"); got == nil {
 		t.Errorf("b should still be present")
 	}
 }
 
 func TestDeleteMissingIsNoop(t *testing.T) {
 	s := newStore(t, time.Now())
-	if err := s.Delete("nope"); err != nil {
+	if err := s.Delete(t.Context(), "nope"); err != nil {
 		t.Errorf("Delete on missing file: %v", err)
 	}
 }
@@ -182,7 +182,7 @@ func TestSaveWritesMode0600(t *testing.T) {
 		t.Skip("file mode bits not meaningful on Windows")
 	}
 	s := newStore(t, time.Now())
-	if err := s.Save("w0", session.Entry{Token: "t", LifetimeSeconds: 60}); err != nil {
+	if err := s.Save(t.Context(), "w0", session.Entry{Token: "t", LifetimeSeconds: 60}); err != nil {
 		t.Fatalf("Save: %v", err)
 	}
 	info, err := statFile(s.Path)
@@ -207,7 +207,7 @@ func TestSaveBlocksWhileLockHeld(t *testing.T) {
 	// Force the lock-file directory + path to exist by running one Save
 	// first; otherwise the external flock.New below would lock a path
 	// that the production code creates on demand.
-	if err := s.Save("seed", session.Entry{Token: "t", LifetimeSeconds: 60}); err != nil {
+	if err := s.Save(t.Context(), "seed", session.Entry{Token: "t", LifetimeSeconds: 60}); err != nil {
 		t.Fatalf("seed Save: %v", err)
 	}
 
@@ -224,7 +224,7 @@ func TestSaveBlocksWhileLockHeld(t *testing.T) {
 
 	done := make(chan error, 1)
 	go func() {
-		done <- s.Save("w0", session.Entry{Token: "blocked", LifetimeSeconds: 60})
+		done <- s.Save(t.Context(), "w0", session.Entry{Token: "blocked", LifetimeSeconds: 60})
 	}()
 
 	select {
@@ -248,7 +248,7 @@ func TestSaveBlocksWhileLockHeld(t *testing.T) {
 		t.Fatal("Save did not complete after external Unlock")
 	}
 
-	got, err := s.Load("w0")
+	got, err := s.Load(t.Context(), "w0")
 	if err != nil || got == nil || got.Token != "blocked" {
 		t.Fatalf("post-unlock Load = %+v, %v; want token=blocked", got, err)
 	}
@@ -259,7 +259,7 @@ func TestSaveBlocksWhileLockHeld(t *testing.T) {
 // without timing out.
 func TestStoreReleasesLockAfterSave(t *testing.T) {
 	s := newStore(t, time.Now())
-	if err := s.Save("w0", session.Entry{Token: "t", LifetimeSeconds: 60}); err != nil {
+	if err := s.Save(t.Context(), "w0", session.Entry{Token: "t", LifetimeSeconds: 60}); err != nil {
 		t.Fatalf("Save: %v", err)
 	}
 	ext := flock.New(s.LockPath())


### PR DESCRIPTION
## Summary

- Add `context.Context` to `session.Store.Load` / `Save` / `Delete` and to `api.Heartbeater.Heartbeat`. A Ctrl-C during a slow disk write or while waiting on the (newly added in #140) flock gate now aborts cleanly instead of blocking indefinitely.
- Lock wait switched from `flock.Lock` to `flock.TryLockContext(ctx, 50ms)`.
- `SessionTokenSource.Invalidate` uses `context.Background` for the disk delete — cleanup must complete even when the caller's ctx is already cancelled (auth-failure path), otherwise we'd leak stale tokens.
- All call sites + tests updated; behaviour for non-cancelled calls is unchanged.

Surfaced by the 2026-05-14 code-review pass (finding N2).