### PR TITLE
chore(cli): hide unwired --no-color/--yes flags until they are implemented

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- The global `--no-color` and `--yes` flags are now hidden from
+  `--help` and the generated CLI docs (review follow-up). They were
+  bound but read nowhere — no colourised output is emitted yet and the
+  destructive-write confirmation gate is tracked in #109 — so
+  advertising them implied behaviour that does not exist. They remain
+  parseable (no breaking removal); the owning features will un-hide
+  them when they are wired.
+
 - Strict period decoding in `get_traffic` (re-review follow-up):
   `usage.DecodeTraffic` now decodes the mandatory `year` and `month`
   fields with `soap.Value.MapIntStrict`, so a missing or non-numeric

--- a/docs/cli/kasapi-cli.md
+++ b/docs/cli/kasapi-cli.md
@@ -18,14 +18,12 @@ kasapi-cli [flags]
       --config string                    path to the kasapi-cli config file (overrides the default location)
   -h, --help                             help for kasapi-cli
       --login string                     KAS login (overrides config and KAS_LOGIN)
-      --no-color                         disable coloured output
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)
       --profile string                   profile to select from the config file (overrides default_profile)
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
-  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_accounts.md
+++ b/docs/cli/kasapi-cli_accounts.md
@@ -15,14 +15,12 @@ Inspect KAS accounts owned by the authenticated login
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
       --login string                     KAS login (overrides config and KAS_LOGIN)
-      --no-color                         disable coloured output
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)
       --profile string                   profile to select from the config file (overrides default_profile)
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
-  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_accounts_get.md
+++ b/docs/cli/kasapi-cli_accounts_get.md
@@ -19,14 +19,12 @@ kasapi-cli accounts get <account-login> [flags]
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
       --login string                     KAS login (overrides config and KAS_LOGIN)
-      --no-color                         disable coloured output
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)
       --profile string                   profile to select from the config file (overrides default_profile)
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
-  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_accounts_list.md
+++ b/docs/cli/kasapi-cli_accounts_list.md
@@ -19,14 +19,12 @@ kasapi-cli accounts list [flags]
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
       --login string                     KAS login (overrides config and KAS_LOGIN)
-      --no-color                         disable coloured output
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)
       --profile string                   profile to select from the config file (overrides default_profile)
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
-  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_accounts_resources.md
+++ b/docs/cli/kasapi-cli_accounts_resources.md
@@ -19,14 +19,12 @@ kasapi-cli accounts resources [flags]
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
       --login string                     KAS login (overrides config and KAS_LOGIN)
-      --no-color                         disable coloured output
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)
       --profile string                   profile to select from the config file (overrides default_profile)
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
-  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_accounts_settings.md
+++ b/docs/cli/kasapi-cli_accounts_settings.md
@@ -19,14 +19,12 @@ kasapi-cli accounts settings [flags]
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
       --login string                     KAS login (overrides config and KAS_LOGIN)
-      --no-color                         disable coloured output
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)
       --profile string                   profile to select from the config file (overrides default_profile)
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
-  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_completion.md
+++ b/docs/cli/kasapi-cli_completion.md
@@ -21,14 +21,12 @@ See each sub-command's help for details on how to use the generated script.
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
       --login string                     KAS login (overrides config and KAS_LOGIN)
-      --no-color                         disable coloured output
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)
       --profile string                   profile to select from the config file (overrides default_profile)
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
-  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_completion_bash.md
+++ b/docs/cli/kasapi-cli_completion_bash.md
@@ -44,14 +44,12 @@ kasapi-cli completion bash
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
       --login string                     KAS login (overrides config and KAS_LOGIN)
-      --no-color                         disable coloured output
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)
       --profile string                   profile to select from the config file (overrides default_profile)
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
-  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_completion_fish.md
+++ b/docs/cli/kasapi-cli_completion_fish.md
@@ -35,14 +35,12 @@ kasapi-cli completion fish [flags]
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
       --login string                     KAS login (overrides config and KAS_LOGIN)
