### PR TITLE
chore: address re-review findings from PR #145

### DIFF
--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -21,9 +21,13 @@ import (
 	"github.com/chmmou/kasapi-cli/internal/transport"
 )
 
-// NewConfigCmd returns the "kasapi-cli config" subcommand tree: init
-// (interactive bootstrap), show (resolved effective config with
-// auth_data redacted), and path (resolved config-file path).
+// NewConfigCmd returns the "kasapi-cli config" subcommand tree:
+//   - init (interactive bootstrap of the first profile)
+//   - show (resolved effective config with auth_data redacted)
+//   - path (resolved config-file path)
+//   - add-profile (interactive bootstrap of an additional profile)
+//   - use-profile (switch default_profile + server-side revoke)
+//   - list-profiles (alphabetical listing, default marked, auth_data redacted)
 func NewConfigCmd(opts *RootOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "config",
@@ -282,12 +286,16 @@ type revokeFunc func(ctx context.Context, login, token string) error
 // identifies the session via the (login, token) tuple supplied as
 // auth_data / auth_type=session — no extra parameters are required.
 //
+// endpoint is empty in production (uses api.DefaultEndpoint); tests
+// point it at an httptest.Server so the real soap.Decode + api.Call
+// pipeline runs against canned fixtures.
+//
 // Best-effort: transport, decode, or KAS-fault errors are returned so
 // the caller (runConfigUseProfile) can log them, but the caller must
 // not propagate them — the local cache is the authoritative
 // client-side state, and a failed revoke must not block a profile
 // switch.
-func revokeSession(ctx context.Context, login, token string, logger *slog.Logger) error {
+func revokeSession(ctx context.Context, login, token, endpoint string, logger *slog.Logger) error {
 	tr := transport.New()
 	tr.Logger = logger
 	c := api.New(tr, &api.StaticTokenSource{
@@ -296,6 +304,9 @@ func revokeSession(ctx context.Context, login, token string, logger *slog.Logger
 		AuthType: soap.AuthSession,
 	})
 	c.Logger = logger
+	if endpoint != "" {
+		c.Endpoint = endpoint
+	}
 	_, err := c.Call(ctx, "delete_session", nil)
 	return err
 }
@@ -403,7 +414,7 @@ func newConfigUseProfileCmd(opts *RootOptions) *cobra.Command {
 				return UserError(err, "session store")
 			}
 			revoke := func(ctx context.Context, login, token string) error {
-				return revokeSession(ctx, login, token, logger)
+				return revokeSession(ctx, login, token, "", logger)
 			}
 			return runConfigUseProfile(cmd.Context(), opts.ConfigPath, args[0], revoke, store, logger, cmd.OutOrStdout())
 		},
@@ -457,6 +468,9 @@ func runConfigUseProfile(ctx context.Context, configPath, name string, revoke re
 				if derr := store.Delete(ctx, prof.Login); derr != nil {
 					logger.Warn("config use-profile: session store delete failed",
 						"login", prof.Login, "err", derr)
+				}
+				if _, perr := fmt.Fprintf(w, "Invalidated cached session for %q (login %s)\n", outgoing, prof.Login); perr != nil {
+					return UserError(perr, "")
 				}
 			}
 		}
@@ -522,9 +536,14 @@ func runConfigListProfiles(configPath string, w io.Writer) error {
 		if n == cfg.DefaultProfile {
 			mark = "* "
 		}
+		// Empty auth_type is rare (init / add-profile always write one
+		// via promptAuthType), but possible if the TOML was edited by
+		// hand. Show "no auth_type" so the user sees the real state
+		// instead of an optimistic "(session)" default that may not
+		// match what `cfg.Resolve` will accept.
 		authType := cfg.Profiles[n].AuthType
 		if authType == "" {
-			authType = "session"
+			authType = "no auth_type"
 		}
 		we.printf("%s%s (%s)\n", mark, n, authType)
 	}

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"io"
 	"log/slog"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -499,6 +501,32 @@ func TestRunConfigUseProfileInvalidatesCachedSession(t *testing.T) {
 	}
 }
 
+func TestRunConfigUseProfilePrintsInvalidationLine(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := twoProfileConfig(t, dir)
+	storePath := filepath.Join(dir, "sessions.toml")
+	store, _ := session.New(storePath)
+	pre := session.Entry{
+		Token:     "01234567890abcdef0123456789abcdef0123456",
+		ExpiresAt: time.Now().Add(1 * time.Hour),
+	}
+	if err := store.Save(t.Context(), "w0000000", pre); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	spy := &revokeSpy{}
+	out := &bytes.Buffer{}
+
+	if err := cli.RunConfigUseProfile(t.Context(), cfgPath, "staging", spy.fn(), store, newDiscardLogger(), out); err != nil {
+		t.Fatalf("RunConfigUseProfile: %v", err)
+	}
+	if !strings.Contains(out.String(), `Invalidated cached session for "main"`) {
+		t.Errorf("missing invalidation line in output: %q", out.String())
+	}
+	if !strings.Contains(out.String(), "w0000000") {
+		t.Errorf("invalidation line missing login: %q", out.String())
+	}
+}
+
 func TestRunConfigUseProfileTolerateServerError(t *testing.T) {
 	dir := t.TempDir()
 	cfgPath := twoProfileConfig(t, dir)
@@ -542,6 +570,59 @@ func TestRunConfigUseProfileSkipsRevokeWhenNoToken(t *testing.T) {
 	}
 }
 
