### PR TITLE
test: relax brittle fixture-count assertions to non-empty invariants

### DIFF
--- a/internal/account/account_test.go
+++ b/internal/account/account_test.go
@@ -151,8 +151,8 @@ func TestClientList(t *testing.T) {
 	if fc.GotParams != nil {
 		t.Errorf("params = %v, want nil", fc.GotParams)
 	}
-	if len(got) != 4 {
-		t.Errorf("len = %d, want 4", len(got))
+	if len(got) == 0 {
+		t.Errorf("len = %d, want a non-empty result", len(got))
 	}
 }
 

--- a/internal/cronjob/cronjob_test.go
+++ b/internal/cronjob/cronjob_test.go
@@ -128,8 +128,8 @@ func TestClientList(t *testing.T) {
 	if fc.GotParams != nil {
 		t.Errorf("params = %v, want nil", fc.GotParams)
 	}
-	if len(list) != 2 {
-		t.Errorf("len = %d, want 2", len(list))
+	if len(list) == 0 {
+		t.Errorf("len = %d, want a non-empty list", len(list))
 	}
 }
 

--- a/internal/database/database_test.go
+++ b/internal/database/database_test.go
@@ -76,8 +76,8 @@ func TestClientList(t *testing.T) {
 	if fc.GotParams != nil {
 		t.Errorf("params = %v, want nil", fc.GotParams)
 	}
-	if len(list) != 4 {
-		t.Errorf("len = %d, want 4", len(list))
+	if len(list) == 0 {
+		t.Errorf("len = %d, want a non-empty list", len(list))
 	}
 }
 

--- a/internal/ddns/ddns_test.go
+++ b/internal/ddns/ddns_test.go
@@ -114,8 +114,8 @@ func TestClientList(t *testing.T) {
 	if fc.GotParams != nil {
 		t.Errorf("params = %v, want nil", fc.GotParams)
 	}
-	if len(list) != 2 {
-		t.Errorf("len = %d, want 2", len(list))
+	if len(list) == 0 {
+		t.Errorf("len = %d, want a non-empty list", len(list))
 	}
 }
 

--- a/internal/directoryprotection/directoryprotection_test.go
+++ b/internal/directoryprotection/directoryprotection_test.go
@@ -63,8 +63,8 @@ func TestClientListNoFilter(t *testing.T) {
 	if fc.GotParams != nil {
 		t.Errorf("params = %v, want nil", fc.GotParams)
 	}
-	if len(list) != 1 {
-		t.Errorf("len = %d, want 1", len(list))
+	if len(list) == 0 {
+		t.Errorf("len = %d, want a non-empty list", len(list))
 	}
 }
 
@@ -82,8 +82,8 @@ func TestClientListWithPath(t *testing.T) {
 	if got, _ := fc.GotParams["directory_path"].(string); got != "/protected/directory/" {
 		t.Errorf("params[directory_path] = %v", fc.GotParams["directory_path"])
 	}
-	if len(list) != 1 {
-		t.Errorf("len = %d, want 1", len(list))
+	if len(list) == 0 {
+		t.Errorf("len = %d, want a non-empty list", len(list))
 	}
 }
 

--- a/internal/dns/dns_test.go
+++ b/internal/dns/dns_test.go
@@ -66,8 +66,8 @@ func TestClientSettings(t *testing.T) {
 	if _, ok := fc.GotParams["nameserver"]; ok {
 		t.Errorf("params[nameserver] set but nameserver was empty: %v", fc.GotParams)
 	}
-	if len(list) != 6 {
-		t.Errorf("len = %d, want 6", len(list))
+	if len(list) == 0 {
+		t.Errorf("len = %d, want a non-empty list", len(list))
 	}
 }
 

--- a/internal/domain/domain_test.go
+++ b/internal/domain/domain_test.go
@@ -119,8 +119,8 @@ func TestClientList(t *testing.T) {
 	if fc.GotParams != nil {
 		t.Errorf("params = %v, want nil", fc.GotParams)
 	}
-	if len(list) != 2 {
-		t.Errorf("len = %d, want 2", len(list))
+	if len(list) == 0 {
+		t.Errorf("len = %d, want a non-empty list", len(list))
 	}
 }
 
@@ -173,8 +173,8 @@ func TestClientTopLevelDomains(t *testing.T) {
 	if fc.GotAction != "get_topleveldomains" {
 		t.Errorf("action = %q, want get_topleveldomains", fc.GotAction)
 	}
-	if len(list) != 1077 {
-		t.Errorf("len = %d, want 1077", len(list))
+	if len(list) == 0 {
+		t.Errorf("len = %d, want a non-empty list", len(list))
 	}
 }
 

--- a/internal/ftpuser/ftpuser_test.go
+++ b/internal/ftpuser/ftpuser_test.go
@@ -92,8 +92,8 @@ func TestClientList(t *testing.T) {
 	if fc.GotParams != nil {
 		t.Errorf("params = %v, want nil", fc.GotParams)
 	}
-	if len(list) != 5 {
-		t.Errorf("len = %d, want 5", len(list))
+	if len(list) == 0 {
+		t.Errorf("len = %d, want a non-empty list", len(list))
 	}
 }
 

--- a/internal/mailaccount/mailaccount_test.go
+++ b/internal/mailaccount/mailaccount_test.go
@@ -74,8 +74,8 @@ func TestClientList(t *testing.T) {
 	if fc.GotParams != nil {
 		t.Errorf("params = %v, want nil", fc.GotParams)
 	}
-	if len(list) != 15 {
-		t.Errorf("len = %d, want 15", len(list))
+	if len(list) == 0 {
+		t.Errorf("len = %d, want a non-empty list", len(list))
 	}
 }
 

--- a/internal/mailfilter/mailfilter_test.go
+++ b/internal/mailfilter/mailfilter_test.go
@@ -48,8 +48,8 @@ func TestClientList(t *testing.T) {
 	if fc.GotParams != nil {
 		t.Errorf("params = %v, want nil", fc.GotParams)
 	}
-	if len(list) != 9 {
-		t.Errorf("len = %d, want 9", len(list))
+	if len(list) == 0 {
+		t.Errorf("len = %d, want a non-empty list", len(list))
 	}
 }
 

--- a/internal/mailforward/mailforward_test.go
+++ b/internal/mailforward/mailforward_test.go
@@ -64,8 +64,8 @@ func TestClientList(t *testing.T) {
 	if fc.GotParams != nil {
 		t.Errorf("params = %v, want nil", fc.GotParams)
 	}
-	if len(list) != 2 {
-		t.Errorf("len = %d, want 2", len(list))
+	if len(list) == 0 {
+		t.Errorf("len = %d, want a non-empty list", len(list))
 	}
 }
 

--- a/internal/mailinglist/mailinglist_test.go
+++ b/internal/mailinglist/mailinglist_test.go
@@ -61,8 +61,8 @@ func TestClientList(t *testing.T) {
 	if fc.GotParams != nil {
 		t.Errorf("params = %v, want nil", fc.GotParams)
 	}
-	if len(list) != 2 {
-		t.Errorf("len = %d, want 2", len(list))
+	if len(list) == 0 {
+		t.Errorf("len = %d, want a non-empty list", len(list))
 	}
 }
 

--- a/internal/sambauser/sambauser_test.go
+++ b/internal/sambauser/sambauser_test.go
@@ -49,8 +49,8 @@ func TestClientList(t *testing.T) {
 	if fc.GotParams != nil {
 		t.Errorf("params = %v, want nil", fc.GotParams)
 	}
-	if len(list) != 3 {
-		t.Errorf("len = %d, want 3", len(list))
+	if len(list) == 0 {
+		t.Errorf("len = %d, want a non-empty list", len(list))
 	}
 }
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -39,8 +39,8 @@ func TestClientInformation(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Information: %v", err)
 	}
-	if len(list) != 8 {
-		t.Errorf("len = %d, want 8", len(list))
+	if len(list) == 0 {
+		t.Errorf("len = %d, want a non-empty list", len(list))
 	}
 }
 

--- a/internal/softwareinstall/softwareinstall_test.go
+++ b/internal/softwareinstall/softwareinstall_test.go
@@ -87,8 +87,8 @@ func TestClientList(t *testing.T) {
 	if fc.GotParams != nil {
 		t.Errorf("params = %v, want nil", fc.GotParams)
 	}
-	if len(list) != 22 {
-		t.Errorf("len = %d, want 22", len(list))
+	if len(list) == 0 {
+		t.Errorf("len = %d, want a non-empty list", len(list))
 	}
 }
 

--- a/internal/subdomain/subdomain_test.go
+++ b/internal/subdomain/subdomain_test.go
@@ -49,8 +49,8 @@ func TestClientList(t *testing.T) {
 	if fc.GotParams != nil {
 		t.Errorf("params = %v, want nil", fc.GotParams)
 	}
-	if len(list) != 2 {
-		t.Errorf("len = %d, want 2", len(list))
+	if len(list) == 0 {
+		t.Errorf("len = %d, want a non-empty list", len(list))
 	}
 }
 

--- a/internal/usage/usage_test.go
+++ b/internal/usage/usage_test.go
@@ -147,8 +147,8 @@ func TestClientSpace(t *testing.T) {
 	if fc.GotParams != nil {
 		t.Errorf("params = %v, want nil", fc.GotParams)
 	}
-	if len(list) != 5 {
-		t.Errorf("len = %d, want 5", len(list))
+	if len(list) == 0 {
+		t.Errorf("len = %d, want a non-empty list", len(list))
 	}
 }
 


### PR DESCRIPTION
The `TestClient*` smoke tests asserted an exact decoded-slice length with no follow-up content/index check, so refreshing a captured `testdata/*.xml` fixture broke them for no real reason. Relax those bare checks to a non-emptiness invariant; Decode/Tabular tests that gate a subsequent index or content assertion, and the `*_empty_list` variants, are left untouched.

Closes #155.