-      --no-color                         disable coloured output
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)
       --profile string                   profile to select from the config file (overrides default_profile)
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
-  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_completion_powershell.md
+++ b/docs/cli/kasapi-cli_completion_powershell.md
@@ -32,14 +32,12 @@ kasapi-cli completion powershell [flags]
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
       --login string                     KAS login (overrides config and KAS_LOGIN)
-      --no-color                         disable coloured output
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)
       --profile string                   profile to select from the config file (overrides default_profile)
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
-  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_completion_zsh.md
+++ b/docs/cli/kasapi-cli_completion_zsh.md
@@ -46,14 +46,12 @@ kasapi-cli completion zsh [flags]
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
       --login string                     KAS login (overrides config and KAS_LOGIN)
-      --no-color                         disable coloured output
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)
       --profile string                   profile to select from the config file (overrides default_profile)
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
-  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_config.md
+++ b/docs/cli/kasapi-cli_config.md
@@ -15,14 +15,12 @@ Inspect and bootstrap the kasapi-cli configuration
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
       --login string                     KAS login (overrides config and KAS_LOGIN)
-      --no-color                         disable coloured output
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)
       --profile string                   profile to select from the config file (overrides default_profile)
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
-  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_config_add-profile.md
+++ b/docs/cli/kasapi-cli_config_add-profile.md
@@ -20,14 +20,12 @@ kasapi-cli config add-profile <name> [flags]
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
       --login string                     KAS login (overrides config and KAS_LOGIN)
-      --no-color                         disable coloured output
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)
       --profile string                   profile to select from the config file (overrides default_profile)
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
-  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_config_init.md
+++ b/docs/cli/kasapi-cli_config_init.md
@@ -21,14 +21,12 @@ kasapi-cli config init [flags]
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
       --login string                     KAS login (overrides config and KAS_LOGIN)
-      --no-color                         disable coloured output
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)
       --profile string                   profile to select from the config file (overrides default_profile)
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
-  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_config_list-profiles.md
+++ b/docs/cli/kasapi-cli_config_list-profiles.md
@@ -19,14 +19,12 @@ kasapi-cli config list-profiles [flags]
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
       --login string                     KAS login (overrides config and KAS_LOGIN)
-      --no-color                         disable coloured output
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)
       --profile string                   profile to select from the config file (overrides default_profile)
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
-  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_config_path.md
+++ b/docs/cli/kasapi-cli_config_path.md
@@ -19,14 +19,12 @@ kasapi-cli config path [flags]
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
       --login string                     KAS login (overrides config and KAS_LOGIN)
-      --no-color                         disable coloured output
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)
       --profile string                   profile to select from the config file (overrides default_profile)
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
-  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_config_show.md
+++ b/docs/cli/kasapi-cli_config_show.md
@@ -19,14 +19,12 @@ kasapi-cli config show [flags]
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
       --login string                     KAS login (overrides config and KAS_LOGIN)
-      --no-color                         disable coloured output
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)
       --profile string                   profile to select from the config file (overrides default_profile)
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
-  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_config_use-profile.md
+++ b/docs/cli/kasapi-cli_config_use-profile.md
@@ -19,14 +19,12 @@ kasapi-cli config use-profile <name> [flags]
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
       --login string                     KAS login (overrides config and KAS_LOGIN)
-      --no-color                         disable coloured output
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)
       --profile string                   profile to select from the config file (overrides default_profile)
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
-  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_cronjobs.md
+++ b/docs/cli/kasapi-cli_cronjobs.md
@@ -15,14 +15,12 @@ Inspect cronjobs visible to the login (get_cronjobs)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
       --login string                     KAS login (overrides config and KAS_LOGIN)
-      --no-color                         disable coloured output
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)
       --profile string                   profile to select from the config file (overrides default_profile)
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
-  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_cronjobs_get.md
+++ b/docs/cli/kasapi-cli_cronjobs_get.md
@@ -19,14 +19,12 @@ kasapi-cli cronjobs get <cronjob-id> [flags]
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
       --login string                     KAS login (overrides config and KAS_LOGIN)
