### PR TITLE
refactor(soap): add strict numeric decoding for required KAS fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Strict numeric decoding for required KAS fields (review follow-up):
+  added `soap.Value.AsIntStrict` / `MapIntStrict` / `MapInt64Strict`,
+  the error-returning siblings of the lenient `AsInt` / `MapInt` /
+  `MapInt64` accessors — a missing key, empty/`xsi:nil`, or non-numeric
+  value yields an error instead of being silently coerced to `0`.
+  Adopted in the account resource-quota decoder (`decodeQuota`): a
+  present quota Map whose mandatory `max`/`reserved`/`created`/`used`/
+  `free` integers are malformed now fails `DecodeAccountResources`
+  rather than misreporting a `0` limit. The lenient accessors are
+  unchanged and remain the right choice for genuinely optional fields;
+  broader per-field adoption is deferred until each field's
+  presence is fixture-verified.
+
 - Repo-consistency pass (post-review): `testdata/statistic/` renamed to
   `testdata/usage/` so the fixture subdirectory matches its module
   (`internal/usage`, CLI `usage`) per the one-subdir-per-module

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   added `soap.Value.AsIntStrict` / `MapIntStrict` / `MapInt64Strict`,
   the error-returning siblings of the lenient `AsInt` / `MapInt` /
   `MapInt64` accessors — a missing key, empty/`xsi:nil`, or non-numeric
-  value yields an error instead of being silently coerced to `0`.
+  value yields an error instead of being silently coerced to `0`;
+  `MapIntStrict` additionally rejects a value that would overflow the
+  platform `int` (32-bit targets) rather than truncating it silently.
   Adopted in the account resource-quota decoder (`decodeQuota`): a
   present quota Map whose mandatory `max`/`reserved`/`created`/`used`/
   `free` integers are malformed now fails `DecodeAccountResources`

--- a/internal/account/account_test.go
+++ b/internal/account/account_test.go
@@ -3,9 +3,11 @@ package account_test
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/chmmou/kasapi-cli/internal/account"
+	"github.com/chmmou/kasapi-cli/internal/soap"
 	"github.com/chmmou/kasapi-cli/internal/testutil"
 )
 
@@ -104,6 +106,30 @@ func TestDecodeAccountResources(t *testing.T) {
 	}
 	if got.MaxMailingList.Max != -1 {
 		t.Errorf("MaxMailingList.Max = %d, want -1", got.MaxMailingList.Max)
+	}
+}
+
+// TestDecodeAccountResourcesRejectsMalformedQuota proves the strict
+// quota path: a present quota Map whose mandatory `max` is non-numeric
+// is a corrupt response and must fail the decode instead of silently
+// reporting a 0 limit.
+func TestDecodeAccountResourcesRejectsMalformedQuota(t *testing.T) {
+	t.Parallel()
+	bad := soap.Value{Kind: soap.KindMap, Map: []soap.KV{
+		{Key: "max_subdomain", Value: soap.Value{Kind: soap.KindMap, Map: []soap.KV{
+			{Key: "max", Value: soap.Value{Kind: soap.KindString, String: "not-a-number"}},
+			{Key: "reserved", Value: soap.Value{Kind: soap.KindInt, Int: 0}},
+			{Key: "created", Value: soap.Value{Kind: soap.KindInt, Int: 0}},
+			{Key: "used", Value: soap.Value{Kind: soap.KindInt, Int: 0}},
+			{Key: "free", Value: soap.Value{Kind: soap.KindInt, Int: 0}},
+		}}},
+	}}
+	_, err := account.DecodeAccountResources(bad)
+	if err == nil {
+		t.Fatal("DecodeAccountResources err = nil, want a strict-quota error for malformed max")
+	}
+	if !strings.Contains(err.Error(), "quota max") {
+		t.Errorf("err = %q, want it to mention 'quota max'", err)
 	}
 }
 

