### PR TITLE
fix(cli): truthful session/revoke output and gen-docs user-error exit code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -154,6 +154,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Truthful CLI output and exit-code classification (review follow-up):
+  `kasapi-cli sessions delete` and `config use-profile` no longer claim
+  the local session cache was cleared (or that the server-side session
+  was invalidated) when the underlying `store.Delete` / `delete_session`
+  call actually failed — the message now reflects what really happened,
+  and `sessions delete` returns a non-zero exit when the local cache
+  removal fails instead of swallowing it. `gen-docs` local filesystem
+  failures (`mkdir` / write) now map to the user-error exit code (1)
+  via `UserError` instead of falling through as the API-fault code (2).
+  No behaviour change to the success paths.
+
 - `internal/session/store.go`: serialise `Load` / `Save` / `Delete`
   through an advisory file lock (`github.com/gofrs/flock`) at
   `<sessions.toml>.lock`. Previously two `kasapi-cli` processes running

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -463,15 +463,31 @@ func runConfigUseProfile(ctx context.Context, configPath, name string, revoke re
 					"login", prof.Login, "err", lerr)
 			}
 			if entry != nil && entry.Token != "" {
-				if rerr := revoke(ctx, prof.Login, entry.Token); rerr != nil {
+				rerr := revoke(ctx, prof.Login, entry.Token)
+				if rerr != nil {
 					logger.Warn("config use-profile: server-side revoke failed (continuing)",
 						"login", prof.Login, "err", rerr)
 				}
-				if derr := store.Delete(ctx, prof.Login); derr != nil {
+				derr := store.Delete(ctx, prof.Login)
+				if derr != nil {
 					logger.Warn("config use-profile: session store delete failed",
 						"login", prof.Login, "err", derr)
 				}
-				if _, perr := fmt.Fprintf(w, "Invalidated cached session for %q (login %s)\n", outgoing, prof.Login); perr != nil {
+				// Best-effort: a revoke/cache failure never aborts the
+				// profile switch (see the function doc), but the message
+				// must not imply a success that did not happen.
+				var msg string
+				switch {
+				case rerr == nil && derr == nil:
+					msg = fmt.Sprintf("Invalidated cached session for %q (login %s)\n", outgoing, prof.Login)
+				case rerr != nil && derr == nil:
+					msg = fmt.Sprintf("Cleared the local session cache for %q (login %s); server-side delete_session failed (see --verbose) — continuing\n", outgoing, prof.Login)
+				case rerr == nil && derr != nil:
+					msg = fmt.Sprintf("Revoked the server-side session for %q (login %s); the local cache could NOT be cleared (see --verbose) — continuing\n", outgoing, prof.Login)
+				default:
+					msg = fmt.Sprintf("Could not fully invalidate the cached session for %q (login %s): both server-side delete_session and local cache removal failed (see --verbose) — continuing\n", outgoing, prof.Login)
+				}
+				if _, perr := fmt.Fprint(w, msg); perr != nil {
 					return UserError(perr, "")
 				}
 			}

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -555,6 +555,35 @@ func TestRunConfigUseProfileTolerateServerError(t *testing.T) {
 	}
 }
 
+// TestRunConfigUseProfilePrintsTruthfulLineOnRevokeFailure asserts the
+// user message no longer implies a server-side invalidation that did
+// not happen: the switch still proceeds (best-effort), but the line must
+// disclose the revoke failure instead of "Invalidated cached session".
+func TestRunConfigUseProfilePrintsTruthfulLineOnRevokeFailure(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := twoProfileConfig(t, dir)
+	store, _ := session.New(filepath.Join(dir, "sessions.toml"))
+	if err := store.Save(t.Context(), "w0000000", session.Entry{
+		Token:     "01234567890abcdef0123456789abcdef0123456",
+		ExpiresAt: time.Now().Add(time.Hour),
+	}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	spy := &revokeSpy{wantErr: errors.New("kas_session_invalid")}
+	out := &bytes.Buffer{}
+
+	if err := cli.RunConfigUseProfile(t.Context(), cfgPath, "staging", spy.fn(), store, newDiscardLogger(), out); err != nil {
+		t.Fatalf("switch must not fail on revoke error: %v", err)
+	}
+	got := out.String()
+	if strings.Contains(got, "Invalidated cached session") {
+		t.Errorf("output falsely claims full invalidation despite revoke failure: %q", got)
+	}
+	if !strings.Contains(got, "server-side delete_session failed") {
+		t.Errorf("output must disclose the server-side revoke failure: %q", got)
+	}
+}
+
 func TestRunConfigUseProfileSkipsRevokeWhenNoToken(t *testing.T) {
 	dir := t.TempDir()
 	cfgPath := twoProfileConfig(t, dir)

--- a/internal/cli/gendocs.go
+++ b/internal/cli/gendocs.go
@@ -32,12 +32,12 @@ func NewGenDocsCmd() *cobra.Command {
 			out := args[0]
 			//nolint:gosec // G301: output dir holds public CLI reference docs (docs/cli/), 0o755 is the intentional umask-friendly default.
 			if err := os.MkdirAll(out, 0o755); err != nil {
-				return fmt.Errorf("gen-docs: mkdir %s: %w", out, err)
+				return UserError(fmt.Errorf("gen-docs: mkdir %s: %w", out, err), "")
 			}
 			root := cmd.Root()
 			root.DisableAutoGenTag = true
 			if err := doc.GenMarkdownTree(root, out); err != nil {
-				return fmt.Errorf("gen-docs: write %s: %w", out, err)
+				return UserError(fmt.Errorf("gen-docs: write %s: %w", out, err), "")
 			}
 			return nil
 		},

--- a/internal/cli/gendocs_test.go
+++ b/internal/cli/gendocs_test.go
@@ -54,3 +54,29 @@ func TestGenDocsRequiresOutDirArg(t *testing.T) {
 		t.Fatal("Execute returned nil, want error for missing <out-dir> argument")
 	}
 }
+
+// TestGenDocsMkdirFailureIsUserError verifies a local filesystem failure
+// maps to the user-error exit code (1), not the API-fault code (2): a
+// regular file as the parent of <out-dir> makes os.MkdirAll fail with
+// ENOTDIR, which the command must classify via UserError.
+func TestGenDocsMkdirFailureIsUserError(t *testing.T) {
+	t.Parallel()
+	root, _ := cli.NewRootCmd()
+	root.AddCommand(cli.NewGenDocsCmd())
+
+	f := filepath.Join(t.TempDir(), "not-a-dir")
+	if err := os.WriteFile(f, []byte("x"), 0o600); err != nil {
+		t.Fatalf("seed file: %v", err)
+	}
+	var buf bytes.Buffer
+	root.SetOut(&buf)
+	root.SetErr(&buf)
+	root.SetArgs([]string{"gen-docs", filepath.Join(f, "sub")})
+	err := root.Execute()
+	if err == nil {
+		t.Fatal("Execute returned nil, want a filesystem error")
+	}
+	if got := cli.CodeFor(err); got != cli.ExitUserError {
+		t.Errorf("CodeFor = %d, want ExitUserError (%d); err=%v", got, cli.ExitUserError, err)
+	}
+}

--- a/internal/cli/sessions.go
+++ b/internal/cli/sessions.go
@@ -70,14 +70,15 @@ func newSessionsDeleteCmd(opts *RootOptions) *cobra.Command {
 // the profile's *currently cached* session token and, if present,
 // invalidates it server-side via revoke (delete_session) and removes
 // the on-disk cache entry. The local cache is the authoritative
-// client-side state, so it is cleared whenever a token was found —
-// even if the server-side revoke fails.
+// client-side state, so its removal is attempted whenever a token was
+// found, even if the server-side revoke fails.
 //
 // Unlike the implicit best-effort revoke in `config use-profile`, this
-// explicit command surfaces a real server-side failure: an
-// already-invalid token (unknown_session) is idempotent success, but
-// any other transport/KAS error is returned with a non-zero exit after
-// the local cache has been cleared, so scripts notice.
+// explicit command surfaces real failures so scripts notice: any
+// transport/KAS error other than an already-invalid token
+// (unknown_session, which is idempotent success) returns a non-zero
+// exit, and a local cache-removal failure is reported truthfully and
+// also returns a non-zero exit rather than being silently swallowed.
 func runSessionsDelete(ctx context.Context, opts *RootOptions, revoke revokeFunc, store *session.Store, logger *slog.Logger, w io.Writer) error {
 	creds, err := resolveCreds(opts)
 	if err != nil {
@@ -102,28 +103,42 @@ func runSessionsDelete(ctx context.Context, opts *RootOptions, revoke revokeFunc
 	}
 
 	revokeErr := revoke(ctx, creds.Login, entry.Token)
-	if derr := store.Delete(ctx, creds.Login); derr != nil {
+	derr := store.Delete(ctx, creds.Login)
+	if derr != nil {
 		logger.Warn("sessions delete: session store delete failed",
 			"login", creds.Login, "err", derr)
 	}
 
+	// The local cache message must reflect whether store.Delete actually
+	// succeeded — never claim it was cleared when it was not.
+	cacheNote := "Cleared the local cache."
+	if derr != nil {
+		cacheNote = "The local cache could NOT be cleared (see --verbose)."
+	}
+
 	switch {
 	case revokeErr == nil:
-		if _, perr := fmt.Fprintf(w, "Deleted server-side session for login %s and cleared the local cache\n", creds.Login); perr != nil {
+		if _, perr := fmt.Fprintf(w, "Deleted server-side session for login %s. %s\n", creds.Login, cacheNote); perr != nil {
 			return UserError(perr, "")
+		}
+		if derr != nil {
+			return APIError(derr, "session store delete")
 		}
 		return nil
 	case api.IsCode(revokeErr, api.CodeUnknownSession):
-		logger.Info("sessions delete: token already invalid server-side; cleared local cache",
+		logger.Info("sessions delete: token already invalid server-side",
 			"login", creds.Login)
-		if _, perr := fmt.Fprintf(w, "Session for login %s was already invalid server-side; cleared the local cache\n", creds.Login); perr != nil {
+		if _, perr := fmt.Fprintf(w, "Session for login %s was already invalid server-side. %s\n", creds.Login, cacheNote); perr != nil {
 			return UserError(perr, "")
+		}
+		if derr != nil {
+			return APIError(derr, "session store delete")
 		}
 		return nil
 	default:
-		logger.Warn("sessions delete: server-side revoke failed (local cache cleared)",
+		logger.Warn("sessions delete: server-side revoke failed",
 			"login", creds.Login, "err", revokeErr)
-		if _, perr := fmt.Fprintf(w, "Cleared the local cache for login %s; the server-side delete_session call failed:\n", creds.Login); perr != nil {
+		if _, perr := fmt.Fprintf(w, "Server-side delete_session for login %s failed. %s\n", creds.Login, cacheNote); perr != nil {
 			return UserError(perr, "")
 		}
 		return APIError(revokeErr, "delete_session")

--- a/internal/cli/sessions_test.go
+++ b/internal/cli/sessions_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -235,5 +236,46 @@ func TestSessionsDeleteToleratesUnknownSessionFault(t *testing.T) {
 	}
 	if !strings.Contains(out.String(), "already invalid") {
 		t.Errorf("output missing idempotent note: %q", out.String())
+	}
+}
+
+// TestRunSessionsDeleteReportsLocalCacheDeleteFailure exercises the
+// derr != nil branch: revoke succeeds but the local cache removal fails,
+// so the command must not claim the cache was cleared and must return a
+// non-zero exit instead of swallowing the failure.
+func TestRunSessionsDeleteReportsLocalCacheDeleteFailure(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("cannot exercise an EACCES store-delete failure as root")
+	}
+	clearKASEnv(t)
+	dir := t.TempDir()
+	cfgPath := twoProfileConfig(t, dir)
+	store := storeWithSession(t, dir, "w0000000", fixtureToken)
+	spy := &revokeSpy{} // revoke succeeds
+	out := &bytes.Buffer{}
+
+	// 0500 keeps the dir readable (config.Load + store.Load only read and
+	// open the pre-existing lock file) but blocks store.Delete's
+	// os.Remove(sessions.toml) with EACCES — a deterministic derr.
+	//nolint:gosec // G302: 0500 is a directory mode (deny write to force EACCES on os.Remove), not a file mode.
+	if err := os.Chmod(dir, 0o500); err != nil {
+		t.Fatalf("chmod dir read-only: %v", err)
+	}
+	//nolint:gosec // G302: 0700 restores the temp dir so t.TempDir cleanup can remove it.
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o700) })
+
+	opts := &cli.RootOptions{ConfigPath: cfgPath}
+	err := cli.RunSessionsDelete(t.Context(), opts, spy.fn(), store, newDiscardLogger(), out)
+	if err == nil {
+		t.Fatal("RunSessionsDelete err = nil, want a non-zero exit when local cache delete fails")
+	}
+	if got := cli.CodeFor(err); got != cli.ExitAPIError {
+		t.Errorf("CodeFor = %d, want ExitAPIError (%d); err=%v", got, cli.ExitAPIError, err)
+	}
+	if !strings.Contains(out.String(), "could NOT be cleared") {
+		t.Errorf("output must report the local cache was NOT cleared: %q", out.String())
+	}
+	if strings.Contains(out.String(), "Cleared the local cache.") {
+		t.Errorf("output falsely claims the cache was cleared: %q", out.String())
 	}
 }


### PR DESCRIPTION
Review follow-up (Should #1–#3).

- `sessions delete` / `config use-profile`: the user-facing message no longer claims the local cache was cleared (or the server-side session invalidated) when `store.Delete` / `delete_session` actually failed.
- `sessions delete` now returns a non-zero exit when the local cache removal fails instead of silently swallowing it.
- `gen-docs` local filesystem failures map to the user-error exit code (1) via `UserError` instead of the API-fault code (2).

Success paths unchanged.