### PR TITLE
fix(cli): classify local session-store delete failure as user error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -169,6 +169,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Exit-code classification for `sessions delete` (re-review
+  follow-up): a failure to remove the local `sessions.toml` entry now
+  exits with the user-error code (1) instead of the API-error code
+  (2). A local cache-removal failure is a client-side problem, not a
+  KAS fault or network failure, so it now matches the same
+  classification the `gen-docs` filesystem failures already use. The
+  truthful "could NOT be cleared" message and the non-zero exit are
+  unchanged; only the code differs.
+
 - Monotonic flood-delay gate (review follow-up):
   `transport.Client.RecordDelay` now extends the gate to `now+d` only
   when that is later than an already-pending deadline, instead of

--- a/internal/cli/sessions.go
+++ b/internal/cli/sessions.go
@@ -76,9 +76,10 @@ func newSessionsDeleteCmd(opts *RootOptions) *cobra.Command {
 // Unlike the implicit best-effort revoke in `config use-profile`, this
 // explicit command surfaces real failures so scripts notice: any
 // transport/KAS error other than an already-invalid token
-// (unknown_session, which is idempotent success) returns a non-zero
+// (unknown_session, which is idempotent success) returns an API-error
 // exit, and a local cache-removal failure is reported truthfully and
-// also returns a non-zero exit rather than being silently swallowed.
+// returns a user-error exit (the local cache is a client-side concern,
+// like a missing config file) rather than being silently swallowed.
 func runSessionsDelete(ctx context.Context, opts *RootOptions, revoke revokeFunc, store *session.Store, logger *slog.Logger, w io.Writer) error {
 	creds, err := resolveCreds(opts)
 	if err != nil {
@@ -122,7 +123,7 @@ func runSessionsDelete(ctx context.Context, opts *RootOptions, revoke revokeFunc
 			return UserError(perr, "")
 		}
 		if derr != nil {
-			return APIError(derr, "session store delete")
+			return UserError(derr, "session store delete")
 		}
 		return nil
 	case api.IsCode(revokeErr, api.CodeUnknownSession):
@@ -132,7 +133,7 @@ func runSessionsDelete(ctx context.Context, opts *RootOptions, revoke revokeFunc
 			return UserError(perr, "")
 		}
 		if derr != nil {
-			return APIError(derr, "session store delete")
+			return UserError(derr, "session store delete")
 		}
 		return nil
 	default:

--- a/internal/cli/sessions_test.go
+++ b/internal/cli/sessions_test.go
@@ -269,8 +269,11 @@ func TestRunSessionsDeleteReportsLocalCacheDeleteFailure(t *testing.T) {
 	if err == nil {
 		t.Fatal("RunSessionsDelete err = nil, want a non-zero exit when local cache delete fails")
 	}
-	if got := cli.CodeFor(err); got != cli.ExitAPIError {
-		t.Errorf("CodeFor = %d, want ExitAPIError (%d); err=%v", got, cli.ExitAPIError, err)
+	// A local sessions.toml removal failure is a client-side problem, not
+	// a KAS/network fault — it maps to the user-error exit (1), the same
+	// classification gen-docs filesystem failures use.
+	if got := cli.CodeFor(err); got != cli.ExitUserError {
+		t.Errorf("CodeFor = %d, want ExitUserError (%d); err=%v", got, cli.ExitUserError, err)
 	}
 	if !strings.Contains(out.String(), "could NOT be cleared") {
 		t.Errorf("output must report the local cache was NOT cleared: %q", out.String())


### PR DESCRIPTION
A failed local `sessions.toml` removal in `sessions delete` now exits with the user-error code (1) instead of the API-error code (2). A local cache-removal failure is a client-side problem, not a KAS fault or network failure, so it matches the classification `gen-docs` filesystem failures already use. The truthful "could NOT be cleared" message and the non-zero exit are unchanged.

From the 2026-05-16 re-review (Should #1).