-      --no-color                         disable coloured output
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)
       --profile string                   profile to select from the config file (overrides default_profile)
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
-  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_cronjobs_list.md
+++ b/docs/cli/kasapi-cli_cronjobs_list.md
@@ -19,14 +19,12 @@ kasapi-cli cronjobs list [flags]
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
       --login string                     KAS login (overrides config and KAS_LOGIN)
-      --no-color                         disable coloured output
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)
       --profile string                   profile to select from the config file (overrides default_profile)
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
-  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_databases.md
+++ b/docs/cli/kasapi-cli_databases.md
@@ -15,14 +15,12 @@ Inspect databases visible to the login (get_databases)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
       --login string                     KAS login (overrides config and KAS_LOGIN)
-      --no-color                         disable coloured output
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)
       --profile string                   profile to select from the config file (overrides default_profile)
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
-  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_databases_get.md
+++ b/docs/cli/kasapi-cli_databases_get.md
@@ -19,14 +19,12 @@ kasapi-cli databases get <database-login> [flags]
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
       --login string                     KAS login (overrides config and KAS_LOGIN)
-      --no-color                         disable coloured output
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)
       --profile string                   profile to select from the config file (overrides default_profile)
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
-  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_databases_list.md
+++ b/docs/cli/kasapi-cli_databases_list.md
@@ -19,14 +19,12 @@ kasapi-cli databases list [flags]
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
       --login string                     KAS login (overrides config and KAS_LOGIN)
-      --no-color                         disable coloured output
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)
       --profile string                   profile to select from the config file (overrides default_profile)
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
-  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_ddnsusers.md
+++ b/docs/cli/kasapi-cli_ddnsusers.md
@@ -15,14 +15,12 @@ Inspect DDNS users visible to the login (get_ddnsusers)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
       --login string                     KAS login (overrides config and KAS_LOGIN)
-      --no-color                         disable coloured output
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)
       --profile string                   profile to select from the config file (overrides default_profile)
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
-  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_ddnsusers_get.md
+++ b/docs/cli/kasapi-cli_ddnsusers_get.md
@@ -19,14 +19,12 @@ kasapi-cli ddnsusers get <ddns-login> [flags]
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
       --login string                     KAS login (overrides config and KAS_LOGIN)
-      --no-color                         disable coloured output
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)
       --profile string                   profile to select from the config file (overrides default_profile)
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
-  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_ddnsusers_list.md
+++ b/docs/cli/kasapi-cli_ddnsusers_list.md
@@ -19,14 +19,12 @@ kasapi-cli ddnsusers list [flags]
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
       --login string                     KAS login (overrides config and KAS_LOGIN)
-      --no-color                         disable coloured output
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)
       --profile string                   profile to select from the config file (overrides default_profile)
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
-  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_directoryprotection.md
+++ b/docs/cli/kasapi-cli_directoryprotection.md
@@ -15,14 +15,12 @@ Inspect directory (htaccess) protections (get_directoryprotection)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
       --login string                     KAS login (overrides config and KAS_LOGIN)
-      --no-color                         disable coloured output
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)
       --profile string                   profile to select from the config file (overrides default_profile)
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
-  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_directoryprotection_list.md
+++ b/docs/cli/kasapi-cli_directoryprotection_list.md
@@ -20,14 +20,12 @@ kasapi-cli directoryprotection list [flags]
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
       --login string                     KAS login (overrides config and KAS_LOGIN)
-      --no-color                         disable coloured output
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)
       --profile string                   profile to select from the config file (overrides default_profile)
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
-  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_dns.md
+++ b/docs/cli/kasapi-cli_dns.md
@@ -15,14 +15,12 @@ Inspect DNS records for a zone
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
       --login string                     KAS login (overrides config and KAS_LOGIN)
-      --no-color                         disable coloured output
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)
       --profile string                   profile to select from the config file (overrides default_profile)
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
-  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_dns_list.md
+++ b/docs/cli/kasapi-cli_dns_list.md
@@ -21,14 +21,12 @@ kasapi-cli dns list [flags]
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
       --login string                     KAS login (overrides config and KAS_LOGIN)
