### PR TITLE
feat(session): add sessions delete subcommand (delete_session)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `kasapi-cli sessions delete` invalidates the resolved profile's
+  cached session token both server-side (KAS API `delete_session`) and
+  in the local `sessions.toml` cache. It acts on the *currently
+  cached* token only and never bootstraps a fresh one just to delete
+  it. The command is idempotent: a missing or already-invalid
+  (`unknown_session`) session is reported and exits 0; any other
+  transport/KAS error is surfaced with a non-zero exit after the local
+  cache has been cleared (the local cache is the authoritative
+  client-side state). No confirmation prompt — deleting a session
+  merely forces a re-authentication on the next session-mode call.
+  `add_session` is *not* a separate endpoint: it is the KasAuth
+  credential-token flow already covered by `internal/auth`, so it gets
+  no subcommand. The shared `delete_session` use case now lives in
+  `internal/session` (`session.Client`); `config use-profile`'s
+  revoke path was refactored to delegate to it. Closes #60.
+
 - `kasapi-cli config add-profile <name>` / `use-profile <name>` /
   `list-profiles` for managing multiple profiles in `config.toml`.
   `add-profile` reuses the `config init` prompt flow with `--force` to

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -11,7 +11,7 @@ The list is kept in sync with the code on `main`. To claim an unchecked item, pl
 - [x] `KasAuth` credential-token flow (plain + session, optional 2FA via `--otp`)
 - [x] Persistent session-token cache (`sessions.toml`) survives across CLI invocations
 - [x] Session lifetime extension (`update_lifetime`)
-- [ ] Standalone `add_session` / `delete_session` subcommands
+- [x] Standalone `delete_session` subcommand (`kasapi-cli sessions delete`); `add_session` is the KasAuth credential-token flow already covered above (`internal/auth`), not a separate endpoint
 
 ## Configuration
 

--- a/cmd/kasapi-cli/main.go
+++ b/cmd/kasapi-cli/main.go
@@ -30,6 +30,7 @@ func main() {
 		cli.NewSoftwareInstallsCmd(opts),
 		cli.NewDDNSUsersCmd(opts),
 		cli.NewUsageCmd(opts),
+		cli.NewSessionsCmd(opts),
 		cli.NewConfigCmd(opts),
 		cli.NewGenDocsCmd(),
 	)

--- a/docs/cli/kasapi-cli.md
+++ b/docs/cli/kasapi-cli.md
@@ -43,6 +43,7 @@ kasapi-cli [flags]
 * [kasapi-cli mail](kasapi-cli_mail.md)	 - Inspect mail accounts, forwards, filters, and mailing lists
 * [kasapi-cli sambausers](kasapi-cli_sambausers.md)	 - Inspect Samba/CIFS users visible to the login (get_sambausers)
 * [kasapi-cli server](kasapi-cli_server.md)	 - Inspect the host server kasapi-cli is talking to
+* [kasapi-cli sessions](kasapi-cli_sessions.md)	 - Manage KAS session tokens (delete_session)
 * [kasapi-cli softwareinstalls](kasapi-cli_softwareinstalls.md)	 - Inspect installable software templates (get_softwareinstall)
 * [kasapi-cli subdomains](kasapi-cli_subdomains.md)	 - Inspect subdomains owned by the authenticated account
 * [kasapi-cli tlds](kasapi-cli_tlds.md)	 - Inspect the catalog of registrable top-level domains

--- a/docs/cli/kasapi-cli_sessions.md
+++ b/docs/cli/kasapi-cli_sessions.md
@@ -1,0 +1,38 @@
+## kasapi-cli sessions
+
+Manage KAS session tokens (delete_session)
+
+### Synopsis
+
+Manage KAS session tokens.
+
+add_session is not a separate endpoint — it is the KasAuth credential-token flow driven transparently by auth_type=session (see `config init`). Only delete_session is exposed here, as the explicit counterpart to the implicit logout in `config use-profile`.
+
+### Options
+
+```
+  -h, --help   help for sessions
+```
+
+### Options inherited from parent commands
+
+```
+      --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
+      --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
+      --config string                    path to the kasapi-cli config file (overrides the default location)
+      --login string                     KAS login (overrides config and KAS_LOGIN)
+      --no-color                         disable coloured output
+      --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
+  -o, --output string                    output format: json|yaml|table (default table)
+      --profile string                   profile to select from the config file (overrides default_profile)
+      --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
+      --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
+  -v, --verbose                          enable verbose logging on stderr
+  -y, --yes                              skip confirmation prompts on destructive operations
+```
+
+### SEE ALSO
+
+* [kasapi-cli](kasapi-cli.md)	 - Command-line client for the All-Inkl KAS API
+* [kasapi-cli sessions delete](kasapi-cli_sessions_delete.md)	 - Invalidate the active profile's cached session token (delete_session)
+

