### PR TITLE
feat(config): add multi-profile management subcommands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `kasapi-cli config add-profile <name>` / `use-profile <name>` /
+  `list-profiles` for managing multiple profiles in `config.toml`.
+  `add-profile` reuses the `config init` prompt flow with `--force` to
+  overwrite an existing profile; `use-profile` flips `default_profile`
+  and, if the outgoing profile had a non-expired cached session token,
+  invokes the KAS API `delete_session` action on it before removing
+  the local entry from `sessions.toml`. The server-side revoke is
+  best-effort — a transport or `unknown_session` fault is logged
+  under `--verbose` but does not abort the switch, because the local
+  cache is the authoritative client-side state. `list-profiles` prints
+  one line per profile, marks the default with `* `, and never writes
+  `auth_data`. Closes #39.
+
 ### Changed
 
 - `internal/cli/wire.go`: the first-run error from `BuildAPIClient` now

--- a/docs/cli/kasapi-cli_config_add-profile.md
+++ b/docs/cli/kasapi-cli_config_add-profile.md
@@ -1,11 +1,16 @@
-## kasapi-cli config
+## kasapi-cli config add-profile
 
-Inspect and bootstrap the kasapi-cli configuration
+Interactively add a new profile to the config file
+
+```
+kasapi-cli config add-profile <name> [flags]
+```
 
 ### Options
 
 ```
-  -h, --help   help for config
+      --force   overwrite an existing profile of the same name
+  -h, --help    help for add-profile
 ```
 
 ### Options inherited from parent commands
@@ -27,11 +32,5 @@ Inspect and bootstrap the kasapi-cli configuration
 
 ### SEE ALSO
 
-* [kasapi-cli](kasapi-cli.md)	 - Command-line client for the All-Inkl KAS API
-* [kasapi-cli config add-profile](kasapi-cli_config_add-profile.md)	 - Interactively add a new profile to the config file
-* [kasapi-cli config init](kasapi-cli_config_init.md)	 - Interactively create or replace a profile in the config file
-* [kasapi-cli config list-profiles](kasapi-cli_config_list-profiles.md)	 - List configured profiles and their auth_type (auth_data redacted)
-* [kasapi-cli config path](kasapi-cli_config_path.md)	 - Print the resolved config-file path
-* [kasapi-cli config show](kasapi-cli_config_show.md)	 - Print the resolved effective config (auth_data redacted)
-* [kasapi-cli config use-profile](kasapi-cli_config_use-profile.md)	 - Switch the persistent default_profile and invalidate the outgoing session
+* [kasapi-cli config](kasapi-cli_config.md)	 - Inspect and bootstrap the kasapi-cli configuration
 

--- a/docs/cli/kasapi-cli_config_list-profiles.md
+++ b/docs/cli/kasapi-cli_config_list-profiles.md
@@ -1,11 +1,15 @@
-## kasapi-cli config
+## kasapi-cli config list-profiles
 
-Inspect and bootstrap the kasapi-cli configuration
+List configured profiles and their auth_type (auth_data redacted)
+
+```
+kasapi-cli config list-profiles [flags]
+```
 
 ### Options
 
 ```
-  -h, --help   help for config
+  -h, --help   help for list-profiles
 ```
 
 ### Options inherited from parent commands
@@ -27,11 +31,5 @@ Inspect and bootstrap the kasapi-cli configuration
 
 ### SEE ALSO
 
-* [kasapi-cli](kasapi-cli.md)	 - Command-line client for the All-Inkl KAS API
-* [kasapi-cli config add-profile](kasapi-cli_config_add-profile.md)	 - Interactively add a new profile to the config file
-* [kasapi-cli config init](kasapi-cli_config_init.md)	 - Interactively create or replace a profile in the config file
-* [kasapi-cli config list-profiles](kasapi-cli_config_list-profiles.md)	 - List configured profiles and their auth_type (auth_data redacted)
-* [kasapi-cli config path](kasapi-cli_config_path.md)	 - Print the resolved config-file path
-* [kasapi-cli config show](kasapi-cli_config_show.md)	 - Print the resolved effective config (auth_data redacted)
-* [kasapi-cli config use-profile](kasapi-cli_config_use-profile.md)	 - Switch the persistent default_profile and invalidate the outgoing session
+* [kasapi-cli config](kasapi-cli_config.md)	 - Inspect and bootstrap the kasapi-cli configuration
 

