### PR TITLE
chore: address re-review findings from PR #143

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `internal/cli/wire.go`: the first-run error from `BuildAPIClient` now
-  appends `(run \`kasapi-cli config init\` to create a profile
-  interactively)` when no config file exists at all, so a fresh user
+  appends ``(run `kasapi-cli config init` to create a profile
+  interactively)`` when no config file exists at all, so a fresh user
   who runs `kasapi-cli accounts list` without env vars or flags is
   pointed at the existing bootstrap wizard instead of having to guess
   at flag combinations. Partial-config cases (file exists but a profile

--- a/internal/cli/wire_test.go
+++ b/internal/cli/wire_test.go
@@ -68,20 +68,9 @@ func TestBuildAPIClientMissingCreds(t *testing.T) {
 	} else if ee.Code != cli.ExitUserError {
 		t.Errorf("Code = %d, want %d", ee.Code, cli.ExitUserError)
 	}
-}
-
-func TestBuildAPIClientFirstRunHint(t *testing.T) {
-	t.Setenv("KAS_LOGIN", "")
-	t.Setenv("KAS_AUTHDATA", "")
-	t.Setenv("KAS_AUTHTYPE", "")
-
-	opts := &cli.RootOptions{
-		ConfigPath: filepath.Join(t.TempDir(), "missing-config.toml"),
-	}
-	_, err := cli.BuildAPIClient(opts)
-	if err == nil {
-		t.Fatal("expected error for missing credentials")
-	}
+	// Genuine first-run (no config file at all) must surface the
+	// `config init` discoverability hint so a fresh user is pointed at
+	// the bootstrap wizard instead of guessing flag combinations.
 	if !strings.Contains(err.Error(), "config init") {
 		t.Errorf("err = %q, want hint containing %q", err, "config init")
 	}


### PR DESCRIPTION
## Summary

Two follow-ups from the post-merge re-review of PR #143 (issue #138):

- **F1 — CHANGELOG Markdown fix.** The new first-run-hint bullet used `\`...\`` inside an already-open inline-code span; that is not a valid Markdown escape, so the backslashes rendered literally and the inner backtick closed the outer span early. Switched the outer span to double backticks.
- **N1 — Test consolidation.** `TestBuildAPIClientFirstRunHint` and `TestBuildAPIClientMissingCreds` had identical setup. Folded the hint-substring assertion into `TestBuildAPIClientMissingCreds` and removed the now-redundant standalone test.