### PR TITLE
refactor(session): typed sentinel for delete_session contract violation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Exported sentinel `session.ErrUnexpectedReturnString` (review
+  follow-up): `session.Client.Delete` now wraps it with `%w` when
+  `delete_session` returns without a SOAP fault but `ReturnString` is
+  not `"TRUE"`, so callers can `errors.Is` the contract violation apart
+  from a transport or KAS-fault error instead of string-matching the
+  message.
+
 - `kasapi-cli sessions delete` invalidates the resolved profile's
   cached session token both server-side (KAS API `delete_session`) and
   in the local `sessions.toml` cache. It acts on the *currently

--- a/internal/session/client.go
+++ b/internal/session/client.go
@@ -2,10 +2,18 @@ package session
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/chmmou/kasapi-cli/internal/kasread"
 )
+
+// ErrUnexpectedReturnString is returned by Delete when delete_session
+// responds without a SOAP fault but ReturnString is not "TRUE" (API
+// drift / contract violation). Callers may errors.Is against it to
+// distinguish a protocol-shape regression from a transport or fault
+// error; the wrapped message carries the observed value.
+var ErrUnexpectedReturnString = errors.New("session: delete_session: unexpected ReturnString (want TRUE)")
 
 // Caller is the subset of *api.Client this package's KAS-side use case
 // depends on. Reusing the shared kasread.Caller keeps tests free of
@@ -40,8 +48,8 @@ func NewClient(c Caller) *Client { return &Client{c: c} }
 // surfaced verbatim by the Caller and returned so the caller can
 // classify it via the api error helpers. On a non-fault response the
 // server echoes ReturnString="TRUE"; any other value is treated as a
-// contract violation so a future API drift fails the mapping test
-// instead of silently passing.
+// contract violation (wrapping ErrUnexpectedReturnString) so a future
+// API drift fails the mapping test instead of silently passing.
 func (cl *Client) Delete(ctx context.Context) error {
 	resp, err := cl.c.Call(ctx, deleteSessionAction, nil)
 	if err != nil {
@@ -51,7 +59,7 @@ func (cl *Client) Delete(ctx context.Context) error {
 		return fmt.Errorf("session: %s: nil response without error from Caller", deleteSessionAction)
 	}
 	if got := resp.Body.ReturnString; got != "TRUE" {
-		return fmt.Errorf("session: %s: unexpected ReturnString %q (want TRUE)", deleteSessionAction, got)
+		return fmt.Errorf("%w: got %q", ErrUnexpectedReturnString, got)
 	}
 	return nil
 }

--- a/internal/session/client_test.go
+++ b/internal/session/client_test.go
@@ -46,7 +46,8 @@ func TestClientDeleteRejectsNonTrueReturnString(t *testing.T) {
 	t.Parallel()
 	resp := &soap.Response{Body: soap.ResponseBody{ReturnString: "FALSE"}}
 	fc := &testutil.FakeCaller{Resp: resp}
-	if err := session.NewClient(fc).Delete(context.Background()); err == nil {
-		t.Error("Delete err = nil, want contract-violation error for ReturnString != TRUE")
+	err := session.NewClient(fc).Delete(context.Background())
+	if !errors.Is(err, session.ErrUnexpectedReturnString) {
+		t.Errorf("Delete err = %v, want wrapped session.ErrUnexpectedReturnString", err)
 	}
 }


### PR DESCRIPTION
Exported `session.ErrUnexpectedReturnString`; `session.Client.Delete` wraps it with `%w` when `delete_session` returns without a SOAP fault but `ReturnString != "TRUE"`, so callers can `errors.Is` the contract violation apart from transport/KAS-fault errors. Existing rejection test tightened to assert the wrapped sentinel.

Part of #155.