--- a/docs/cli/kasapi-cli_config_use-profile.md
+++ b/docs/cli/kasapi-cli_config_use-profile.md
@@ -1,11 +1,15 @@
-## kasapi-cli config
+## kasapi-cli config use-profile
 
-Inspect and bootstrap the kasapi-cli configuration
+Switch the persistent default_profile and invalidate the outgoing session
+
+```
+kasapi-cli config use-profile <name> [flags]
+```
 
 ### Options
 
 ```
-  -h, --help   help for config
+  -h, --help   help for use-profile
 ```
 
 ### Options inherited from parent commands
@@ -27,11 +31,5 @@ Inspect and bootstrap the kasapi-cli configuration
 
 ### SEE ALSO
 
-* [kasapi-cli](kasapi-cli.md)	 - Command-line client for the All-Inkl KAS API
-* [kasapi-cli config add-profile](kasapi-cli_config_add-profile.md)	 - Interactively add a new profile to the config file
-* [kasapi-cli config init](kasapi-cli_config_init.md)	 - Interactively create or replace a profile in the config file
-* [kasapi-cli config list-profiles](kasapi-cli_config_list-profiles.md)	 - List configured profiles and their auth_type (auth_data redacted)
-* [kasapi-cli config path](kasapi-cli_config_path.md)	 - Print the resolved config-file path
-* [kasapi-cli config show](kasapi-cli_config_show.md)	 - Print the resolved effective config (auth_data redacted)
-* [kasapi-cli config use-profile](kasapi-cli_config_use-profile.md)	 - Switch the persistent default_profile and invalidate the outgoing session
+* [kasapi-cli config](kasapi-cli_config.md)	 - Inspect and bootstrap the kasapi-cli configuration
 

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -2,9 +2,11 @@ package cli
 
 import (
 	"bufio"
+	"context"
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"sort"
 	"strings"
@@ -12,7 +14,11 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
 
+	"github.com/chmmou/kasapi-cli/internal/api"
 	"github.com/chmmou/kasapi-cli/internal/config"
+	"github.com/chmmou/kasapi-cli/internal/session"
+	"github.com/chmmou/kasapi-cli/internal/soap"
+	"github.com/chmmou/kasapi-cli/internal/transport"
 )
 
 // NewConfigCmd returns the "kasapi-cli config" subcommand tree: init
@@ -27,6 +33,9 @@ func NewConfigCmd(opts *RootOptions) *cobra.Command {
 		newConfigInitCmd(opts),
 		newConfigShowCmd(opts),
 		newConfigPathCmd(opts),
+		newConfigAddProfileCmd(opts),
+		newConfigUseProfileCmd(opts),
+		newConfigListProfilesCmd(opts),
 	)
 	return cmd
 }
@@ -261,6 +270,268 @@ func profileNames(cfg *config.Config) string {
 	}
 	sort.Strings(names)
 	return "[" + strings.Join(names, ", ") + "]"
