### PR TITLE
chore: address re-review findings from PR #147

### DIFF
--- a/docs/cli/kasapi-cli_sessions_delete.md
+++ b/docs/cli/kasapi-cli_sessions_delete.md
@@ -6,7 +6,7 @@ Invalidate the active profile's cached session token (delete_session)
 
 Invalidate the resolved profile's cached session token, both server-side (kas_action=delete_session) and in the local sessions.toml cache.
 
-Acts on the *currently cached* token only; it never bootstraps a fresh token just to delete it. Idempotent: a missing or already-invalid session is reported and exits 0. No confirmation prompt — deleting a session merely forces a re-authentication on the next session-mode call.
+Acts on the *currently cached* token only; it never bootstraps a fresh token just to delete it. Idempotent: a missing or already-invalid session is reported and exits 0. No confirmation prompt — deleting a session merely forces a re-authentication on the next session-mode call; the global --yes flag has no effect here because there is nothing to confirm.
 
 ```
 kasapi-cli sessions delete [flags]

--- a/internal/cli/sessions.go
+++ b/internal/cli/sessions.go
@@ -45,7 +45,8 @@ func newSessionsDeleteCmd(opts *RootOptions) *cobra.Command {
 			"fresh token just to delete it. Idempotent: a missing or " +
 			"already-invalid session is reported and exits 0. No confirmation " +
 			"prompt — deleting a session merely forces a re-authentication on " +
-			"the next session-mode call.",
+			"the next session-mode call; the global --yes flag has no effect " +
+			"here because there is nothing to confirm.",
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			logger := buildLogger(opts.Verbose)
@@ -122,6 +123,9 @@ func runSessionsDelete(ctx context.Context, opts *RootOptions, revoke revokeFunc
 	default:
 		logger.Warn("sessions delete: server-side revoke failed (local cache cleared)",
 			"login", creds.Login, "err", revokeErr)
+		if _, perr := fmt.Fprintf(w, "Cleared the local cache for login %s; the server-side delete_session call failed:\n", creds.Login); perr != nil {
+			return UserError(perr, "")
+		}
 		return APIError(revokeErr, "delete_session")
 	}
 }

--- a/internal/cli/sessions_test.go
+++ b/internal/cli/sessions_test.go
@@ -153,6 +153,11 @@ func TestRunSessionsDeleteSurfacesTransportError(t *testing.T) {
 	if e, _ := store.Load(t.Context(), "w0000000"); e != nil {
 		t.Errorf("local cache not cleared after transport error: %+v", e)
 	}
+	// The user must learn the local cache was still cleared even though
+	// the command exits non-zero (the failure is not silent).
+	if !strings.Contains(out.String(), "Cleared the local cache") {
+		t.Errorf("output missing local-cache-cleared note on failure path: %q", out.String())
+	}
 }
 
 func TestRunSessionsDeleteNoConfigHint(t *testing.T) {

--- a/internal/session/client.go
+++ b/internal/session/client.go
@@ -47,6 +47,9 @@ func (cl *Client) Delete(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	if resp == nil {
+		return fmt.Errorf("session: %s: nil response without error from Caller", deleteSessionAction)
+	}
 	if got := resp.Body.ReturnString; got != "TRUE" {
 		return fmt.Errorf("session: %s: unexpected ReturnString %q (want TRUE)", deleteSessionAction, got)
 	}

--- a/internal/session/client_test.go
+++ b/internal/session/client_test.go
@@ -34,6 +34,14 @@ func TestClientDeletePropagatesError(t *testing.T) {
 	}
 }
 
+func TestClientDeleteRejectsNilResponse(t *testing.T) {
+	t.Parallel()
+	fc := &testutil.FakeCaller{Resp: nil, Err: nil}
+	if err := session.NewClient(fc).Delete(context.Background()); err == nil {
+		t.Error("Delete err = nil, want error for nil response without error from Caller")
+	}
+}
+
 func TestClientDeleteRejectsNonTrueReturnString(t *testing.T) {
 	t.Parallel()
 	resp := &soap.Response{Body: soap.ResponseBody{ReturnString: "FALSE"}}

--- a/internal/session/store.go
+++ b/internal/session/store.go
@@ -1,14 +1,7 @@
-// Package session persists KasAuth credential tokens between CLI
-// invocations so a successful interactive login (including 2FA) does
-// not have to be repeated on every command for as long as the server
-// keeps the session alive.
-//
-// The store is a single TOML file (sessions.toml) keyed by login,
-// living next to the config file and written with mode 0600. Entries
-// expire client-side via ExpiresAt; the server's session_lifetime is
-// the source of truth, but mirroring it locally lets the CLI skip the
-// KasAuth round trip while a token is still good and refresh it
-// transparently once it is not.
+// This file implements the on-disk session-token cache half of the
+// package. The authoritative package overview lives in doc.go; the
+// blank line below keeps this from being a second package-doc comment.
+
 package session
 
 import (
@@ -44,8 +37,17 @@ type Entry struct {
 	UpdateLifetime  bool      `toml:"update_lifetime"`
 }
 
-// Store reads and writes sessions to a TOML file. The zero value is
-// not usable; obtain one via New.
+// Store persists KasAuth credential tokens between CLI invocations so a
+// successful interactive login (including 2FA) is not repeated on every
+// command for as long as the server keeps the session alive. It is a
+// single TOML file (sessions.toml) keyed by login, living next to the
+// config file and written with mode 0600. Entries expire client-side
+// via ExpiresAt; the server's session_lifetime is the source of truth,
+// but mirroring it locally lets the CLI skip the KasAuth round trip
+// while a token is still good and refresh it transparently once it is
+// not.
+//
+// The zero value is not usable; obtain one via New.
 type Store struct {
 	Path string
 	Now  func() time.Time


### PR DESCRIPTION
Re-review fixes for the `sessions delete` slice (#60 / PR #147):

- S1: `internal/session/store.go` no longer carries a second package-doc comment that duplicated/narrowed `doc.go`; the persistence prose moved onto the `Store` type and `doc.go` is now the sole authoritative package doc.
- S2: `sessions delete` now prints a "cleared the local cache" note on the non-`unknown_session` failure path, so a failed-but-partially-applied state is not silent without `--verbose`.
- N1: `session.Client.Delete` guards against a nil response from a misbehaving Caller.
- N2: `sessions delete --help` states the global `--yes` flag has no effect.