### PR TITLE
fix(read): reject ambiguous get results and add transport cancel context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -154,6 +154,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Read-path safety and transport cancellation context (review
+  follow-up): the generic `kasread.ListGet.Get` accessor now returns an
+  explicit `"<label>: %q matched N entries (expected unique)"` error
+  when a singular-variant lookup comes back with more than one entry,
+  instead of silently returning the first — enforcing the documented
+  "single matching entry" contract for every module's `Get`. Transport
+  flood-gate and retry-backoff sleeps that are interrupted by context
+  cancellation now wrap the error with the phase
+  (`flood-gate wait interrupted` / `retry backoff interrupted`) while
+  preserving `errors.Is(err, context.Canceled)`. The `internal/ddns`
+  field-availability comment was corrected to match the captured
+  fixtures (both the list and singular variants return
+  `dyndns_target_ipv4` / `ipv6`).
+
 - Truthful CLI output and exit-code classification (review follow-up):
   `kasapi-cli sessions delete` and `config use-profile` no longer claim
   the local session cache was cleared (or that the server-side session

--- a/internal/ddns/ddns.go
+++ b/internal/ddns/ddns.go
@@ -24,11 +24,12 @@ type Caller = kasread.Caller
 // the response keys use the "dyndns_*" prefix (with `y`). The
 // struct mirrors the wire keys verbatim.
 //
-// The list endpoint returns only the legacy `dyndns_target_ip`;
-// the singular variant additionally returns `dyndns_target_ipv4`
-// and `dyndns_target_ipv6` for explicit dual-stack inspection.
-// Those plus `in_progress` may be absent on either variant, so all
-// three are flagged with omitempty.
+// Per the captured fixtures both variants return the legacy
+// `dyndns_target_ip` alongside the explicit `dyndns_target_ipv4` and
+// `dyndns_target_ipv6` dual-stack fields (see
+// testdata/ddns/get_ddnsuser*_response_success.xml). The ipv4/ipv6
+// pair plus `in_progress` may still be absent on older accounts, so
+// all three are flagged with omitempty.
 type DDNSUser struct {
 	Login    string `json:"dyndns_login" yaml:"dyndns_login"`
 	Password string `json:"dyndns_password,omitempty" yaml:"dyndns_password,omitempty"`

--- a/internal/kasread/kasread.go
+++ b/internal/kasread/kasread.go
@@ -57,10 +57,12 @@ func (lg ListGet[L, E]) List(ctx context.Context) (L, error) {
 	return list, nil
 }
 
-// Get calls Action with {FilterKey: value} and returns the first
-// matching entry, or a "<Label>: %q not found" error if the response
-// carried an empty list. An empty value yields "<Label>: <ArgName>
-// is required" without performing the call.
+// Get calls Action with {FilterKey: value} and returns the single
+// matching entry. An empty response yields a "<Label>: %q not found"
+// error; an ambiguous response with more than one entry yields a
+// "<Label>: %q matched N entries (expected unique)" error rather than
+// silently returning the first. An empty value yields "<Label>:
+// <ArgName> is required" without performing the call.
 func (lg ListGet[L, E]) Get(ctx context.Context, value string) (E, error) {
 	var zero E
 	if value == "" {
@@ -76,6 +78,9 @@ func (lg ListGet[L, E]) Get(ctx context.Context, value string) (E, error) {
 	}
 	if len(list) == 0 {
 		return zero, fmt.Errorf("%s: %q not found", lg.Label, value)
+	}
+	if len(list) > 1 {
+		return zero, fmt.Errorf("%s: %q matched %d entries (expected unique)", lg.Label, value, len(list))
 	}
 	return list[0], nil
 }

--- a/internal/kasread/kasread_test.go
+++ b/internal/kasread/kasread_test.go
@@ -136,3 +136,14 @@ func TestGetPropagatesTransportError(t *testing.T) {
 		t.Errorf("err = %v, want errors.Is == %v", err, want)
 	}
 }
+
+func TestGetRejectsMultipleMatches(t *testing.T) {
+	fc := &testutil.FakeCaller{Resp: arrayResp("dup", "dup")}
+	_, err := newLG(fc).Get(context.Background(), "dup")
+	if err == nil {
+		t.Fatal("expected an ambiguity error for >1 matches, got nil")
+	}
+	if !strings.Contains(err.Error(), "matched 2 entries") {
+		t.Errorf("err = %q, want it to mention 'matched 2 entries'", err)
+	}
+}

--- a/internal/subdomain/subdomain_test.go
+++ b/internal/subdomain/subdomain_test.go
@@ -57,7 +57,20 @@ func TestClientList(t *testing.T) {
 func TestClientGet(t *testing.T) {
 	t.Parallel()
 	resp := testutil.DecodeFixture(t, "subdomain/get_subdomains_response_success.xml")
-	fc := &testutil.FakeCaller{Resp: resp}
+	if resp.Body.ReturnInfo.Kind != soap.KindArray || len(resp.Body.ReturnInfo.Array) == 0 {
+		t.Fatal("fixture is not a non-empty array")
+	}
+	// The captured fixture is the multi-entry list view. The singular
+	// get_subdomains variant (subdomain_name filter) returns the same Map
+	// shape but a single-element array; Get now requires exactly one
+	// match, so feed it the realistic singular cardinality by reusing the
+	// first real entry from the fixture.
+	single := *resp
+	single.Body.ReturnInfo = soap.Value{
+		Kind:  soap.KindArray,
+		Array: resp.Body.ReturnInfo.Array[:1],
+	}
+	fc := &testutil.FakeCaller{Resp: &single}
 	s, err := subdomain.NewClient(fc).Get(context.Background(), "sub1.example.com")
 	if err != nil {
 		t.Fatalf("Get: %v", err)
@@ -68,7 +81,6 @@ func TestClientGet(t *testing.T) {
 	if name, _ := fc.GotParams["subdomain_name"].(string); name != "sub1.example.com" {
 		t.Errorf("params[subdomain_name] = %v, want sub1.example.com", fc.GotParams["subdomain_name"])
 	}
-	// The fixture is the list-view payload; Get unwraps the first entry.
 	if s.Name != "sub1.example.com" {
 		t.Errorf("Name = %q", s.Name)
 	}

--- a/internal/transport/client.go
+++ b/internal/transport/client.go
@@ -100,7 +100,7 @@ func (c *Client) Do(ctx context.Context, endpoint string, body []byte) ([]byte, 
 			c.logger().Info("transport: retry after transient failure",
 				"attempt", attempt, "max", c.MaxRetries, "backoff_ms", backoff.Milliseconds())
 			if err := c.Sleep(ctx, backoff); err != nil {
-				return nil, err
+				return nil, fmt.Errorf("transport: retry backoff interrupted: %w", err)
 			}
 			backoff *= 2
 		}
@@ -128,7 +128,10 @@ func (c *Client) waitGate(ctx context.Context) error {
 		return nil
 	}
 	c.logger().Info("transport: waiting for KasFloodDelay gate", "wait_ms", wait.Milliseconds())
-	return c.Sleep(ctx, wait)
+	if err := c.Sleep(ctx, wait); err != nil {
+		return fmt.Errorf("transport: flood-gate wait interrupted: %w", err)
+	}
+	return nil
 }
 
 func (c *Client) logger() *slog.Logger {

--- a/internal/transport/client_test.go
+++ b/internal/transport/client_test.go
@@ -252,6 +252,32 @@ func TestDoContextCancelDuringBackoff(t *testing.T) {
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("err = %v, want context.Canceled", err)
 	}
+	if !strings.Contains(err.Error(), "retry backoff interrupted") {
+		t.Errorf("err = %q, want it to carry the retry-backoff phase context", err)
+	}
+}
+
+func TestDoContextCancelDuringGateWait(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, "<ok/>")
+	}))
+	defer srv.Close()
+
+	c := transport.New()
+	c.HTTPClient = srv.Client()
+	c.Now = time.Now
+	c.Sleep = func(_ context.Context, _ time.Duration) error {
+		return context.Canceled
+	}
+	c.RecordDelay(500 * time.Millisecond)
+
+	_, err := c.Do(context.Background(), srv.URL, []byte(sampleEnvelope))
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("err = %v, want errors.Is context.Canceled", err)
+	}
+	if !strings.Contains(err.Error(), "flood-gate wait interrupted") {
+		t.Errorf("err = %q, want it to carry the flood-gate-wait phase context", err)
+	}
 }
 
 func TestRecordDelayGatesNextCall(t *testing.T) {


### PR DESCRIPTION
Review follow-up (Should #4 transport-cancel context, #5 ambiguous get; NTH-2/NTH-4 folded in).

- `kasread.ListGet.Get` now returns an explicit ambiguity error on >1 matches instead of silently returning the first, enforcing the documented single-match contract for every module's `Get`.
- Transport flood-gate / retry-backoff sleeps wrap context-cancellation with phase context, preserving `errors.Is(err, context.Canceled)`.
- `internal/ddns` field-availability comment corrected to match the captured fixtures.

Note: `internal/subdomain`'s `TestClientGet` was fed the multi-entry list fixture; it now exercises the realistic single-entry singular cardinality.