--- a/docs/cli/kasapi-cli_sessions_delete.md
+++ b/docs/cli/kasapi-cli_sessions_delete.md
@@ -1,0 +1,41 @@
+## kasapi-cli sessions delete
+
+Invalidate the active profile's cached session token (delete_session)
+
+### Synopsis
+
+Invalidate the resolved profile's cached session token, both server-side (kas_action=delete_session) and in the local sessions.toml cache.
+
+Acts on the *currently cached* token only; it never bootstraps a fresh token just to delete it. Idempotent: a missing or already-invalid session is reported and exits 0. No confirmation prompt — deleting a session merely forces a re-authentication on the next session-mode call.
+
+```
+kasapi-cli sessions delete [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for delete
+```
+
+### Options inherited from parent commands
+
+```
+      --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
+      --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
+      --config string                    path to the kasapi-cli config file (overrides the default location)
+      --login string                     KAS login (overrides config and KAS_LOGIN)
+      --no-color                         disable coloured output
+      --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
+  -o, --output string                    output format: json|yaml|table (default table)
+      --profile string                   profile to select from the config file (overrides default_profile)
+      --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
+      --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
+  -v, --verbose                          enable verbose logging on stderr
+  -y, --yes                              skip confirmation prompts on destructive operations
+```
+
+### SEE ALSO
+
+* [kasapi-cli sessions](kasapi-cli_sessions.md)	 - Manage KAS session tokens (delete_session)
+

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -282,19 +282,22 @@ func profileNames(cfg *config.Config) string {
 type revokeFunc func(ctx context.Context, login, token string) error
 
 // revokeSession server-side invalidates one cached session token by
-// calling kas_action=delete_session with that token. The KAS API
-// identifies the session via the (login, token) tuple supplied as
-// auth_data / auth_type=session — no extra parameters are required.
+// driving the session.Client delete_session use case with that token.
+// The KAS API identifies the session via the (login, token) tuple
+// supplied as auth_data / auth_type=session — no extra parameters are
+// required. This function owns only the outer-layer wiring (transport +
+// StaticTokenSource); the action string and success contract live in
+// internal/session so config use-profile and `sessions delete` share
+// one source of truth.
 //
 // endpoint is empty in production (uses api.DefaultEndpoint); tests
 // point it at an httptest.Server so the real soap.Decode + api.Call
 // pipeline runs against canned fixtures.
 //
-// Best-effort: transport, decode, or KAS-fault errors are returned so
-// the caller (runConfigUseProfile) can log them, but the caller must
-// not propagate them — the local cache is the authoritative
-// client-side state, and a failed revoke must not block a profile
-// switch.
+// Errors (transport, decode, or KAS fault) are returned so callers can
+// log or classify them; whether they are propagated is the caller's
+// decision (config use-profile swallows them best-effort, `sessions
+// delete` surfaces non-unknown_session faults).
 func revokeSession(ctx context.Context, login, token, endpoint string, logger *slog.Logger) error {
 	tr := transport.New()
 	tr.Logger = logger
@@ -307,8 +310,7 @@ func revokeSession(ctx context.Context, login, token, endpoint string, logger *s
 	if endpoint != "" {
 		c.Endpoint = endpoint
 	}
-	_, err := c.Call(ctx, "delete_session", nil)
-	return err
+	return session.NewClient(c).Delete(ctx)
 }
 
 func newConfigAddProfileCmd(opts *RootOptions) *cobra.Command {

--- a/internal/cli/export_test.go
+++ b/internal/cli/export_test.go
@@ -28,3 +28,8 @@ type RevokeFunc = revokeFunc
 // integration tests can drive the full soap.Decode + api.Call pipeline
 // against an httptest.Server serving canned fixtures.
 var RevokeSession = revokeSession
+
+// RunSessionsDelete is the test-visible entry point for the
+// `sessions delete` subcommand. Tests inject a RevokeFunc spy and a
+// temp session.Store, mirroring the `config use-profile` pattern.
+var RunSessionsDelete = runSessionsDelete

--- a/internal/cli/sessions.go
+++ b/internal/cli/sessions.go
@@ -1,0 +1,127 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+
+	"github.com/spf13/cobra"
+
+	"github.com/chmmou/kasapi-cli/internal/api"
+	"github.com/chmmou/kasapi-cli/internal/config"
+	"github.com/chmmou/kasapi-cli/internal/session"
+)
+
+// NewSessionsCmd returns the "kasapi-cli sessions" subcommand tree.
+//
+// Only delete_session has a standalone subcommand: add_session is not a
+// distinct endpoint — it is the KasAuth credential-token flow that
+// `config init` / auth_type=session already drive transparently (see
+// internal/auth). `sessions delete` is the explicit counterpart to the
+// implicit logout performed by `config use-profile`.
+func NewSessionsCmd(opts *RootOptions) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "sessions",
+		Short: "Manage KAS session tokens (delete_session)",
+		Long: "Manage KAS session tokens.\n\n" +
+			"add_session is not a separate endpoint — it is the KasAuth " +
+			"credential-token flow driven transparently by auth_type=session " +
+			"(see `config init`). Only delete_session is exposed here, as the " +
+			"explicit counterpart to the implicit logout in `config use-profile`.",
+	}
+	cmd.AddCommand(newSessionsDeleteCmd(opts))
+	return cmd
+}
+
+func newSessionsDeleteCmd(opts *RootOptions) *cobra.Command {
+	return &cobra.Command{
+		Use:   "delete",
+		Short: "Invalidate the active profile's cached session token (delete_session)",
+		Long: "Invalidate the resolved profile's cached session token, both " +
+			"server-side (kas_action=delete_session) and in the local " +
+			"sessions.toml cache.\n\n" +
+			"Acts on the *currently cached* token only; it never bootstraps a " +
+			"fresh token just to delete it. Idempotent: a missing or " +
+			"already-invalid session is reported and exits 0. No confirmation " +
+			"prompt — deleting a session merely forces a re-authentication on " +
+			"the next session-mode call.",
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			logger := buildLogger(opts.Verbose)
+			storePath, err := session.PathFor(opts.ConfigPath)
+			if err != nil {
+				return UserError(err, "session store")
+			}
+			store, err := session.New(storePath)
+			if err != nil {
+				return UserError(err, "session store")
+			}
+			revoke := func(ctx context.Context, login, token string) error {
+				return revokeSession(ctx, login, token, "", logger)
+			}
+			return runSessionsDelete(cmd.Context(), opts, revoke, store, logger, cmd.OutOrStdout())
+		},
+	}
+}
+
+// runSessionsDelete logs out the resolved active profile. It looks up
+// the profile's *currently cached* session token and, if present,
+// invalidates it server-side via revoke (delete_session) and removes
+// the on-disk cache entry. The local cache is the authoritative
+// client-side state, so it is cleared whenever a token was found —
+// even if the server-side revoke fails.
+//
+// Unlike the implicit best-effort revoke in `config use-profile`, this
+// explicit command surfaces a real server-side failure: an
+// already-invalid token (unknown_session) is idempotent success, but
+// any other transport/KAS error is returned with a non-zero exit after
+// the local cache has been cleared, so scripts notice.
+func runSessionsDelete(ctx context.Context, opts *RootOptions, revoke revokeFunc, store *session.Store, logger *slog.Logger, w io.Writer) error {
+	creds, err := resolveCreds(opts)
+	if err != nil {
+		return err
+	}
+	if creds.AuthType == config.AuthPlain {
+		if _, perr := fmt.Fprintf(w, "no session to delete: profile for login %s uses auth_type=plain (KasAuth is never contacted)\n", creds.Login); perr != nil {
+			return UserError(perr, "")
+		}
+		return nil
+	}
+
+	entry, err := store.Load(ctx, creds.Login)
+	if err != nil {
+		return UserError(err, "session store")
+	}
+	if entry == nil || entry.Token == "" {
+		if _, perr := fmt.Fprintf(w, "no active cached session for login %s; nothing to revoke\n", creds.Login); perr != nil {
+			return UserError(perr, "")
+		}
+		return nil
+	}
+
+	revokeErr := revoke(ctx, creds.Login, entry.Token)
+	if derr := store.Delete(ctx, creds.Login); derr != nil {
+		logger.Warn("sessions delete: session store delete failed",
+			"login", creds.Login, "err", derr)
+	}
+
+	switch {
+	case revokeErr == nil:
+		if _, perr := fmt.Fprintf(w, "Deleted server-side session for login %s and cleared the local cache\n", creds.Login); perr != nil {
+			return UserError(perr, "")
+		}
+		return nil
+	case api.IsCode(revokeErr, api.CodeUnknownSession):
+		logger.Info("sessions delete: token already invalid server-side; cleared local cache",
+			"login", creds.Login)
+		if _, perr := fmt.Fprintf(w, "Session for login %s was already invalid server-side; cleared the local cache\n", creds.Login); perr != nil {
+			return UserError(perr, "")
+		}
+		return nil
+	default:
+		logger.Warn("sessions delete: server-side revoke failed (local cache cleared)",
+			"login", creds.Login, "err", revokeErr)
+		return APIError(revokeErr, "delete_session")
+	}
+}

