### PR TITLE
chore: address NTH bundle from 2026-05-14 code-review pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `Tabular`, so this error always indicates a kasapi-cli bug rather than
   a user choice; the message now says so while keeping the
   `--output=json` / `--output=yaml` workaround hint.
+- `internal/soap/envelope.go` + `internal/auth/codec.go`: wrap the SOAP
+  decoder's input reader in `io.LimitReader(r, soap.MaxResponseBytes)`
+  (16 MB) and set `dec.Strict = true` explicitly. The KAS server is
+  trusted, so this is defense-in-depth against a malformed or hostile
+  response (compromised endpoint, MITM, server bug) — the largest
+  captured fixture is ~70 KB, so the cap is well above any legitimate
+  payload.
+- `internal/cli/wire.go`: rename `sessionOpts.any()` to `isSet()` to
+  stop shadowing the Go 1.18 builtin alias `any` in IDE auto-complete
+  and code review. Behaviour and the single call site are unchanged.
+- `internal/session/store.go`: document why the explicit
+  `tmp.Chmod(0o600)` after `os.CreateTemp` is kept — redundant on Unix
+  but Windows ignores the create-mode bits, so the set is
+  defense-in-depth across platforms.
+- test: `internal/account` — added unit tests for `Client.Settings`,
+  `Client.Resources`, plus the previously-unexercised `TableHeaders`
+  on `AccountResources` and `AccountSettings` (and the `TableRows` of
+  `AccountSettings`). Lifts package coverage from 69.9% to 85.4%.
+- test: `internal/cli` — added help-output tests for the `dns`,
+  `domains`, `subdomains`, `tlds`, and `mail` (incl. `accounts` /
+  `forwards` / `filters` / `lists` subgroups) command factories,
+  mirroring the pattern already used for the
+  cronjobs/databases/... factories. Lifts package coverage from 60.0%
+  to 69.9%.
+- test: `internal/auth` — added negative-path and nil-input tests for
+  the `IsLoginFailed`, `IsLoginLocked`, `IsUnknownSession`,
+  `IsOTPPinIncorrect`, `IsCode`, and `AsError` sentinel helpers.
 
 ### Fixed
 
@@ -127,21 +154,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   returns the catalog of pre-defined spam/virus filter presets that an
   account can attach via the `mail_spamfilter` setting on a mailaccount
   or forward.
-
-### Tests
-
-- `internal/account`: added unit tests for `Client.Settings`,
-  `Client.Resources`, plus the previously-unexercised `TableHeaders`
-  on `AccountResources` and `AccountSettings` (and the `TableRows` of
-  `AccountSettings`). Lifts package coverage from 69.9% to 85.4%.
-- `internal/cli`: added help-output tests for the `dns`, `domains`,
-  `subdomains`, `tlds`, and `mail` (incl. `accounts` / `forwards` /
-  `filters` / `lists` subgroups) command factories, mirroring the
-  pattern already used for the cronjobs/databases/... factories.
-  Lifts package coverage from 60.0% to 69.9%.
-- `internal/auth`: added negative-path and nil-input tests for the
-  `IsLoginFailed`, `IsLoginLocked`, `IsUnknownSession`, `IsOTPPinIncorrect`,
-  `IsCode`, and `AsError` sentinel helpers.
 
 ## [0.1.0-alpha.1] - 2026-05-10
 

