### PR TITLE
fix(cli): point first-run users at `config init` when credentials are missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `internal/cli/wire.go`: the first-run error from `BuildAPIClient` now
+  appends `(run \`kasapi-cli config init\` to create a profile
+  interactively)` when no config file exists at all, so a fresh user
+  who runs `kasapi-cli accounts list` without env vars or flags is
+  pointed at the existing bootstrap wizard instead of having to guess
+  at flag combinations. Partial-config cases (file exists but a profile
+  is incomplete) keep the bare validation error because `config init`
+  refuses to overwrite without `--force` in that scenario.
+
 - `internal/session/store.go` + `auth/source.go` + `api/client.go`:
   thread the call's `context.Context` through `session.Store.Load` /
   `Save` / `Delete` and through `api.Heartbeater.Heartbeat`. The lock

--- a/internal/cli/wire.go
+++ b/internal/cli/wire.go
@@ -39,9 +39,9 @@ func BuildAPIClient(opts *RootOptions) (*api.Client, error) {
 
 	logger := buildLogger(opts.Verbose)
 
-	cfg, err := config.Load(opts.ConfigPath)
-	if err != nil && !errors.Is(err, config.ErrNoConfig) {
-		return nil, UserError(err, "load config")
+	cfg, loadErr := config.Load(opts.ConfigPath)
+	if loadErr != nil && !errors.Is(loadErr, config.ErrNoConfig) {
+		return nil, UserError(loadErr, "load config")
 	}
 	creds, err := cfg.Resolve(config.EnvFromOS(), config.Override{
 		Profile:  opts.Profile,
@@ -50,6 +50,12 @@ func BuildAPIClient(opts *RootOptions) (*api.Client, error) {
 		AuthType: opts.AuthType,
 	})
 	if err != nil {
+		// Genuine first-run (no config file at all): point at the bootstrap
+		// wizard. Partial-config cases keep the bare validation error because
+		// `config init` would refuse without --force in that scenario.
+		if errors.Is(loadErr, config.ErrNoConfig) {
+			err = fmt.Errorf("%w (run `kasapi-cli config init` to create a profile interactively)", err)
+		}
 		return nil, UserError(err, "")
 	}
 	logger.Info("cli: credentials resolved",

--- a/internal/cli/wire_test.go
+++ b/internal/cli/wire_test.go
@@ -2,7 +2,9 @@ package cli_test
 
 import (
 	"errors"
+	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/chmmou/kasapi-cli/internal/cli"
@@ -65,6 +67,45 @@ func TestBuildAPIClientMissingCreds(t *testing.T) {
 		t.Errorf("err is not *ExitError: %T", err)
 	} else if ee.Code != cli.ExitUserError {
 		t.Errorf("Code = %d, want %d", ee.Code, cli.ExitUserError)
+	}
+}
+
+func TestBuildAPIClientFirstRunHint(t *testing.T) {
+	t.Setenv("KAS_LOGIN", "")
+	t.Setenv("KAS_AUTHDATA", "")
+	t.Setenv("KAS_AUTHTYPE", "")
+
+	opts := &cli.RootOptions{
+		ConfigPath: filepath.Join(t.TempDir(), "missing-config.toml"),
+	}
+	_, err := cli.BuildAPIClient(opts)
+	if err == nil {
+		t.Fatal("expected error for missing credentials")
+	}
+	if !strings.Contains(err.Error(), "config init") {
+		t.Errorf("err = %q, want hint containing %q", err, "config init")
+	}
+}
+
+func TestBuildAPIClientPartialConfigNoHint(t *testing.T) {
+	t.Setenv("KAS_LOGIN", "")
+	t.Setenv("KAS_AUTHDATA", "")
+	t.Setenv("KAS_AUTHTYPE", "")
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.toml")
+	contents := "default_profile = \"broken\"\n\n[profiles.broken]\nlogin = \"w0000000\"\n"
+	if err := os.WriteFile(cfgPath, []byte(contents), 0o600); err != nil {
+		t.Fatalf("write partial config: %v", err)
+	}
+
+	opts := &cli.RootOptions{ConfigPath: cfgPath}
+	_, err := cli.BuildAPIClient(opts)
+	if err == nil {
+		t.Fatal("expected error for partial config")
+	}
+	if strings.Contains(err.Error(), "config init") {
+		t.Errorf("err = %q, must not contain hint %q for partial config", err, "config init")
 	}
 }
 


### PR DESCRIPTION
## Summary

When `kasapi-cli <subcommand>` is run with no config file, no env vars, and no flags, the missing-credentials error now ends with `(run \`kasapi-cli config init\` to create a profile interactively)`. This points fresh users at the existing bootstrap wizard (shipped via #34) instead of leaving them guessing at flag combinations.

Partial-config cases (file exists but the profile is incomplete) deliberately keep the bare validation error, because `config init` refuses to overwrite without `--force` — the hint would be misleading there.

Closes #138