-      --no-color                         disable coloured output
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)
       --profile string                   profile to select from the config file (overrides default_profile)
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
-  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_domains.md
+++ b/docs/cli/kasapi-cli_domains.md
@@ -15,14 +15,12 @@ Inspect domains owned by the authenticated account
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
       --login string                     KAS login (overrides config and KAS_LOGIN)
-      --no-color                         disable coloured output
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)
       --profile string                   profile to select from the config file (overrides default_profile)
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
-  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_domains_get.md
+++ b/docs/cli/kasapi-cli_domains_get.md
@@ -19,14 +19,12 @@ kasapi-cli domains get <domain-name> [flags]
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
       --login string                     KAS login (overrides config and KAS_LOGIN)
-      --no-color                         disable coloured output
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)
       --profile string                   profile to select from the config file (overrides default_profile)
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
-  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_domains_list.md
+++ b/docs/cli/kasapi-cli_domains_list.md
@@ -19,14 +19,12 @@ kasapi-cli domains list [flags]
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
       --login string                     KAS login (overrides config and KAS_LOGIN)
-      --no-color                         disable coloured output
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)
       --profile string                   profile to select from the config file (overrides default_profile)
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
-  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_ftpusers.md
+++ b/docs/cli/kasapi-cli_ftpusers.md
@@ -15,14 +15,12 @@ Inspect FTP users visible to the login (get_ftpusers)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
       --login string                     KAS login (overrides config and KAS_LOGIN)
-      --no-color                         disable coloured output
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)
       --profile string                   profile to select from the config file (overrides default_profile)
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
-  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_ftpusers_get.md
+++ b/docs/cli/kasapi-cli_ftpusers_get.md
@@ -19,14 +19,12 @@ kasapi-cli ftpusers get <ftp-login> [flags]
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
       --login string                     KAS login (overrides config and KAS_LOGIN)
-      --no-color                         disable coloured output
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)
       --profile string                   profile to select from the config file (overrides default_profile)
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
-  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_ftpusers_list.md
+++ b/docs/cli/kasapi-cli_ftpusers_list.md
@@ -19,14 +19,12 @@ kasapi-cli ftpusers list [flags]
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
       --login string                     KAS login (overrides config and KAS_LOGIN)
-      --no-color                         disable coloured output
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)
       --profile string                   profile to select from the config file (overrides default_profile)
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
-  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_mail.md
+++ b/docs/cli/kasapi-cli_mail.md
@@ -15,14 +15,12 @@ Inspect mail accounts, forwards, filters, and mailing lists
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
       --login string                     KAS login (overrides config and KAS_LOGIN)
-      --no-color                         disable coloured output
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)
       --profile string                   profile to select from the config file (overrides default_profile)
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
-  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_mail_accounts.md
+++ b/docs/cli/kasapi-cli_mail_accounts.md
@@ -15,14 +15,12 @@ Inspect mail accounts (get_mailaccounts)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
       --login string                     KAS login (overrides config and KAS_LOGIN)
-      --no-color                         disable coloured output
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)
       --profile string                   profile to select from the config file (overrides default_profile)
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
-  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_mail_accounts_get.md
+++ b/docs/cli/kasapi-cli_mail_accounts_get.md
@@ -19,14 +19,12 @@ kasapi-cli mail accounts get <mail-login> [flags]
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
       --login string                     KAS login (overrides config and KAS_LOGIN)
-      --no-color                         disable coloured output
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)
       --profile string                   profile to select from the config file (overrides default_profile)
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
-  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_mail_accounts_list.md
+++ b/docs/cli/kasapi-cli_mail_accounts_list.md
@@ -19,14 +19,12 @@ kasapi-cli mail accounts list [flags]
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
       --login string                     KAS login (overrides config and KAS_LOGIN)
-      --no-color                         disable coloured output
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)
       --profile string                   profile to select from the config file (overrides default_profile)
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
-  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_mail_filters.md
+++ b/docs/cli/kasapi-cli_mail_filters.md
@@ -15,14 +15,12 @@ Inspect mail standard filters (get_mailstandardfilter)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
       --login string                     KAS login (overrides config and KAS_LOGIN)
