### PR TITLE
chore(cli): drop reserved --yes mention from sessions delete help

### DIFF
--- a/docs/cli/kasapi-cli_sessions_delete.md
+++ b/docs/cli/kasapi-cli_sessions_delete.md
@@ -6,7 +6,7 @@ Invalidate the active profile's cached session token (delete_session)
 
 Invalidate the resolved profile's cached session token, both server-side (kas_action=delete_session) and in the local sessions.toml cache.
 
-Acts on the *currently cached* token only; it never bootstraps a fresh token just to delete it. Idempotent: a missing or already-invalid session is reported and exits 0. No confirmation prompt — deleting a session merely forces a re-authentication on the next session-mode call; the global --yes flag has no effect here because there is nothing to confirm.
+Acts on the *currently cached* token only; it never bootstraps a fresh token just to delete it. Idempotent: a missing or already-invalid session is reported and exits 0. No confirmation prompt — deleting a session merely forces a re-authentication on the next session-mode call.
 
 ```
 kasapi-cli sessions delete [flags]

--- a/internal/cli/sessions.go
+++ b/internal/cli/sessions.go
@@ -45,8 +45,7 @@ func newSessionsDeleteCmd(opts *RootOptions) *cobra.Command {
 			"fresh token just to delete it. Idempotent: a missing or " +
 			"already-invalid session is reported and exits 0. No confirmation " +
 			"prompt — deleting a session merely forces a re-authentication on " +
-			"the next session-mode call; the global --yes flag has no effect " +
-			"here because there is nothing to confirm.",
+			"the next session-mode call.",
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			logger := buildLogger(opts.Verbose)


### PR DESCRIPTION
PR #161 hid the global `--yes` flag from `--help`/docs until it is wired (#109), but the `sessions delete` long text still explained it ("the global --yes flag has no effect here"), advertising a flag that appears in no flag list. Trim the clause to flag-agnostic wording and regenerate the one affected `docs/cli` page. No behaviour change.

Follow-up to #155 / PR #161.