### PR TITLE
refactor(usage): strict decode for required traffic year/month

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Strict period decoding in `get_traffic` (re-review follow-up):
+  `usage.DecodeTraffic` now decodes the mandatory `year` and `month`
+  fields with `soap.Value.MapIntStrict`, so a missing or non-numeric
+  value yields a decode error instead of a silent `0` that would
+  mislabel the reporting period. Scope is deliberately limited to
+  those two always-present fields: `day` stays lenient (the monthly
+  summary row legitimately omits it) and the `http_`/`ftp_` traffic
+  and hit counters stay lenient (KAS returns `xsi:nil` for a bucket
+  with no data, so a strict reading would turn a real no-traffic
+  response into a hard error). This continues the strict-numeric
+  rollout deferred in the first review follow-up.
+
 - Strict numeric decoding for required KAS fields (review follow-up):
   added `soap.Value.AsIntStrict` / `MapIntStrict` / `MapInt64Strict`,
   the error-returning siblings of the lenient `AsInt` / `MapInt` /

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -202,10 +202,27 @@ func DecodeTraffic(returnInfo soap.Value) (TrafficList, error) {
 		if kv.Value.Kind != soap.KindMap {
 			return nil, fmt.Errorf("usage: ReturnInfo entry %q is not a Map", kv.Key)
 		}
+		// year and month identify the period every traffic row (the
+		// summary and each daily entry) belongs to and are present in
+		// every captured row: a missing or malformed value is a corrupt
+		// response, not a zero, so they are decoded strictly. day stays
+		// lenient on purpose — the monthly summary row (key "0")
+		// legitimately omits it. http_/ftp_traffic and *_hits also stay
+		// lenient: KAS returns xsi:nil for a bucket with no data (the
+		// fixture's ftp_* are nil), so a strict reading would turn a
+		// real no-traffic response into a hard error.
+		year, err := kv.Value.MapIntStrict("year")
+		if err != nil {
+			return nil, fmt.Errorf("usage: traffic entry %q: year: %w", kv.Key, err)
+		}
+		month, err := kv.Value.MapIntStrict("month")
+		if err != nil {
+			return nil, fmt.Errorf("usage: traffic entry %q: month: %w", kv.Key, err)
+		}
 		out = append(out, Traffic{
 			AccountLogin: kv.Value.MapString("account_login"),
-			Year:         kv.Value.MapInt("year"),
-			Month:        kv.Value.MapInt("month"),
+			Year:         year,
+			Month:        month,
 			Day:          kv.Value.MapInt("day"),
 			HTTPTraffic:  kv.Value.MapInt64("http_traffic"),
 			FTPTraffic:   kv.Value.MapInt64("ftp_traffic"),

--- a/internal/usage/usage_test.go
+++ b/internal/usage/usage_test.go
@@ -5,9 +5,23 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/chmmou/kasapi-cli/internal/soap"
 	"github.com/chmmou/kasapi-cli/internal/testutil"
 	"github.com/chmmou/kasapi-cli/internal/usage"
 )
+
+// trafficRow builds a get_traffic ReturnInfo map with a single entry
+// whose year/month carry the given raw string values, so the strict
+// decode of the mandatory period fields can be exercised in isolation.
+func trafficRow(year, month string) soap.Value {
+	return soap.Value{Kind: soap.KindMap, Map: []soap.KV{
+		{Key: "0", Value: soap.Value{Kind: soap.KindMap, Map: []soap.KV{
+			{Key: "account_login", Value: soap.Value{Kind: soap.KindString, String: "w0000001"}},
+			{Key: "year", Value: soap.Value{Kind: soap.KindString, String: year}},
+			{Key: "month", Value: soap.Value{Kind: soap.KindString, String: month}},
+		}}},
+	}}
+}
 
 func TestDecodeSpace(t *testing.T) {
 	t.Parallel()
@@ -99,6 +113,23 @@ func TestDecodeTraffic(t *testing.T) {
 	}
 	if day.IsSummary() {
 		t.Errorf("day.IsSummary() = true, want false")
+	}
+}
+
+func TestDecodeTrafficRejectsMalformedYear(t *testing.T) {
+	t.Parallel()
+	if _, err := usage.DecodeTraffic(trafficRow("abc", "05")); err == nil {
+		t.Fatal("DecodeTraffic err = nil for non-numeric year, want a decode error")
+	}
+	if _, err := usage.DecodeTraffic(trafficRow("2026", "")); err == nil {
+		t.Fatal("DecodeTraffic err = nil for empty month, want a decode error")
+	}
+	got, err := usage.DecodeTraffic(trafficRow("2026", "05"))
+	if err != nil {
+		t.Fatalf("DecodeTraffic on valid period: %v", err)
+	}
+	if len(got) != 1 || got[0].Year != 2026 || got[0].Month != 5 {
+		t.Errorf("got = %+v, want one row with year 2026 month 5", got)
 	}
 }
 


### PR DESCRIPTION
`usage.DecodeTraffic` decoded the always-present `year` and `month` period fields with the lenient `MapInt`, silently yielding `0` on a malformed value and mislabelling the reporting period. They are now decoded with `MapIntStrict` so a parse error surfaces. Scope is deliberately limited to those two always-present fields: `day` stays lenient (the monthly summary row legitimately omits it) and the `http_`/`ftp_` traffic and hit counters stay lenient (KAS returns `xsi:nil` for empty buckets, so a strict reading would turn a real no-traffic response into a hard error). Continues the strict-numeric rollout deferred in the first review follow-up.

From the 2026-05-16 re-review (Nice-to-have #3).