-      --no-color                         disable coloured output
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)
       --profile string                   profile to select from the config file (overrides default_profile)
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
-  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_mail_filters_list.md
+++ b/docs/cli/kasapi-cli_mail_filters_list.md
@@ -19,14 +19,12 @@ kasapi-cli mail filters list [flags]
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
       --login string                     KAS login (overrides config and KAS_LOGIN)
-      --no-color                         disable coloured output
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)
       --profile string                   profile to select from the config file (overrides default_profile)
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
-  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_mail_forwards.md
+++ b/docs/cli/kasapi-cli_mail_forwards.md
@@ -15,14 +15,12 @@ Inspect mail forwards (get_mailforwards)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
       --login string                     KAS login (overrides config and KAS_LOGIN)
-      --no-color                         disable coloured output
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)
       --profile string                   profile to select from the config file (overrides default_profile)
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
-  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_mail_forwards_get.md
+++ b/docs/cli/kasapi-cli_mail_forwards_get.md
@@ -19,14 +19,12 @@ kasapi-cli mail forwards get <mail-forward> [flags]
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
       --login string                     KAS login (overrides config and KAS_LOGIN)
-      --no-color                         disable coloured output
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)
       --profile string                   profile to select from the config file (overrides default_profile)
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
-  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_mail_forwards_list.md
+++ b/docs/cli/kasapi-cli_mail_forwards_list.md
@@ -19,14 +19,12 @@ kasapi-cli mail forwards list [flags]
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
       --login string                     KAS login (overrides config and KAS_LOGIN)
-      --no-color                         disable coloured output
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)
       --profile string                   profile to select from the config file (overrides default_profile)
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
-  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_mail_lists.md
+++ b/docs/cli/kasapi-cli_mail_lists.md
@@ -15,14 +15,12 @@ Inspect mailing lists (get_mailinglists)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
       --login string                     KAS login (overrides config and KAS_LOGIN)
-      --no-color                         disable coloured output
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)
       --profile string                   profile to select from the config file (overrides default_profile)
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
-  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_mail_lists_get.md
+++ b/docs/cli/kasapi-cli_mail_lists_get.md
@@ -19,14 +19,12 @@ kasapi-cli mail lists get <mailinglist-name> [flags]
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
       --login string                     KAS login (overrides config and KAS_LOGIN)
-      --no-color                         disable coloured output
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)
       --profile string                   profile to select from the config file (overrides default_profile)
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
-  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_mail_lists_list.md
+++ b/docs/cli/kasapi-cli_mail_lists_list.md
@@ -19,14 +19,12 @@ kasapi-cli mail lists list [flags]
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
       --login string                     KAS login (overrides config and KAS_LOGIN)
-      --no-color                         disable coloured output
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)
       --profile string                   profile to select from the config file (overrides default_profile)
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
-  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_sambausers.md
+++ b/docs/cli/kasapi-cli_sambausers.md
@@ -15,14 +15,12 @@ Inspect Samba/CIFS users visible to the login (get_sambausers)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
       --login string                     KAS login (overrides config and KAS_LOGIN)
-      --no-color                         disable coloured output
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)
       --profile string                   profile to select from the config file (overrides default_profile)
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
-  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_sambausers_get.md
+++ b/docs/cli/kasapi-cli_sambausers_get.md
@@ -19,14 +19,12 @@ kasapi-cli sambausers get <samba-login> [flags]
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
       --login string                     KAS login (overrides config and KAS_LOGIN)
-      --no-color                         disable coloured output
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)
       --profile string                   profile to select from the config file (overrides default_profile)
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
-  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_sambausers_list.md
+++ b/docs/cli/kasapi-cli_sambausers_list.md
@@ -19,14 +19,12 @@ kasapi-cli sambausers list [flags]
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
       --login string                     KAS login (overrides config and KAS_LOGIN)
-      --no-color                         disable coloured output
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)
       --profile string                   profile to select from the config file (overrides default_profile)
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
-  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_server.md
+++ b/docs/cli/kasapi-cli_server.md
@@ -15,14 +15,12 @@ Inspect the host server kasapi-cli is talking to
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
       --login string                     KAS login (overrides config and KAS_LOGIN)