--- a/internal/auth/codec.go
+++ b/internal/auth/codec.go
@@ -72,8 +72,12 @@ func EncodeRequest(w io.Writer, r Request) error {
 // DecodeResponse parses a KasAuth SOAP envelope. On success it returns
 // the credential token; on a SOAP-ENV:Fault body it returns
 // *soap.FaultError so callers can wrap it into auth.Error.
+//
+// The reader is wrapped in an io.LimitReader (soap.MaxResponseBytes)
+// and Strict mode is set explicitly; see soap.Decode for the rationale.
 func DecodeResponse(r io.Reader) (string, error) {
-	dec := xml.NewDecoder(r)
+	dec := xml.NewDecoder(io.LimitReader(r, soap.MaxResponseBytes))
+	dec.Strict = true
 	for {
 		tok, err := dec.Token()
 		if errors.Is(err, io.EOF) {

--- a/internal/cli/wire.go
+++ b/internal/cli/wire.go
@@ -93,14 +93,17 @@ type sessionOpts struct {
 	UpdateLifetime string
 }
 
-func (s sessionOpts) any() bool {
+// isSet reports whether the caller passed any of the KasAuth-only flags
+// captured by sessionOpts. Named to avoid shadowing the Go 1.18 builtin
+// `any` alias for interface{} in IDE auto-complete and code review.
+func (s sessionOpts) isSet() bool {
 	return s.OTP != "" || s.Lifetime != 0 || s.UpdateLifetime != ""
 }
 
 func tokenSource(tr *transport.Client, creds config.Credentials, s sessionOpts, logger *slog.Logger) (api.TokenSource, error) {
 	switch creds.AuthType {
 	case config.AuthPlain:
-		if s.any() {
+		if s.isSet() {
 			return nil, fmt.Errorf(
 				"--otp / --session-lifetime / --session-update-lifetime cannot be used with " +
 					"auth_type=plain: these are KasAuth-only parameters and KasAuth is not " +

--- a/internal/session/store.go
+++ b/internal/session/store.go
@@ -249,6 +249,9 @@ func (s *Store) write(file fileFormat) error {
 	}
 	tmpPath := tmp.Name()
 	cleanup := func() { _ = os.Remove(tmpPath) }
+	// Chmod is redundant on Unix where os.CreateTemp already opens the
+	// file with mode 0600, but Windows ignores the create-mode bits, so
+	// we set them explicitly as defense-in-depth across platforms.
 	if cherr := tmp.Chmod(0o600); cherr != nil {
 		_ = tmp.Close()
 		cleanup()

--- a/internal/soap/envelope.go
+++ b/internal/soap/envelope.go
@@ -7,6 +7,14 @@ import (
 	"io"
 )
 
+// MaxResponseBytes caps the byte count the KAS-API decoders will read
+// from a single response body. Real KAS responses are well under 1 MB
+// (the largest captured fixture is ~70 KB); 16 MB is comfortable
+// headroom while still preventing a pathological response (compromised
+// endpoint, MITM, server bug) from exhausting memory through a
+// streaming XML payload that never ends.
+const MaxResponseBytes = 16 << 20
+
 // Response is the parsed body of a successful KasApi SOAP envelope. It
 // keeps both the typed shortcuts (KasFloodDelay, ReturnString, ReturnInfo)
 // and the full ordered Map for callers needing extras.
@@ -47,8 +55,15 @@ func (e *FaultError) Error() string {
 
 // Decode parses a KasApi SOAP envelope. It returns a typed Response on
 // success and a *FaultError when the body contained a SOAP-ENV:Fault.
+//
+// The reader is wrapped in an io.LimitReader (MaxResponseBytes) and the
+// decoder runs in Strict mode (the encoding/xml default, set explicitly
+// here so a future refactor cannot silently flip it). The KAS server is
+// trusted, so this is defense-in-depth against a malformed or hostile
+// response rather than a security boundary.
 func Decode(r io.Reader) (*Response, error) {
-	dec := xml.NewDecoder(r)
+	dec := xml.NewDecoder(io.LimitReader(r, MaxResponseBytes))
+	dec.Strict = true
 	for {
 		tok, err := dec.Token()
 		if err == io.EOF {


### PR DESCRIPTION
## Summary

Bundles four nice-to-have findings from the 2026-05-14 review pass that already landed S1 (#140) and N2 (#141):

- **N1** — `internal/soap/envelope.go` + `internal/auth/codec.go`: wrap SOAP decoder input in `io.LimitReader(soap.MaxResponseBytes)` (16 MB) + `dec.Strict = true`. Defense-in-depth against malformed/hostile responses.
- **N4** — `CHANGELOG.md`: drop the non-standard `### Tests` section under `[Unreleased]`; re-fold the bullets into `### Changed` with a `test:` prefix (Keep-a-Changelog 1.1.0 section set).
- **N5** — `internal/cli/wire.go`: rename `sessionOpts.any()` → `isSet()` (no longer shadows the Go 1.18 builtin alias `any`).
- **N6** — `internal/session/store.go`: document why the explicit `tmp.Chmod(0o600)` after `os.CreateTemp` is kept (Windows ignores create-mode bits — defense-in-depth across platforms).

**N3** (released `[0.1.0-alpha.1]` section has multiple `### Changed` headers) is intentionally not addressed: released history stays as-shipped.

Closes the review loop opened on 2026-05-14.