--- a/internal/cli/sessions_test.go
+++ b/internal/cli/sessions_test.go
@@ -1,0 +1,234 @@
+package cli_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/chmmou/kasapi-cli/internal/api"
+	"github.com/chmmou/kasapi-cli/internal/cli"
+	"github.com/chmmou/kasapi-cli/internal/session"
+)
+
+const fixtureToken = "01234567890abcdef0123456789abcdef0123456"
+
+// clearKASEnv makes resolveCreds hermetic regardless of the developer's
+// shell: the KAS_* env vars are consulted by config.EnvFromOS and would
+// otherwise leak into the profile resolution.
+func clearKASEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("KAS_LOGIN", "")
+	t.Setenv("KAS_AUTHDATA", "")
+	t.Setenv("KAS_AUTHTYPE", "")
+}
+
+func storeWithSession(t *testing.T, dir, login, token string) *session.Store {
+	t.Helper()
+	store, err := session.New(filepath.Join(dir, "sessions.toml"))
+	if err != nil {
+		t.Fatalf("session.New: %v", err)
+	}
+	if err := store.Save(t.Context(), login, session.Entry{
+		Token:     token,
+		ExpiresAt: time.Now().Add(time.Hour),
+	}); err != nil {
+		t.Fatalf("store.Save: %v", err)
+	}
+	return store
+}
+
+func TestRunSessionsDeleteRevokesCachedSession(t *testing.T) {
+	clearKASEnv(t)
+	dir := t.TempDir()
+	cfgPath := twoProfileConfig(t, dir)
+	store := storeWithSession(t, dir, "w0000000", fixtureToken)
+	spy := &revokeSpy{}
+	out := &bytes.Buffer{}
+
+	opts := &cli.RootOptions{ConfigPath: cfgPath}
+	if err := cli.RunSessionsDelete(t.Context(), opts, spy.fn(), store, newDiscardLogger(), out); err != nil {
+		t.Fatalf("RunSessionsDelete: %v", err)
+	}
+	if spy.calls != 1 {
+		t.Fatalf("revoke called %d times, want 1", spy.calls)
+	}
+	if spy.login != "w0000000" || spy.token != fixtureToken {
+		t.Errorf("revoke(login=%q token=%q), want (w0000000, %s)", spy.login, spy.token, fixtureToken)
+	}
+	if e, _ := store.Load(t.Context(), "w0000000"); e != nil {
+		t.Errorf("local cache entry still present after delete: %+v", e)
+	}
+	if !strings.Contains(out.String(), "Deleted server-side session") {
+		t.Errorf("output missing success line: %q", out.String())
+	}
+}
+
+func TestRunSessionsDeleteNoCachedSession(t *testing.T) {
+	clearKASEnv(t)
+	dir := t.TempDir()
+	cfgPath := twoProfileConfig(t, dir)
+	store, _ := session.New(filepath.Join(dir, "sessions.toml"))
+	spy := &revokeSpy{}
+	out := &bytes.Buffer{}
+
+	opts := &cli.RootOptions{ConfigPath: cfgPath}
+	if err := cli.RunSessionsDelete(t.Context(), opts, spy.fn(), store, newDiscardLogger(), out); err != nil {
+		t.Fatalf("RunSessionsDelete: %v", err)
+	}
+	if spy.calls != 0 {
+		t.Errorf("revoke called %d times without cached session, want 0", spy.calls)
+	}
+	if !strings.Contains(out.String(), "nothing to revoke") {
+		t.Errorf("output missing 'nothing to revoke': %q", out.String())
+	}
+}
+
+func TestRunSessionsDeletePlainProfile(t *testing.T) {
+	clearKASEnv(t)
+	dir := t.TempDir()
+	cfgPath := twoProfileConfig(t, dir)
+	store, _ := session.New(filepath.Join(dir, "sessions.toml"))
+	spy := &revokeSpy{}
+	out := &bytes.Buffer{}
+
+	// staging is auth_type=plain in twoProfileConfig.
+	opts := &cli.RootOptions{ConfigPath: cfgPath, Profile: "staging"}
+	if err := cli.RunSessionsDelete(t.Context(), opts, spy.fn(), store, newDiscardLogger(), out); err != nil {
+		t.Fatalf("RunSessionsDelete: %v", err)
+	}
+	if spy.calls != 0 {
+		t.Errorf("revoke called %d times for plain profile, want 0", spy.calls)
+	}
+	if !strings.Contains(out.String(), "auth_type=plain") {
+		t.Errorf("output missing plain-profile note: %q", out.String())
+	}
+}
+
+func TestRunSessionsDeleteToleratesUnknownSession(t *testing.T) {
+	clearKASEnv(t)
+	dir := t.TempDir()
+	cfgPath := twoProfileConfig(t, dir)
+	store := storeWithSession(t, dir, "w0000000", fixtureToken)
+	spy := &revokeSpy{wantErr: &api.Error{Code: api.CodeUnknownSession, Action: "delete_session"}}
+	out := &bytes.Buffer{}
+
+	opts := &cli.RootOptions{ConfigPath: cfgPath}
+	if err := cli.RunSessionsDelete(t.Context(), opts, spy.fn(), store, newDiscardLogger(), out); err != nil {
+		t.Fatalf("RunSessionsDelete returned error for already-invalid session, want nil: %v", err)
+	}
+	if spy.calls != 1 {
+		t.Errorf("revoke called %d times, want 1", spy.calls)
+	}
+	if e, _ := store.Load(t.Context(), "w0000000"); e != nil {
+		t.Errorf("local cache not cleared after unknown_session: %+v", e)
+	}
+	if !strings.Contains(out.String(), "already invalid") {
+		t.Errorf("output missing idempotent note: %q", out.String())
+	}
+}
+
+func TestRunSessionsDeleteSurfacesTransportError(t *testing.T) {
+	clearKASEnv(t)
+	dir := t.TempDir()
+	cfgPath := twoProfileConfig(t, dir)
+	store := storeWithSession(t, dir, "w0000000", fixtureToken)
+	spy := &revokeSpy{wantErr: errors.New("boom")}
+	out := &bytes.Buffer{}
+
+	opts := &cli.RootOptions{ConfigPath: cfgPath}
+	err := cli.RunSessionsDelete(t.Context(), opts, spy.fn(), store, newDiscardLogger(), out)
+	if err == nil {
+		t.Fatal("RunSessionsDelete err = nil, want a surfaced transport error")
+	}
+	if spy.calls != 1 {
+		t.Errorf("revoke called %d times, want 1", spy.calls)
+	}
+	// Local cache is authoritative: it is cleared even though the
+	// server-side revoke failed.
+	if e, _ := store.Load(t.Context(), "w0000000"); e != nil {
+		t.Errorf("local cache not cleared after transport error: %+v", e)
+	}
+}
+
+func TestRunSessionsDeleteNoConfigHint(t *testing.T) {
+	clearKASEnv(t)
+	dir := t.TempDir()
+	store, _ := session.New(filepath.Join(dir, "sessions.toml"))
+	spy := &revokeSpy{}
+
+	opts := &cli.RootOptions{ConfigPath: filepath.Join(dir, "missing.toml")}
+	err := cli.RunSessionsDelete(t.Context(), opts, spy.fn(), store, newDiscardLogger(), io.Discard)
+	if err == nil {
+		t.Fatal("expected error when no config file exists")
+	}
+	if !strings.Contains(err.Error(), "config init") {
+		t.Errorf("err %q missing first-run `config init` hint", err)
+	}
+	if spy.calls != 0 {
+		t.Errorf("revoke called %d times without config, want 0", spy.calls)
+	}
+}
+
+// --- integration against testdata fixtures (real soap.Decode pipeline) ---
+
+func TestSessionsDeleteCallsDeleteSessionAction(t *testing.T) {
+	clearKASEnv(t)
+	dir := t.TempDir()
+	cfgPath := twoProfileConfig(t, dir)
+	store := storeWithSession(t, dir, "w0000000", fixtureToken)
+
+	var captured []byte
+	srv := newRevokeServer(t, "../../testdata/session/delete_session_response_success.xml", &captured)
+	defer srv.Close()
+
+	logger := newDiscardLogger()
+	revoke := func(ctx context.Context, login, token string) error {
+		return cli.RevokeSession(ctx, login, token, srv.URL, logger)
+	}
+	opts := &cli.RootOptions{ConfigPath: cfgPath}
+	out := &bytes.Buffer{}
+	if err := cli.RunSessionsDelete(t.Context(), opts, revoke, store, logger, out); err != nil {
+		t.Fatalf("RunSessionsDelete: %v", err)
+	}
+	body := string(captured)
+	for _, want := range []string{
+		`"kas_action":"delete_session"`,
+		`"kas_auth_type":"session"`,
+		`"kas_login":"w0000000"`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("request body missing %s: %s", want, body)
+		}
+	}
+}
+
+func TestSessionsDeleteToleratesUnknownSessionFault(t *testing.T) {
+	clearKASEnv(t)
+	dir := t.TempDir()
+	cfgPath := twoProfileConfig(t, dir)
+	store := storeWithSession(t, dir, "w0000000", "expiredtoken")
+
+	srv := newRevokeServer(t, "../../testdata/session/delete_session_response_failed_unknown_session.xml", nil)
+	defer srv.Close()
+
+	logger := newDiscardLogger()
+	revoke := func(ctx context.Context, login, token string) error {
+		return cli.RevokeSession(ctx, login, token, srv.URL, logger)
+	}
+	opts := &cli.RootOptions{ConfigPath: cfgPath}
+	out := &bytes.Buffer{}
+	if err := cli.RunSessionsDelete(t.Context(), opts, revoke, store, logger, out); err != nil {
+		t.Fatalf("RunSessionsDelete returned error for unknown_session fault, want idempotent nil: %v", err)
+	}
+	if e, _ := store.Load(t.Context(), "w0000000"); e != nil {
+		t.Errorf("local cache not cleared after unknown_session fault: %+v", e)
+	}
+	if !strings.Contains(out.String(), "already invalid") {
+		t.Errorf("output missing idempotent note: %q", out.String())
+	}
+}