-      --no-color                         disable coloured output
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)
       --profile string                   profile to select from the config file (overrides default_profile)
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
-  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_server_info.md
+++ b/docs/cli/kasapi-cli_server_info.md
@@ -19,14 +19,12 @@ kasapi-cli server info [flags]
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
       --login string                     KAS login (overrides config and KAS_LOGIN)
-      --no-color                         disable coloured output
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)
       --profile string                   profile to select from the config file (overrides default_profile)
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
-  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_sessions.md
+++ b/docs/cli/kasapi-cli_sessions.md
@@ -21,14 +21,12 @@ add_session is not a separate endpoint — it is the KasAuth credential-token fl
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
       --login string                     KAS login (overrides config and KAS_LOGIN)
-      --no-color                         disable coloured output
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)
       --profile string                   profile to select from the config file (overrides default_profile)
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
-  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_sessions_delete.md
+++ b/docs/cli/kasapi-cli_sessions_delete.md
@@ -25,14 +25,12 @@ kasapi-cli sessions delete [flags]
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
       --login string                     KAS login (overrides config and KAS_LOGIN)
-      --no-color                         disable coloured output
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)
       --profile string                   profile to select from the config file (overrides default_profile)
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
-  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_softwareinstalls.md
+++ b/docs/cli/kasapi-cli_softwareinstalls.md
@@ -15,14 +15,12 @@ Inspect installable software templates (get_softwareinstall)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
       --login string                     KAS login (overrides config and KAS_LOGIN)
-      --no-color                         disable coloured output
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)
       --profile string                   profile to select from the config file (overrides default_profile)
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
-  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_softwareinstalls_get.md
+++ b/docs/cli/kasapi-cli_softwareinstalls_get.md
@@ -19,14 +19,12 @@ kasapi-cli softwareinstalls get <software-id> [flags]
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
       --login string                     KAS login (overrides config and KAS_LOGIN)
-      --no-color                         disable coloured output
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)
       --profile string                   profile to select from the config file (overrides default_profile)
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
-  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_softwareinstalls_list.md
+++ b/docs/cli/kasapi-cli_softwareinstalls_list.md
@@ -19,14 +19,12 @@ kasapi-cli softwareinstalls list [flags]
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
       --login string                     KAS login (overrides config and KAS_LOGIN)
-      --no-color                         disable coloured output
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)
       --profile string                   profile to select from the config file (overrides default_profile)
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
-  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_subdomains.md
+++ b/docs/cli/kasapi-cli_subdomains.md
@@ -15,14 +15,12 @@ Inspect subdomains owned by the authenticated account
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
       --login string                     KAS login (overrides config and KAS_LOGIN)
-      --no-color                         disable coloured output
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)
       --profile string                   profile to select from the config file (overrides default_profile)
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
-  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_subdomains_get.md
+++ b/docs/cli/kasapi-cli_subdomains_get.md
@@ -19,14 +19,12 @@ kasapi-cli subdomains get <subdomain-name> [flags]
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
       --login string                     KAS login (overrides config and KAS_LOGIN)
-      --no-color                         disable coloured output
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)
       --profile string                   profile to select from the config file (overrides default_profile)
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
-  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_subdomains_list.md
+++ b/docs/cli/kasapi-cli_subdomains_list.md
@@ -19,14 +19,12 @@ kasapi-cli subdomains list [flags]
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
       --login string                     KAS login (overrides config and KAS_LOGIN)
-      --no-color                         disable coloured output
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)
       --profile string                   profile to select from the config file (overrides default_profile)
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
-  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_tlds.md
+++ b/docs/cli/kasapi-cli_tlds.md
@@ -15,14 +15,12 @@ Inspect the catalog of registrable top-level domains
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
       --login string                     KAS login (overrides config and KAS_LOGIN)
-      --no-color                         disable coloured output
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)
       --profile string                   profile to select from the config file (overrides default_profile)
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
-  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_tlds_list.md
+++ b/docs/cli/kasapi-cli_tlds_list.md
@@ -19,14 +19,12 @@ kasapi-cli tlds list [flags]
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
       --login string                     KAS login (overrides config and KAS_LOGIN)