+}
+
+// revokeFunc abstracts the server-side session-invalidation call so
+// tests can drive `use-profile` switches without an httptest server.
+// Production wires it to revokeSession; tests inject a spy.
+type revokeFunc func(ctx context.Context, login, token string) error
+
+// revokeSession server-side invalidates one cached session token by
+// calling kas_action=delete_session with that token. The KAS API
+// identifies the session via the (login, token) tuple supplied as
+// auth_data / auth_type=session — no extra parameters are required.
+//
+// Best-effort: transport, decode, or KAS-fault errors are returned so
+// the caller (runConfigUseProfile) can log them, but the caller must
+// not propagate them — the local cache is the authoritative
+// client-side state, and a failed revoke must not block a profile
+// switch.
+func revokeSession(ctx context.Context, login, token string, logger *slog.Logger) error {
+	tr := transport.New()
+	tr.Logger = logger
+	c := api.New(tr, &api.StaticTokenSource{
+		Login:    login,
+		AuthData: token,
+		AuthType: soap.AuthSession,
+	})
+	c.Logger = logger
+	_, err := c.Call(ctx, "delete_session", nil)
+	return err
+}
+
+func newConfigAddProfileCmd(opts *RootOptions) *cobra.Command {
+	var force bool
+	cmd := &cobra.Command{
+		Use:   "add-profile <name>",
+		Short: "Interactively add a new profile to the config file",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cio := defaultConfigIO()
+			cio.In = cmd.InOrStdin()
+			cio.Out = cmd.OutOrStdout()
+			return runConfigAddProfile(opts.ConfigPath, args[0], force, cio)
+		},
+	}
+	cmd.Flags().BoolVar(&force, "force", false, "overwrite an existing profile of the same name")
+	return cmd
+}
+
+// runConfigAddProfile is structurally identical to runConfigInit but
+// takes the profile name as a positional argument and never offers a
+// default-profile prompt on a non-empty existing config. It still sets
+// default_profile to the new name when the file had no default before,
+// matching `init`'s behaviour for a fresh file.
+func runConfigAddProfile(configPath, name string, force bool, cio configIO) error {
+	if !cio.IsTTY() {
+		return UserError(errors.New("kasapi-cli config add-profile requires an interactive terminal (stdin is not a TTY)"), "")
+	}
+	if name == "" {
+		return UserError(errors.New("profile name must not be empty"), "")
+	}
+	path, err := resolveConfigPath(configPath)
+	if err != nil {
+		return UserError(err, "")
+	}
+	cfg, err := config.Load(path)
+	if err != nil && !errors.Is(err, config.ErrNoConfig) {
+		return UserError(err, "load config")
+	}
+	if cfg == nil {
+		cfg = &config.Config{}
+	}
+	if cfg.Profiles == nil {
+		cfg.Profiles = map[string]config.Profile{}
+	}
+	if _, exists := cfg.Profiles[name]; exists && !force {
+		return UserError(fmt.Errorf("profile %q already exists in %s (rerun with --force to overwrite)", name, path), "")
+	}
+
+	r := bufio.NewReader(cio.In)
+	login, err := promptLine(r, cio.Out, "KAS login (e.g. w0000000): ")
+	if err != nil {
+		return UserError(err, "")
+	}
+	if login == "" {
+		return UserError(errors.New("login is required"), "")
+	}
+	authType, err := promptAuthType(r, cio.Out)
+	if err != nil {
+		return UserError(err, "")
+	}
+	if _, perr := fmt.Fprint(cio.Out, "auth_data (input hidden): "); perr != nil {
+		return UserError(perr, "")
+	}
+	authData, err := cio.ReadPassword()
+	if err != nil {
+		return UserError(err, "read password")
+	}
+	if authData == "" {
+		return UserError(errors.New("auth_data is required"), "")
+	}
+
+	cfg.Profiles[name] = config.Profile{
+		Login:    login,
+		AuthData: authData,
+		AuthType: authType,
+	}
+	if cfg.DefaultProfile == "" {
+		cfg.DefaultProfile = name
+	}
+	if err := cfg.Save(path); err != nil {
+		return UserError(err, "")
+	}
+	if _, perr := fmt.Fprintf(cio.Out, "Wrote profile %q to %s\n", name, path); perr != nil {
+		return UserError(perr, "")
+	}
+	return nil
+}
+
+func newConfigUseProfileCmd(opts *RootOptions) *cobra.Command {
+	return &cobra.Command{
+		Use:   "use-profile <name>",
+		Short: "Switch the persistent default_profile and invalidate the outgoing session",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			logger := buildLogger(opts.Verbose)
+			storePath, err := session.PathFor(opts.ConfigPath)
+			if err != nil {
+				return UserError(err, "session store")
+			}
+			store, err := session.New(storePath)
+			if err != nil {
+				return UserError(err, "session store")
+			}
+			revoke := func(ctx context.Context, login, token string) error {
+				return revokeSession(ctx, login, token, logger)
+			}
+			return runConfigUseProfile(cmd.Context(), opts.ConfigPath, args[0], revoke, store, logger, cmd.OutOrStdout())
+		},
+	}
+}
+
+// runConfigUseProfile flips default_profile to name. Before writing it
+// looks up the outgoing profile's login in sessions.toml and, if a
+// non-expired token is cached, calls revoke to drop the session
+// server-side. The on-disk cache entry is removed unconditionally
+// afterwards because the local cache is the authoritative client-side
+// state — a server-side revoke failure (network error,
+// unknown_session fault) is logged but does not abort the switch.
+func runConfigUseProfile(ctx context.Context, configPath, name string, revoke revokeFunc, store *session.Store, logger *slog.Logger, w io.Writer) error {
+	if name == "" {
+		return UserError(errors.New("profile name must not be empty"), "")
+	}
+	path, err := resolveConfigPath(configPath)
+	if err != nil {
+		return UserError(err, "")
+	}
+	cfg, err := config.Load(path)
+	if err != nil {
+		if errors.Is(err, config.ErrNoConfig) {
+			return UserError(fmt.Errorf("no config file at %s (run `kasapi-cli config init` to create a profile interactively)", path), "")
+		}
+		return UserError(err, "load config")
+	}
+	if _, ok := cfg.Profiles[name]; !ok {
+		return UserError(fmt.Errorf("profile %q not defined in %s", name, path), "")
+	}
+	if name == cfg.DefaultProfile {
+		if _, perr := fmt.Fprintf(w, "Profile %q is already the default in %s\n", name, path); perr != nil {
+			return UserError(perr, "")
+		}
+		return nil
+	}
+
+	if outgoing := cfg.DefaultProfile; outgoing != "" {
+		if prof, ok := cfg.Profiles[outgoing]; ok && prof.Login != "" {
+			entry, lerr := store.Load(ctx, prof.Login)
+			if lerr != nil {
+				logger.Warn("config use-profile: session store load failed",
+					"login", prof.Login, "err", lerr)
+			}
+			if entry != nil && entry.Token != "" {
+				if rerr := revoke(ctx, prof.Login, entry.Token); rerr != nil {
+					logger.Warn("config use-profile: server-side revoke failed (continuing)",
+						"login", prof.Login, "err", rerr)
+				}
+				if derr := store.Delete(ctx, prof.Login); derr != nil {
+					logger.Warn("config use-profile: session store delete failed",
+						"login", prof.Login, "err", derr)
+				}
+			}
+		}
+	}
+
+	cfg.DefaultProfile = name
+	if err := cfg.Save(path); err != nil {
+		return UserError(err, "")
+	}
+	if _, perr := fmt.Fprintf(w, "Switched default_profile to %q in %s\n", name, path); perr != nil {
+		return UserError(perr, "")
+	}
+	return nil
+}
+
+func newConfigListProfilesCmd(opts *RootOptions) *cobra.Command {
+	return &cobra.Command{
+		Use:   "list-profiles",
+		Short: "List configured profiles and their auth_type (auth_data redacted)",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runConfigListProfiles(opts.ConfigPath, cmd.OutOrStdout())
+		},
+	}
+}
+
+// runConfigListProfiles prints one line per configured profile,
+// alphabetically sorted, prefixed with "* " for the default. auth_data
+// is never written. A missing config file prints a discoverability
+// hint pointing at `config init`, mirroring the first-run pathway
+// used by BuildAPIClient (#138).
+func runConfigListProfiles(configPath string, w io.Writer) error {
+	path, err := resolveConfigPath(configPath)
+	if err != nil {
+		return UserError(err, "")
+	}
+	cfg, err := config.Load(path)
+	if err != nil {
+		if errors.Is(err, config.ErrNoConfig) {
+			_, perr := fmt.Fprintf(w, "no profiles configured (run `kasapi-cli config init` to create one interactively)\n")
+			if perr != nil {
+				return UserError(perr, "")
+			}
+			return nil
+		}
+		return UserError(err, "load config")
+	}
+	if len(cfg.Profiles) == 0 {
+		_, perr := fmt.Fprintf(w, "no profiles configured in %s (run `kasapi-cli config init` to create one interactively)\n", path)
+		if perr != nil {
+			return UserError(perr, "")
+		}
+		return nil
+	}
+	names := make([]string, 0, len(cfg.Profiles))
+	for n := range cfg.Profiles {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	we := &writeErr{w: w}
+	for _, n := range names {
+		mark := "  "
+		if n == cfg.DefaultProfile {
+			mark = "* "
+		}
+		authType := cfg.Profiles[n].AuthType
+		if authType == "" {
+			authType = "session"
+		}
+		we.printf("%s%s (%s)\n", mark, n, authType)
+	}
+	if we.err != nil {
+		return UserError(we.err, "")
+	}
+	return nil
 }
 
 // writeErr is a fmt.Fprintf wrapper that records the first error so a

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -2,18 +2,22 @@ package cli_test
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"io"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/BurntSushi/toml"
 
 	"github.com/chmmou/kasapi-cli/internal/cli"
 	"github.com/chmmou/kasapi-cli/internal/config"
+	"github.com/chmmou/kasapi-cli/internal/session"
 )
 
 func newIO(in string, password string) (*bytes.Buffer, cli.ConfigIO) {
@@ -262,6 +266,328 @@ func TestRunConfigInitDoesNotLeakAuthDataInOutput(t *testing.T) {
 	}
 	if strings.Contains(out.String(), "supersecretpwd") {
 		t.Errorf("auth_data leaked to stdout: %q", out.String())
+	}
+}
+
+// --- add-profile ----------------------------------------------------------
+
+func TestRunConfigAddProfileCreatesEntry(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	pre := &config.Config{
+		DefaultProfile: "main",
+		Profiles: map[string]config.Profile{
+			"main": {Login: "w0000000", AuthData: "secret", AuthType: "session"},
+		},
+	}
+	if err := pre.Save(path); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	_, cio := newIO("w0000001\nplain\n", "stagingsecret")
+
+	if err := cli.RunConfigAddProfile(path, "staging", false, cio); err != nil {
+		t.Fatalf("RunConfigAddProfile: %v", err)
+	}
+	cfg, err := config.Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.DefaultProfile != "main" {
+		t.Errorf("DefaultProfile = %q, want main (unchanged)", cfg.DefaultProfile)
+	}
+	want := config.Profile{Login: "w0000001", AuthData: "stagingsecret", AuthType: "plain"}
+	if cfg.Profiles["staging"] != want {
+		t.Errorf("staging = %+v, want %+v", cfg.Profiles["staging"], want)
+	}
+	if _, ok := cfg.Profiles["main"]; !ok {
+		t.Errorf("main profile lost")
+	}
+}
+
+func TestRunConfigAddProfileRefusesOverwriteWithoutForce(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	pre := &config.Config{
+		Profiles: map[string]config.Profile{
+			"staging": {Login: "w0000001", AuthData: "old", AuthType: "session"},
+		},
+	}
+	if err := pre.Save(path); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	_, cio := newIO("w0000002\nplain\n", "new")
+	err := cli.RunConfigAddProfile(path, "staging", false, cio)
+	if err == nil {
+		t.Fatal("expected error for existing profile without --force")
+	}
+	if !strings.Contains(err.Error(), "already exists") {
+		t.Errorf("err %q missing 'already exists'", err)
+	}
+	cfg, _ := config.Load(path)
+	if cfg.Profiles["staging"].AuthData != "old" {
+		t.Errorf("file overwritten without --force")
+	}
+}
+
+func TestRunConfigAddProfileForceOverwrites(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	pre := &config.Config{
+		Profiles: map[string]config.Profile{
+			"staging": {Login: "w0000001", AuthData: "old", AuthType: "session"},
+		},
+	}
+	if err := pre.Save(path); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	_, cio := newIO("w0000002\nplain\n", "newpwd")
+	if err := cli.RunConfigAddProfile(path, "staging", true, cio); err != nil {
+		t.Fatalf("RunConfigAddProfile: %v", err)
+	}
+	cfg, _ := config.Load(path)
+	want := config.Profile{Login: "w0000002", AuthData: "newpwd", AuthType: "plain"}
+	if cfg.Profiles["staging"] != want {
+		t.Errorf("staging = %+v, want %+v", cfg.Profiles["staging"], want)
+	}
+}
+
+func TestRunConfigAddProfileSetsDefaultWhenEmpty(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	_, cio := newIO("w0000000\nsession\n", "secret")
+	if err := cli.RunConfigAddProfile(path, "main", false, cio); err != nil {
+		t.Fatalf("RunConfigAddProfile: %v", err)
+	}
+	cfg, _ := config.Load(path)
+	if cfg.DefaultProfile != "main" {
+		t.Errorf("DefaultProfile = %q, want main", cfg.DefaultProfile)
+	}
+}
+
+// --- use-profile ----------------------------------------------------------
+
+type revokeSpy struct {
+	calls   int
+	login   string
+	token   string
+	wantErr error
+}
+
+func (s *revokeSpy) fn() cli.RevokeFunc {
+	return func(_ context.Context, login, token string) error {
+		s.calls++
+		s.login = login
+		s.token = token
+		return s.wantErr
+	}
+}
+
+func newDiscardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func twoProfileConfig(t *testing.T, dir string) string {
+	t.Helper()
+	path := filepath.Join(dir, "config.toml")
+	pre := &config.Config{
+		DefaultProfile: "main",
+		Profiles: map[string]config.Profile{
+			"main":    {Login: "w0000000", AuthData: "secret", AuthType: "session"},
+			"staging": {Login: "w0000001", AuthData: "other", AuthType: "plain"},
+		},
+	}
+	if err := pre.Save(path); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	return path
+}
+
+func TestRunConfigUseProfileSwitchesDefault(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := twoProfileConfig(t, dir)
+	storePath := filepath.Join(dir, "sessions.toml")
+	store, err := session.New(storePath)
+	if err != nil {
+		t.Fatalf("session.New: %v", err)
+	}
+	spy := &revokeSpy{}
+	out := &bytes.Buffer{}
+
+	err = cli.RunConfigUseProfile(t.Context(), cfgPath, "staging", spy.fn(), store, newDiscardLogger(), out)
+	if err != nil {
+		t.Fatalf("RunConfigUseProfile: %v", err)
+	}
+	cfg, _ := config.Load(cfgPath)
+	if cfg.DefaultProfile != "staging" {
+		t.Errorf("DefaultProfile = %q, want staging", cfg.DefaultProfile)
+	}
+	if spy.calls != 0 {
+		t.Errorf("revoke called %d times without cached session, want 0", spy.calls)
+	}
+}
+
+func TestRunConfigUseProfileRejectsUnknown(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := twoProfileConfig(t, dir)
+	store, _ := session.New(filepath.Join(dir, "sessions.toml"))
+	spy := &revokeSpy{}
+
+	err := cli.RunConfigUseProfile(t.Context(), cfgPath, "bogus", spy.fn(), store, newDiscardLogger(), io.Discard)
+	if err == nil {
+		t.Fatal("expected error for unknown profile")
+	}
+	if !strings.Contains(err.Error(), "not defined") {
+		t.Errorf("err %q missing 'not defined'", err)
+	}
+	if spy.calls != 0 {
+		t.Errorf("revoke called %d times for unknown profile, want 0", spy.calls)
+	}
+}
+
+func TestRunConfigUseProfileNoOpForCurrentDefault(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := twoProfileConfig(t, dir)
+	store, _ := session.New(filepath.Join(dir, "sessions.toml"))
+	spy := &revokeSpy{}
+	out := &bytes.Buffer{}
+
+	err := cli.RunConfigUseProfile(t.Context(), cfgPath, "main", spy.fn(), store, newDiscardLogger(), out)
+	if err != nil {
+		t.Fatalf("RunConfigUseProfile: %v", err)
+	}
+	if spy.calls != 0 {
+		t.Errorf("revoke called %d times for no-op switch, want 0", spy.calls)
+	}
+	if !strings.Contains(out.String(), "already the default") {
+		t.Errorf("output missing 'already the default': %q", out.String())
+	}
+}
+
+func TestRunConfigUseProfileInvalidatesCachedSession(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := twoProfileConfig(t, dir)
+	storePath := filepath.Join(dir, "sessions.toml")
+	store, err := session.New(storePath)
+	if err != nil {
+		t.Fatalf("session.New: %v", err)
+	}
+	pre := session.Entry{
+		Token:     "01234567890abcdef0123456789abcdef0123456",
+		ExpiresAt: time.Now().Add(1 * time.Hour),
+	}
+	if serr := store.Save(t.Context(), "w0000000", pre); serr != nil {
+		t.Fatalf("Save: %v", serr)
+	}
+	spy := &revokeSpy{}
+
+	err = cli.RunConfigUseProfile(t.Context(), cfgPath, "staging", spy.fn(), store, newDiscardLogger(), io.Discard)
+	if err != nil {
+		t.Fatalf("RunConfigUseProfile: %v", err)
+	}
+	if spy.calls != 1 {
+		t.Errorf("revoke calls = %d, want 1", spy.calls)
+	}
+	if spy.login != "w0000000" || spy.token != pre.Token {
+		t.Errorf("revoke called with (%q, %q), want (w0000000, %q)", spy.login, spy.token, pre.Token)
+	}
+	got, err := store.Load(t.Context(), "w0000000")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got != nil {
+		t.Errorf("session entry still present after switch: %+v", got)
+	}
+}
+
+func TestRunConfigUseProfileTolerateServerError(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := twoProfileConfig(t, dir)
+	storePath := filepath.Join(dir, "sessions.toml")
+	store, _ := session.New(storePath)
+	pre := session.Entry{
+		Token:     "01234567890abcdef0123456789abcdef0123456",
+		ExpiresAt: time.Now().Add(1 * time.Hour),
+	}
+	if err := store.Save(t.Context(), "w0000000", pre); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	spy := &revokeSpy{wantErr: errors.New("kas_session_invalid")}
+
+	err := cli.RunConfigUseProfile(t.Context(), cfgPath, "staging", spy.fn(), store, newDiscardLogger(), io.Discard)
+	if err != nil {
+		t.Fatalf("switch must not fail on revoke error: %v", err)
+	}
+	cfg, _ := config.Load(cfgPath)
+	if cfg.DefaultProfile != "staging" {
+		t.Errorf("DefaultProfile = %q, want staging despite revoke error", cfg.DefaultProfile)
+	}
+	got, _ := store.Load(t.Context(), "w0000000")
+	if got != nil {
+		t.Errorf("session entry must be removed even on revoke error, got %+v", got)
+	}
+}
+
+func TestRunConfigUseProfileSkipsRevokeWhenNoToken(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := twoProfileConfig(t, dir)
+	store, _ := session.New(filepath.Join(dir, "sessions.toml"))
+	spy := &revokeSpy{}
+
+	err := cli.RunConfigUseProfile(t.Context(), cfgPath, "staging", spy.fn(), store, newDiscardLogger(), io.Discard)
+	if err != nil {
+		t.Fatalf("RunConfigUseProfile: %v", err)
+	}
+	if spy.calls != 0 {
+		t.Errorf("revoke called %d times without cached token, want 0", spy.calls)
+	}
+}
+
+// --- list-profiles --------------------------------------------------------
+
+func TestRunConfigListProfilesMarksDefault(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := twoProfileConfig(t, dir)
+	out := &bytes.Buffer{}
+	if err := cli.RunConfigListProfiles(cfgPath, out); err != nil {
+		t.Fatalf("RunConfigListProfiles: %v", err)
+	}
+	got := out.String()
+	wantPrefix := "* main (session)\n  staging (plain)\n"
+	if got != wantPrefix {
+		t.Errorf("output = %q, want %q", got, wantPrefix)
+	}
+}
+
+func TestRunConfigListProfilesNoConfigHint(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "missing.toml")
+	out := &bytes.Buffer{}
+	if err := cli.RunConfigListProfiles(cfgPath, out); err != nil {
+		t.Fatalf("RunConfigListProfiles: %v", err)
+	}
+	if !strings.Contains(out.String(), "config init") {
+		t.Errorf("missing first-run hint: %q", out.String())
+	}
+}
+
+func TestRunConfigListProfilesDoesNotLeakAuthData(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.toml")
+	pre := &config.Config{
+		DefaultProfile: "main",
+		Profiles: map[string]config.Profile{
+			"main": {Login: "w0000000", AuthData: "supersecretXYZ", AuthType: "session"},
+		},
+	}
+	if err := pre.Save(cfgPath); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	out := &bytes.Buffer{}
+	if err := cli.RunConfigListProfiles(cfgPath, out); err != nil {
+		t.Fatalf("RunConfigListProfiles: %v", err)
+	}
+	if strings.Contains(out.String(), "supersecretXYZ") {
+		t.Errorf("auth_data leaked: %q", out.String())
 	}
 }
 