--- a/internal/cli/wire.go
+++ b/internal/cli/wire.go
@@ -39,24 +39,9 @@ func BuildAPIClient(opts *RootOptions) (*api.Client, error) {
 
 	logger := buildLogger(opts.Verbose)
 
-	cfg, loadErr := config.Load(opts.ConfigPath)
-	if loadErr != nil && !errors.Is(loadErr, config.ErrNoConfig) {
-		return nil, UserError(loadErr, "load config")
-	}
-	creds, err := cfg.Resolve(config.EnvFromOS(), config.Override{
-		Profile:  opts.Profile,
-		Login:    opts.Login,
-		AuthData: opts.AuthData,
-		AuthType: opts.AuthType,
-	})
+	creds, err := resolveCreds(opts)
 	if err != nil {
-		// Genuine first-run (no config file at all): point at the bootstrap
-		// wizard. Partial-config cases keep the bare validation error because
-		// `config init` would refuse without --force in that scenario.
-		if errors.Is(loadErr, config.ErrNoConfig) {
-			err = fmt.Errorf("%w (run `kasapi-cli config init` to create a profile interactively)", err)
-		}
-		return nil, UserError(err, "")
+		return nil, err
 	}
 	logger.Info("cli: credentials resolved",
 		"login", creds.Login, "auth_type", creds.AuthType, "auth_data", "<redacted>")
@@ -75,6 +60,38 @@ func BuildAPIClient(opts *RootOptions) (*api.Client, error) {
 	c := api.New(tr, ts)
 	c.Logger = logger
 	return c, nil
+}
+
+// resolveCreds runs the config + env + flag credential resolution that
+// BuildAPIClient performs, including the genuine-first-run `config init`
+// hint when no config file exists at all (#138). It is the read-only
+// half BuildAPIClient builds a token source on top of; commands that
+// must act on the *resolved* profile without bootstrapping a fresh
+// session token (e.g. `sessions delete`) call it directly.
+func resolveCreds(opts *RootOptions) (config.Credentials, error) {
+	if opts == nil {
+		return config.Credentials{}, UserError(errors.New("nil RootOptions"), "cli")
+	}
+	cfg, loadErr := config.Load(opts.ConfigPath)
+	if loadErr != nil && !errors.Is(loadErr, config.ErrNoConfig) {
+		return config.Credentials{}, UserError(loadErr, "load config")
+	}
+	creds, err := cfg.Resolve(config.EnvFromOS(), config.Override{
+		Profile:  opts.Profile,
+		Login:    opts.Login,
+		AuthData: opts.AuthData,
+		AuthType: opts.AuthType,
+	})
+	if err != nil {
+		// Genuine first-run (no config file at all): point at the bootstrap
+		// wizard. Partial-config cases keep the bare validation error because
+		// `config init` would refuse without --force in that scenario.
+		if errors.Is(loadErr, config.ErrNoConfig) {
+			err = fmt.Errorf("%w (run `kasapi-cli config init` to create a profile interactively)", err)
+		}
+		return config.Credentials{}, UserError(err, "")
+	}
+	return creds, nil
 }
 
 // buildLogger returns a stderr text-handler logger when verbose is set,

--- a/internal/session/client.go
+++ b/internal/session/client.go
@@ -1,0 +1,54 @@
+package session
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/chmmou/kasapi-cli/internal/kasread"
+)
+
+// Caller is the subset of *api.Client this package's KAS-side use case
+// depends on. Reusing the shared kasread.Caller keeps tests free of
+// network setup: a testutil.FakeCaller can return a *soap.Response
+// decoded from a fixture.
+type Caller = kasread.Caller
+
+// deleteSessionAction is the KAS action that invalidates the session
+// identified by the (login, token) tuple supplied as kas_auth_data /
+// kas_auth_type=session. It takes no KasRequestParams.
+const deleteSessionAction = "delete_session"
+
+// Client wraps the session-write endpoints of the KAS API that are
+// genuinely distinct from the KasAuth credential-token flow. Today that
+// is delete_session only; add_session is the KasAuth flow itself and
+// lives in internal/auth (see the package doc).
+type Client struct {
+	c Caller
+}
+
+// NewClient returns a Client backed by the given Caller (in production
+// an *api.Client wired with a session-token StaticTokenSource).
+func NewClient(c Caller) *Client { return &Client{c: c} }
+
+// Delete invalidates the session whose 40-char token the underlying
+// Caller authenticates with, by calling kas_action=delete_session with
+// no parameters. The KAS API identifies the session via the
+// (login, token) tuple in the auth envelope, so nothing is passed in
+// KasRequestParams.
+//
+// A SOAP fault (e.g. unknown_session for an already-dead token) is
+// surfaced verbatim by the Caller and returned so the caller can
+// classify it via the api error helpers. On a non-fault response the
+// server echoes ReturnString="TRUE"; any other value is treated as a
+// contract violation so a future API drift fails the mapping test
+// instead of silently passing.
+func (cl *Client) Delete(ctx context.Context) error {
+	resp, err := cl.c.Call(ctx, deleteSessionAction, nil)
+	if err != nil {
+		return err
+	}
+	if got := resp.Body.ReturnString; got != "TRUE" {
+		return fmt.Errorf("session: %s: unexpected ReturnString %q (want TRUE)", deleteSessionAction, got)
+	}
+	return nil
+}

