### PR TITLE
test(mailaccount): align singular fixture login parity and tighten Get

### DIFF
--- a/internal/mailaccount/mailaccount_test.go
+++ b/internal/mailaccount/mailaccount_test.go
@@ -93,8 +93,11 @@ func TestClientGet(t *testing.T) {
 	if got, _ := fc.GotParams["mail_login"].(string); got != "m0000001" {
 		t.Errorf("params[mail_login] = %v, want m0000001", fc.GotParams["mail_login"])
 	}
-	if a.Login == "" {
-		t.Errorf("Login empty")
+	// The returned row must echo the requested login. The singular
+	// fixture's request echo and response row are aligned, so this can
+	// assert equality rather than just non-emptiness.
+	if a.Login != "m0000001" {
+		t.Errorf("Login = %q, want m0000001 (the requested login)", a.Login)
 	}
 }
 

--- a/testdata/mailaccount/get_mailaccount_response_success.xml
+++ b/testdata/mailaccount/get_mailaccount_response_success.xml
@@ -19,7 +19,7 @@
                             <value xsi:type="ns2:Map">
                                 <item>
                                     <key xsi:type="xsd:string">mail_login</key>
-                                    <value xsi:type="xsd:string">m06cdf1d</value>
+                                    <value xsi:type="xsd:string">m0000001</value>
                                 </item>
                             </value>
                         </item>


### PR DESCRIPTION
The singular `get_mailaccount` fixture echoed `mail_login=m06cdf1d` in the request block while the response row carried the anonymised `m0000001`. The request echo is now aligned with the anonymised scheme (also a redaction-hygiene fix), so `TestClientGet` asserts the returned login equals the requested login instead of mere non-emptiness. Response payload is unchanged.

From the 2026-05-16 re-review (former Should #2, reclassified to Nice-to-have — functionally inert, fixture hygiene only).