--- a/internal/cli/export_test.go
+++ b/internal/cli/export_test.go
@@ -10,3 +10,16 @@ type ConfigIO = configIO
 // Tests use it instead of executing the cobra subcommand directly so
 // the IsTTY/ReadPassword hooks can be substituted.
 var RunConfigInit = runConfigInit
+
+// RunConfigAddProfile, RunConfigUseProfile, RunConfigListProfiles are
+// the test-visible entry points for the multi-profile management
+// subcommands.
+var (
+	RunConfigAddProfile   = runConfigAddProfile
+	RunConfigUseProfile   = runConfigUseProfile
+	RunConfigListProfiles = runConfigListProfiles
+)
+
+// RevokeFunc mirrors the unexported revokeFunc dependency injected
+// into runConfigUseProfile so tests can supply a spy.
+type RevokeFunc = revokeFunc


### PR DESCRIPTION
## Summary

Three new `kasapi-cli config` subcommands to manage the multi-profile schema that `config.toml` already supports:

- **`add-profile <name>`** — interactive prompt flow (reuses `config init`'s helpers), `--force` to overwrite.
- **`use-profile <name>`** — switches `default_profile`. If the outgoing profile has a non-expired cached session token, calls the KAS API action `delete_session` to drop it server-side, then removes the local `sessions.toml` entry. Best-effort: a transport / `unknown_session` fault is logged under `--verbose` but does not abort the switch.
- **`list-profiles`** — alphabetical profile listing, default marked with `* `, `auth_data` never printed.

The server-side revoke is dependency-injected into `runConfigUseProfile`, so tests use a spy instead of an httptest server. Production wires the real `revokeSession` (builds an `api.Client` with a `StaticTokenSource` holding the cached token).

Closes #39