--- a/internal/session/client_test.go
+++ b/internal/session/client_test.go
@@ -1,0 +1,44 @@
+package session_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/chmmou/kasapi-cli/internal/session"
+	"github.com/chmmou/kasapi-cli/internal/soap"
+	"github.com/chmmou/kasapi-cli/internal/testutil"
+)
+
+func TestClientDeleteSuccess(t *testing.T) {
+	t.Parallel()
+	resp := testutil.DecodeFixture(t, "session/delete_session_response_success.xml")
+	fc := &testutil.FakeCaller{Resp: resp}
+	if err := session.NewClient(fc).Delete(context.Background()); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if fc.GotAction != "delete_session" {
+		t.Errorf("action = %q, want delete_session", fc.GotAction)
+	}
+	if fc.GotParams != nil {
+		t.Errorf("params = %v, want nil (delete_session takes no KasRequestParams)", fc.GotParams)
+	}
+}
+
+func TestClientDeletePropagatesError(t *testing.T) {
+	t.Parallel()
+	want := errors.New("boom")
+	fc := &testutil.FakeCaller{Err: want}
+	if err := session.NewClient(fc).Delete(context.Background()); !errors.Is(err, want) {
+		t.Errorf("Delete err = %v, want %v wrapped", err, want)
+	}
+}
+
+func TestClientDeleteRejectsNonTrueReturnString(t *testing.T) {
+	t.Parallel()
+	resp := &soap.Response{Body: soap.ResponseBody{ReturnString: "FALSE"}}
+	fc := &testutil.FakeCaller{Resp: resp}
+	if err := session.NewClient(fc).Delete(context.Background()); err == nil {
+		t.Error("Delete err = nil, want contract-violation error for ReturnString != TRUE")
+	}
+}