+// --- revokeSession (integration against testdata fixtures) --------------
+
+func newRevokeServer(t *testing.T, fixturePath string, capture *[]byte) *httptest.Server {
+	t.Helper()
+	//nolint:gosec // G304: fixturePath is a test-controlled constant pointing into testdata/.
+	body, err := os.ReadFile(fixturePath)
+	if err != nil {
+		t.Fatalf("read fixture %s: %v", fixturePath, err)
+	}
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if capture != nil {
+			b, _ := io.ReadAll(r.Body)
+			*capture = b
+		}
+		w.Header().Set("Content-Type", "text/xml; charset=utf-8")
+		_, _ = w.Write(body)
+	}))
+}
+
+func TestRevokeSessionCallsDeleteSessionAction(t *testing.T) {
+	var captured []byte
+	srv := newRevokeServer(t, "../../testdata/session/delete_session_response_success.xml", &captured)
+	defer srv.Close()
+
+	err := cli.RevokeSession(t.Context(), "w0000000", "01234567890abcdef0123456789abcdef0123456", srv.URL, newDiscardLogger())
+	if err != nil {
+		t.Fatalf("RevokeSession: %v", err)
+	}
+	body := string(captured)
+	if !strings.Contains(body, `"kas_action":"delete_session"`) {
+		t.Errorf("request body missing kas_action=delete_session: %s", body)
+	}
+	if !strings.Contains(body, `"kas_auth_type":"session"`) {
+		t.Errorf("request body missing kas_auth_type=session: %s", body)
+	}
+	if !strings.Contains(body, `"kas_login":"w0000000"`) {
+		t.Errorf("request body missing kas_login: %s", body)
+	}
+}
+
+func TestRevokeSessionPropagatesUnknownSessionFault(t *testing.T) {
+	srv := newRevokeServer(t, "../../testdata/session/delete_session_response_failed_unknown_session.xml", nil)
+	defer srv.Close()
+
+	err := cli.RevokeSession(t.Context(), "w0000000", "expiredtoken", srv.URL, newDiscardLogger())
+	if err == nil {
+		t.Fatal("expected error for unknown_session fault")
+	}
+	if !strings.Contains(err.Error(), "unknown_session") {
+		t.Errorf("err %q does not mention unknown_session", err)
+	}
+}
+
 // --- list-profiles --------------------------------------------------------
 
 func TestRunConfigListProfilesMarksDefault(t *testing.T) {
@@ -555,6 +636,22 @@ func TestRunConfigListProfilesMarksDefault(t *testing.T) {
 	wantPrefix := "* main (session)\n  staging (plain)\n"
 	if got != wantPrefix {
 		t.Errorf("output = %q, want %q", got, wantPrefix)
+	}
+}
+
+func TestRunConfigListProfilesShowsUnsetAuthType(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.toml")
+	contents := "default_profile = \"main\"\n\n[profiles.main]\nlogin = \"w0000000\"\nauth_data = \"secret\"\n"
+	if err := os.WriteFile(cfgPath, []byte(contents), 0o600); err != nil {
+		t.Fatalf("write partial config: %v", err)
+	}
+	out := &bytes.Buffer{}
+	if err := cli.RunConfigListProfiles(cfgPath, out); err != nil {
+		t.Fatalf("RunConfigListProfiles: %v", err)
+	}
+	if !strings.Contains(out.String(), "no auth_type") {
+		t.Errorf("expected 'no auth_type' marker for empty auth_type, got %q", out.String())
 	}
 }
 

--- a/internal/cli/export_test.go
+++ b/internal/cli/export_test.go
@@ -23,3 +23,8 @@ var (
 // RevokeFunc mirrors the unexported revokeFunc dependency injected
 // into runConfigUseProfile so tests can supply a spy.
 type RevokeFunc = revokeFunc
+
+// RevokeSession is the production revoke implementation, exposed so
+// integration tests can drive the full soap.Decode + api.Call pipeline
+// against an httptest.Server serving canned fixtures.
+var RevokeSession = revokeSession


### PR DESCRIPTION
## Summary

Re-review follow-ups from the post-merge pass on PR #145 (issue #39):

- **F1 (Should) — stale doc**: `NewConfigCmd` doc-comment listed only the three pre-existing subcommands. Replaced with a bulleted list that names all six.
- **N1 — Integration test for `revokeSession`**: added an `endpoint` parameter so an httptest-server test can drive the full `soap.Decode` + `api.Call` pipeline against the `testdata/session` fixtures. Two new tests assert the encoded request shape (`kas_action=delete_session`, `kas_auth_type=session`, `kas_login`) and that an `unknown_session` fault surfaces as an error.
- **N2 — User-visible invalidation hint**: `use-profile` now prints `Invalidated cached session for "<profile>" (login w…)` so users without `--verbose` still see the server-side side effect.
- **N3 — Honest `list-profiles` output**: an empty `auth_type` now renders as `(no auth_type)` instead of optimistically defaulting to `(session)`, matching what `cfg.Resolve` would actually accept.