--- a/internal/account/decode.go
+++ b/internal/account/decode.go
@@ -41,7 +41,10 @@ func DecodeAccountResources(returnInfo soap.Value) (AccountResources, error) {
 	}
 	var out AccountResources
 	for _, kv := range returnInfo.Map {
-		q := decodeQuota(kv.Value)
+		q, err := decodeQuota(kv.Value)
+		if err != nil {
+			return AccountResources{}, fmt.Errorf("account: resource %q: %w", kv.Key, err)
+		}
 		switch kv.Key {
 		case "max_subdomain":
 			out.MaxSubdomain = q
@@ -198,18 +201,44 @@ func mapOfStringSlices(m soap.Value) map[string][]string {
 	return out
 }
 
-func decodeQuota(v soap.Value) ResourceQuota {
+// decodeQuota maps a single resource-quota Map. A non-Map slot is "no
+// quota" and yields the zero value without error (lenient, unchanged).
+// When the quota Map is present its five accounting integers are
+// mandatory: a missing or malformed value is a corrupt response and is
+// surfaced as an error rather than silently decoded as 0, which would
+// misreport the account's limits/usage.
+func decodeQuota(v soap.Value) (ResourceQuota, error) {
 	if v.Kind != soap.KindMap {
-		return ResourceQuota{}
+		return ResourceQuota{}, nil
+	}
+	max, err := v.MapIntStrict("max")
+	if err != nil {
+		return ResourceQuota{}, fmt.Errorf("quota max: %w", err)
+	}
+	reserved, err := v.MapIntStrict("reserved")
+	if err != nil {
+		return ResourceQuota{}, fmt.Errorf("quota reserved: %w", err)
+	}
+	created, err := v.MapIntStrict("created")
+	if err != nil {
+		return ResourceQuota{}, fmt.Errorf("quota created: %w", err)
+	}
+	used, err := v.MapIntStrict("used")
+	if err != nil {
+		return ResourceQuota{}, fmt.Errorf("quota used: %w", err)
+	}
+	free, err := v.MapIntStrict("free")
+	if err != nil {
+		return ResourceQuota{}, fmt.Errorf("quota free: %w", err)
 	}
 	return ResourceQuota{
-		Max:      v.MapInt("max"),
+		Max:      max,
 		Exceeded: getBool(v, "exceeded"),
-		Reserved: v.MapInt("reserved"),
-		Created:  v.MapInt("created"),
-		Used:     v.MapInt("used"),
-		Free:     v.MapInt("free"),
-	}
+		Reserved: reserved,
+		Created:  created,
+		Used:     used,
+		Free:     free,
+	}, nil
 }
 
 func getBool(m soap.Value, key string) bool {

--- a/internal/soap/soap_test.go
+++ b/internal/soap/soap_test.go
@@ -282,6 +282,46 @@ func TestValueMapAccessors(t *testing.T) {
 	}
 }
 
+func TestValueStrictIntAccessors(t *testing.T) {
+	m := soap.Value{Kind: soap.KindMap, Map: []soap.KV{
+		{Key: "count", Value: soap.Value{Kind: soap.KindInt, Int: 42}},
+		{Key: "ratio", Value: soap.Value{Kind: soap.KindFloat, Float: 1.9}},
+		{Key: "stringy_int", Value: soap.Value{Kind: soap.KindString, String: " 7 "}},
+		{Key: "blank", Value: soap.Value{Kind: soap.KindString, String: ""}},
+		{Key: "garbage", Value: soap.Value{Kind: soap.KindString, String: "abc"}},
+		{Key: "nil_field", Value: soap.Value{Kind: soap.KindNil}},
+	}}
+
+	// Success cases: typed int, truncated float, parseable string.
+	for _, tc := range []struct {
+		key  string
+		want int
+	}{{"count", 42}, {"ratio", 1}, {"stringy_int", 7}} {
+		got, err := m.MapIntStrict(tc.key)
+		if err != nil {
+			t.Errorf("MapIntStrict(%q) unexpected err: %v", tc.key, err)
+		}
+		if got != tc.want {
+			t.Errorf("MapIntStrict(%q) = %d, want %d", tc.key, got, tc.want)
+		}
+	}
+
+	// Failure cases: every one must error (not silently coerce to 0).
+	for _, key := range []string{"blank", "garbage", "nil_field", "missing"} {
+		if _, err := m.MapInt64Strict(key); err == nil {
+			t.Errorf("MapInt64Strict(%q) err = nil, want a strict error", key)
+		}
+	}
+
+	// Non-numeric kind via AsIntStrict directly.
+	if _, err := (soap.Value{Kind: soap.KindMap}).AsIntStrict(); err == nil {
+		t.Error("AsIntStrict on a Map kind err = nil, want error")
+	}
+	if n, err := (soap.Value{Kind: soap.KindInt, Int: -1}).AsIntStrict(); err != nil || n != -1 {
+		t.Errorf("AsIntStrict(int -1) = (%d, %v), want (-1, nil)", n, err)
+	}
+}
+
 // TestEncodeRequestRequiresFields verifies that EncodeRequest rejects
 // malformed input rather than silently producing an unauthenticated call.
 func TestEncodeRequestRequiresFields(t *testing.T) {

--- a/internal/soap/value.go
+++ b/internal/soap/value.go
@@ -3,6 +3,7 @@ package soap
 import (
 	"encoding/xml"
 	"fmt"
+	"math"
 	"strconv"
 	"strings"
 )
@@ -410,11 +411,16 @@ func (v Value) MapInt64Strict(key string) (int64, error) {
 }
 
 // MapIntStrict is the int form of MapInt64Strict for fields that fit a
-// 32-bit int on all targets.
+// platform int. A value outside [MinInt, MaxInt] (possible on 32-bit
+// targets) is rejected rather than silently truncated — consistent
+// with the strict contract.
 func (v Value) MapIntStrict(key string) (int, error) {
 	n, err := v.MapInt64Strict(key)
 	if err != nil {
 		return 0, err
+	}
+	if n < math.MinInt || n > math.MaxInt {
+		return 0, fmt.Errorf("soap: key %q: value %d overflows platform int", key, n)
 	}
 	return int(n), nil
 }

--- a/internal/soap/value.go
+++ b/internal/soap/value.go
@@ -367,6 +367,58 @@ func (v Value) MapInt64(key string) int64 {
 	return inner.AsInt()
 }
 
+// AsIntStrict is the error-returning form of AsInt for required
+// numeric fields: a malformed, empty, xsi:nil, or non-numeric value
+// yields an error instead of being silently coerced to 0. Int and
+// Float kinds succeed (Float truncates toward zero, as AsInt); a
+// String must parse as a base-10 int64.
+func (v Value) AsIntStrict() (int64, error) {
+	switch v.Kind {
+	case KindInt:
+		return v.Int, nil
+	case KindFloat:
+		return int64(v.Float), nil
+	case KindString:
+		s := strings.TrimSpace(v.String)
+		if s == "" {
+			return 0, fmt.Errorf("soap: empty string is not an integer")
+		}
+		n, err := strconv.ParseInt(s, 10, 64)
+		if err != nil {
+			return 0, fmt.Errorf("soap: %q is not an integer: %w", s, err)
+		}
+		return n, nil
+	}
+	return 0, fmt.Errorf("soap: value kind %d is not an integer", v.Kind)
+}
+
+// MapInt64Strict looks up key in a Map Value and returns the entry via
+// AsIntStrict. A missing key or a value that is not a valid integer
+// yields an error, so callers can enforce required KAS fields instead
+// of silently decoding a malformed response as 0. Use the lenient
+// MapInt64 for optional fields.
+func (v Value) MapInt64Strict(key string) (int64, error) {
+	inner, ok := v.Get(key)
+	if !ok {
+		return 0, fmt.Errorf("soap: missing required key %q", key)
+	}
+	n, err := inner.AsIntStrict()
+	if err != nil {
+		return 0, fmt.Errorf("soap: key %q: %w", key, err)
+	}
+	return n, nil
+}
+
+// MapIntStrict is the int form of MapInt64Strict for fields that fit a
+// 32-bit int on all targets.
+func (v Value) MapIntStrict(key string) (int, error) {
+	n, err := v.MapInt64Strict(key)
+	if err != nil {
+		return 0, err
+	}
+	return int(n), nil
+}
+
 // MapFloat looks up key in a Map Value and returns the entry coerced
 // to float64 via AsFloat. Missing keys yield 0.
 func (v Value) MapFloat(key string) float64 {


### PR DESCRIPTION
Review follow-up (Should #6: silent numeric 0-coercion).

- Adds `soap.Value.AsIntStrict` / `MapIntStrict` / `MapInt64Strict` — error-returning siblings of the lenient int accessors (missing/empty/xsi:nil/non-numeric → error, not silent 0).
- Adopted in the account resource-quota decoder (`decodeQuota`): a corrupt quota Map now fails `DecodeAccountResources` instead of misreporting a 0 limit.
- Lenient accessors unchanged (correct for genuinely optional fields).

Scope note: investigation showed the plan's other named modules (database/softwareinstall) have no `MapInt` fields, and blanket strictness across the remaining modules would risk regressions without per-field fixture proof of mandatory presence. Broader adoption is therefore deferred (documented in the CHANGELOG) — the helper API and the safety-critical quota path are delivered here.