-      --no-color                         disable coloured output
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)
       --profile string                   profile to select from the config file (overrides default_profile)
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
-  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_usage.md
+++ b/docs/cli/kasapi-cli_usage.md
@@ -15,14 +15,12 @@ Inspect webspace and traffic counters
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
       --login string                     KAS login (overrides config and KAS_LOGIN)
-      --no-color                         disable coloured output
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)
       --profile string                   profile to select from the config file (overrides default_profile)
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
-  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_usage_space-detail.md
+++ b/docs/cli/kasapi-cli_usage_space-detail.md
@@ -20,14 +20,12 @@ kasapi-cli usage space-detail [flags]
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
       --login string                     KAS login (overrides config and KAS_LOGIN)
-      --no-color                         disable coloured output
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)
       --profile string                   profile to select from the config file (overrides default_profile)
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
-  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_usage_space.md
+++ b/docs/cli/kasapi-cli_usage_space.md
@@ -19,14 +19,12 @@ kasapi-cli usage space [flags]
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
       --login string                     KAS login (overrides config and KAS_LOGIN)
-      --no-color                         disable coloured output
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)
       --profile string                   profile to select from the config file (overrides default_profile)
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
-  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_usage_traffic.md
+++ b/docs/cli/kasapi-cli_usage_traffic.md
@@ -21,14 +21,12 @@ kasapi-cli usage traffic [flags]
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
       --login string                     KAS login (overrides config and KAS_LOGIN)
-      --no-color                         disable coloured output
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)
       --profile string                   profile to select from the config file (overrides default_profile)
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
-  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -91,6 +91,15 @@ func NewRootCmd() (*cobra.Command, *RootOptions) {
 	pf.BoolVarP(&opts.Verbose, "verbose", "v", false, "enable verbose logging on stderr")
 	pf.BoolVarP(&opts.Yes, "yes", "y", false, "skip confirmation prompts on destructive operations")
 
+	// --no-color and --yes are reserved but not yet wired: no colourised
+	// output is emitted today, and the destructive-write confirmation
+	// gate is tracked in issue #109. Keep them parseable (so a future
+	// release can honour them without a breaking flag re-introduction)
+	// but hidden, so --help and the generated docs do not advertise
+	// flags that currently do nothing.
+	_ = pf.MarkHidden("no-color")
+	_ = pf.MarkHidden("yes")
+
 	return cmd, opts
 }
 

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/chmmou/kasapi-cli/internal/cli"
 )
 
-func TestRootHelpListsAllPersistentFlags(t *testing.T) {
+func TestRootHelpListsVisiblePersistentFlags(t *testing.T) {
 	t.Parallel()
 	root, _ := cli.NewRootCmd()
 	var out bytes.Buffer
@@ -21,10 +21,18 @@ func TestRootHelpListsAllPersistentFlags(t *testing.T) {
 	got := out.String()
 	for _, flag := range []string{
 		"--config", "--profile", "--login", "--auth-data", "--auth-type",
-		"--output", "--no-color", "--verbose", "--yes",
+		"--output", "--verbose",
 	} {
 		if !strings.Contains(got, flag) {
 			t.Errorf("help is missing flag %s; got:\n%s", flag, got)
+		}
+	}
+	// --no-color and --yes are reserved but unwired (issue #109): they
+	// stay parseable but must not be advertised in --help until they do
+	// something. TestRootBindsFlagsToOptions still proves they parse.
+	for _, hidden := range []string{"--no-color", "--yes"} {
+		if strings.Contains(got, hidden) {
+			t.Errorf("help advertises unwired flag %s; want it hidden until implemented; got:\n%s", hidden, got)
 		}
 	}
 }


### PR DESCRIPTION
`--no-color` and `--yes` were bound to `RootOptions` but read nowhere — no colourised output is emitted yet and the confirmation gate is tracked in #109. `MarkHidden` keeps them parseable (no breaking removal) but drops them from `--help` and the regenerated `docs/cli/` so the CLI no longer advertises non-existent behaviour.

Part of #155.