### PR TITLE
fix(transport): make flood-delay gate monotonic across overlapping updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -154,6 +154,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Monotonic flood-delay gate (review follow-up):
+  `transport.Client.RecordDelay` now extends the gate to `now+d` only
+  when that is later than an already-pending deadline, instead of
+  unconditionally overwriting it. Previously a shorter `KasFloodDelay`
+  arriving while a longer gate was still active reset the gate to the
+  shorter window, which could let the client resume early and trip the
+  server's flood protection. An explicit zero/negative delay still
+  clears the gate unconditionally (unchanged contract).
+
 - Read-path safety and transport cancellation context (review
   follow-up): the generic `kasread.ListGet.Get` accessor now returns an
   explicit `"<label>: %q matched N entries (expected unique)"` error

--- a/internal/transport/client.go
+++ b/internal/transport/client.go
@@ -70,6 +70,12 @@ func New() *Client {
 // RecordDelay schedules a window during which subsequent calls to Do
 // will block. d is the KasFloodDelay reported by the server in the
 // most recent response. Negative or zero values clear the gate.
+//
+// For a positive d the gate is monotonic: it extends to now+d only
+// when that is later than an already-pending deadline, so a shorter
+// delay arriving while a longer one is still active cannot shorten the
+// active gate (which would risk tripping the server's flood
+// protection). An explicit zero/negative d still clears unconditionally.
 func (c *Client) RecordDelay(d time.Duration) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -77,7 +83,9 @@ func (c *Client) RecordDelay(d time.Duration) {
 		c.nextEarliest = time.Time{}
 		return
 	}
-	c.nextEarliest = c.now().Add(d)
+	if cand := c.now().Add(d); cand.After(c.nextEarliest) {
+		c.nextEarliest = cand
+	}
 }
 
 // Do posts body to endpoint, blocking first until any pending flood

--- a/internal/transport/client_test.go
+++ b/internal/transport/client_test.go
@@ -328,6 +328,51 @@ func TestRecordDelayZeroClears(t *testing.T) {
 	}
 }
 
+func TestRecordDelayKeepsLongerExistingDelay(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, "<ok/>")
+	}))
+	defer srv.Close()
+
+	fc := newFakeClock()
+	c := newClient(srv, fc)
+	// A long gate followed by a shorter one (the fakeClock does not
+	// advance between RecordDelay calls): the shorter delay must not
+	// shorten the still-pending longer gate.
+	c.RecordDelay(time.Second)
+	c.RecordDelay(100 * time.Millisecond)
+
+	if _, err := c.Do(context.Background(), srv.URL, nil); err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	naps := fc.Naps()
+	if len(naps) != 1 || naps[0] != time.Second {
+		t.Errorf("naps = %v, want [1s] (longer gate preserved, not reduced to 100ms)", naps)
+	}
+}
+
+func TestRecordDelayExtendsWhenNewDelayIsLonger(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, "<ok/>")
+	}))
+	defer srv.Close()
+
+	fc := newFakeClock()
+	c := newClient(srv, fc)
+	// A short gate followed by a longer one: the gate must extend to the
+	// later deadline.
+	c.RecordDelay(100 * time.Millisecond)
+	c.RecordDelay(time.Second)
+
+	if _, err := c.Do(context.Background(), srv.URL, nil); err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	naps := fc.Naps()
+	if len(naps) != 1 || naps[0] != time.Second {
+		t.Errorf("naps = %v, want [1s] (gate extended to the longer delay)", naps)
+	}
+}
+
 func TestDoRespectsContextDeadlineDuringRequest(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		<-r.Context().Done()


### PR DESCRIPTION
Review follow-up (Should #4).

`RecordDelay` now extends the flood-delay gate to `now+d` only when that is later than an already-pending deadline, instead of unconditionally overwriting it. A shorter `KasFloodDelay` arriving while a longer gate is still active no longer shortens the gate (which could let the client resume early and trip server-side flood protection). An explicit zero/negative delay still clears the gate unconditionally (contract unchanged).