--- a/internal/session/doc.go
+++ b/internal/session/doc.go
@@ -1,4 +1,17 @@
-// Package session holds the domain types and use cases for the KAS session
-// endpoints (add_session, delete_session) used by the session-mode auth
-// flow. See issues #5 and #11.
+// Package session covers the KAS API session domain in two cohesive
+// halves:
+//
+//   - Store persists KasAuth credential tokens between CLI invocations
+//     (a single sessions.toml keyed by login, written 0600 next to the
+//     config file) so an interactive login including 2FA is not
+//     repeated while the server keeps the session alive.
+//   - Client wraps delete_session, the session-write endpoint that is
+//     genuinely distinct from the KasAuth flow: it invalidates a
+//     server-side session identified by the (login, token) auth tuple.
+//
+// add_session is not a distinct endpoint — it is the KasAuth
+// credential-token flow itself (same parameters, KasAuth.php envelope,
+// bare-string token reply) and is implemented in internal/auth
+// (Client.GetCredentialToken / SessionTokenSource). See issues #5,
+// #11, and #60.
 package session


### PR DESCRIPTION
Adds `kasapi-cli sessions delete`: invalidates the resolved profile's cached session token server-side (KAS API `delete_session`) and removes the local `sessions.toml` entry. Idempotent — a missing or already-invalid (`unknown_session`) session exits 0; other transport/KAS errors exit non-zero after the local cache is cleared. No confirmation prompt (session deletion only forces a re-auth).

The fixtures show `add_session` is the KasAuth credential-token flow already covered by `internal/auth`, so it gets no subcommand. The `delete_session` use case now lives in `internal/session` (`session.Client`); `config use-profile`'s revoke path delegates to it.

Closes #60