### PR TITLE
feat(cli): destructive-write confirmation gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Destructive-write confirmation gate (#109, v0.2.0 write-phase
+  prerequisite): the global `--yes` / `-y` flag is now wired and
+  advertised again. New `cli.GateDestructive` enforces an explicit
+  `[y/N]` prompt before any destructive SOAP call — declining or a
+  non-interactive stdin without `--yes` aborts with exit code 1
+  (exported sentinels `cli.ErrConfirmationDeclined` /
+  `cli.ErrConfirmationRequired`, `errors.Is`-able). `--yes` bypasses
+  the prompt for automation. TTY detection is now shared by `config
+  init`/`add-profile` and the gate. The safety contract is documented
+  in `docs/usage/destructive-writes.md`. Per-command wiring lands with
+  the first write endpoint (#13); read commands are unaffected.
+
 - Exported sentinel `session.ErrUnexpectedReturnString` (review
   follow-up): `session.Client.Delete` now wraps it with `%w` when
   `delete_session` returns without a SOAP fault but `ReturnString` is

--- a/docs/cli/kasapi-cli.md
+++ b/docs/cli/kasapi-cli.md
@@ -24,6 +24,7 @@ kasapi-cli [flags]
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
+  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_accounts.md
+++ b/docs/cli/kasapi-cli_accounts.md
@@ -21,6 +21,7 @@ Inspect KAS accounts owned by the authenticated login
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
+  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_accounts_get.md
+++ b/docs/cli/kasapi-cli_accounts_get.md
@@ -25,6 +25,7 @@ kasapi-cli accounts get <account-login> [flags]
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
+  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_accounts_list.md
+++ b/docs/cli/kasapi-cli_accounts_list.md
@@ -25,6 +25,7 @@ kasapi-cli accounts list [flags]
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
+  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_accounts_resources.md
+++ b/docs/cli/kasapi-cli_accounts_resources.md
@@ -25,6 +25,7 @@ kasapi-cli accounts resources [flags]
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
+  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_accounts_settings.md
+++ b/docs/cli/kasapi-cli_accounts_settings.md
@@ -25,6 +25,7 @@ kasapi-cli accounts settings [flags]
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
+  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_completion.md
+++ b/docs/cli/kasapi-cli_completion.md
@@ -27,6 +27,7 @@ See each sub-command's help for details on how to use the generated script.
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
+  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_completion_bash.md
+++ b/docs/cli/kasapi-cli_completion_bash.md
@@ -50,6 +50,7 @@ kasapi-cli completion bash
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
+  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_completion_fish.md
+++ b/docs/cli/kasapi-cli_completion_fish.md
@@ -41,6 +41,7 @@ kasapi-cli completion fish [flags]
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
+  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_completion_powershell.md
+++ b/docs/cli/kasapi-cli_completion_powershell.md
@@ -38,6 +38,7 @@ kasapi-cli completion powershell [flags]
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
+  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_completion_zsh.md
+++ b/docs/cli/kasapi-cli_completion_zsh.md
@@ -52,6 +52,7 @@ kasapi-cli completion zsh [flags]
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
+  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_config.md
+++ b/docs/cli/kasapi-cli_config.md
@@ -21,6 +21,7 @@ Inspect and bootstrap the kasapi-cli configuration
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
+  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_config_add-profile.md
+++ b/docs/cli/kasapi-cli_config_add-profile.md
@@ -26,6 +26,7 @@ kasapi-cli config add-profile <name> [flags]
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
+  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_config_init.md
+++ b/docs/cli/kasapi-cli_config_init.md
@@ -27,6 +27,7 @@ kasapi-cli config init [flags]
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
+  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_config_list-profiles.md
+++ b/docs/cli/kasapi-cli_config_list-profiles.md
@@ -25,6 +25,7 @@ kasapi-cli config list-profiles [flags]
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
+  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_config_path.md
+++ b/docs/cli/kasapi-cli_config_path.md
@@ -25,6 +25,7 @@ kasapi-cli config path [flags]
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
+  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_config_show.md
+++ b/docs/cli/kasapi-cli_config_show.md
@@ -25,6 +25,7 @@ kasapi-cli config show [flags]
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
+  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_config_use-profile.md
+++ b/docs/cli/kasapi-cli_config_use-profile.md
@@ -25,6 +25,7 @@ kasapi-cli config use-profile <name> [flags]
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
+  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_cronjobs.md
+++ b/docs/cli/kasapi-cli_cronjobs.md
@@ -21,6 +21,7 @@ Inspect cronjobs visible to the login (get_cronjobs)
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
+  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_cronjobs_get.md
+++ b/docs/cli/kasapi-cli_cronjobs_get.md
@@ -25,6 +25,7 @@ kasapi-cli cronjobs get <cronjob-id> [flags]
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
+  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_cronjobs_list.md
+++ b/docs/cli/kasapi-cli_cronjobs_list.md
@@ -25,6 +25,7 @@ kasapi-cli cronjobs list [flags]
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
+  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_databases.md
+++ b/docs/cli/kasapi-cli_databases.md
@@ -21,6 +21,7 @@ Inspect databases visible to the login (get_databases)
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
+  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_databases_get.md
+++ b/docs/cli/kasapi-cli_databases_get.md
@@ -25,6 +25,7 @@ kasapi-cli databases get <database-login> [flags]
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
+  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_databases_list.md
+++ b/docs/cli/kasapi-cli_databases_list.md
@@ -25,6 +25,7 @@ kasapi-cli databases list [flags]
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
+  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_ddnsusers.md
+++ b/docs/cli/kasapi-cli_ddnsusers.md
@@ -21,6 +21,7 @@ Inspect DDNS users visible to the login (get_ddnsusers)
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
+  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_ddnsusers_get.md
+++ b/docs/cli/kasapi-cli_ddnsusers_get.md
@@ -25,6 +25,7 @@ kasapi-cli ddnsusers get <ddns-login> [flags]
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
+  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_ddnsusers_list.md
+++ b/docs/cli/kasapi-cli_ddnsusers_list.md
@@ -25,6 +25,7 @@ kasapi-cli ddnsusers list [flags]
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
+  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_directoryprotection.md
+++ b/docs/cli/kasapi-cli_directoryprotection.md
@@ -21,6 +21,7 @@ Inspect directory (htaccess) protections (get_directoryprotection)
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
+  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_directoryprotection_list.md
+++ b/docs/cli/kasapi-cli_directoryprotection_list.md
@@ -26,6 +26,7 @@ kasapi-cli directoryprotection list [flags]
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
+  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_dns.md
+++ b/docs/cli/kasapi-cli_dns.md
@@ -21,6 +21,7 @@ Inspect DNS records for a zone
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
+  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_dns_list.md
+++ b/docs/cli/kasapi-cli_dns_list.md
@@ -27,6 +27,7 @@ kasapi-cli dns list [flags]
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
+  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_domains.md
+++ b/docs/cli/kasapi-cli_domains.md
@@ -21,6 +21,7 @@ Inspect domains owned by the authenticated account
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
+  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_domains_get.md
+++ b/docs/cli/kasapi-cli_domains_get.md
@@ -25,6 +25,7 @@ kasapi-cli domains get <domain-name> [flags]
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
+  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_domains_list.md
+++ b/docs/cli/kasapi-cli_domains_list.md
@@ -25,6 +25,7 @@ kasapi-cli domains list [flags]
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
+  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_ftpusers.md
+++ b/docs/cli/kasapi-cli_ftpusers.md
@@ -21,6 +21,7 @@ Inspect FTP users visible to the login (get_ftpusers)
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
+  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_ftpusers_get.md
+++ b/docs/cli/kasapi-cli_ftpusers_get.md
@@ -25,6 +25,7 @@ kasapi-cli ftpusers get <ftp-login> [flags]
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
+  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_ftpusers_list.md
+++ b/docs/cli/kasapi-cli_ftpusers_list.md
@@ -25,6 +25,7 @@ kasapi-cli ftpusers list [flags]
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
+  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_mail.md
+++ b/docs/cli/kasapi-cli_mail.md
@@ -21,6 +21,7 @@ Inspect mail accounts, forwards, filters, and mailing lists
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
+  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_mail_accounts.md
+++ b/docs/cli/kasapi-cli_mail_accounts.md
@@ -21,6 +21,7 @@ Inspect mail accounts (get_mailaccounts)
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
+  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_mail_accounts_get.md
+++ b/docs/cli/kasapi-cli_mail_accounts_get.md
@@ -25,6 +25,7 @@ kasapi-cli mail accounts get <mail-login> [flags]
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
+  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_mail_accounts_list.md
+++ b/docs/cli/kasapi-cli_mail_accounts_list.md
@@ -25,6 +25,7 @@ kasapi-cli mail accounts list [flags]
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
+  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_mail_filters.md
+++ b/docs/cli/kasapi-cli_mail_filters.md
@@ -21,6 +21,7 @@ Inspect mail standard filters (get_mailstandardfilter)
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
+  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_mail_filters_list.md
+++ b/docs/cli/kasapi-cli_mail_filters_list.md
@@ -25,6 +25,7 @@ kasapi-cli mail filters list [flags]
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
+  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_mail_forwards.md
+++ b/docs/cli/kasapi-cli_mail_forwards.md
@@ -21,6 +21,7 @@ Inspect mail forwards (get_mailforwards)
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
+  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_mail_forwards_get.md
+++ b/docs/cli/kasapi-cli_mail_forwards_get.md
@@ -25,6 +25,7 @@ kasapi-cli mail forwards get <mail-forward> [flags]
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
+  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_mail_forwards_list.md
+++ b/docs/cli/kasapi-cli_mail_forwards_list.md
@@ -25,6 +25,7 @@ kasapi-cli mail forwards list [flags]
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
+  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_mail_lists.md
+++ b/docs/cli/kasapi-cli_mail_lists.md
@@ -21,6 +21,7 @@ Inspect mailing lists (get_mailinglists)
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
+  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_mail_lists_get.md
+++ b/docs/cli/kasapi-cli_mail_lists_get.md
@@ -25,6 +25,7 @@ kasapi-cli mail lists get <mailinglist-name> [flags]
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
+  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_mail_lists_list.md
+++ b/docs/cli/kasapi-cli_mail_lists_list.md
@@ -25,6 +25,7 @@ kasapi-cli mail lists list [flags]
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
+  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_sambausers.md
+++ b/docs/cli/kasapi-cli_sambausers.md
@@ -21,6 +21,7 @@ Inspect Samba/CIFS users visible to the login (get_sambausers)
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
+  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_sambausers_get.md
+++ b/docs/cli/kasapi-cli_sambausers_get.md
@@ -25,6 +25,7 @@ kasapi-cli sambausers get <samba-login> [flags]
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
+  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_sambausers_list.md
+++ b/docs/cli/kasapi-cli_sambausers_list.md
@@ -25,6 +25,7 @@ kasapi-cli sambausers list [flags]
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
+  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_server.md
+++ b/docs/cli/kasapi-cli_server.md
@@ -21,6 +21,7 @@ Inspect the host server kasapi-cli is talking to
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
+  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_server_info.md
+++ b/docs/cli/kasapi-cli_server_info.md
@@ -25,6 +25,7 @@ kasapi-cli server info [flags]
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
+  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_sessions.md
+++ b/docs/cli/kasapi-cli_sessions.md
@@ -27,6 +27,7 @@ add_session is not a separate endpoint — it is the KasAuth credential-token fl
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
+  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_sessions_delete.md
+++ b/docs/cli/kasapi-cli_sessions_delete.md
@@ -31,6 +31,7 @@ kasapi-cli sessions delete [flags]
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
+  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_softwareinstalls.md
+++ b/docs/cli/kasapi-cli_softwareinstalls.md
@@ -21,6 +21,7 @@ Inspect installable software templates (get_softwareinstall)
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
+  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_softwareinstalls_get.md
+++ b/docs/cli/kasapi-cli_softwareinstalls_get.md
@@ -25,6 +25,7 @@ kasapi-cli softwareinstalls get <software-id> [flags]
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
+  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_softwareinstalls_list.md
+++ b/docs/cli/kasapi-cli_softwareinstalls_list.md
@@ -25,6 +25,7 @@ kasapi-cli softwareinstalls list [flags]
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
+  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_subdomains.md
+++ b/docs/cli/kasapi-cli_subdomains.md
@@ -21,6 +21,7 @@ Inspect subdomains owned by the authenticated account
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
+  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_subdomains_get.md
+++ b/docs/cli/kasapi-cli_subdomains_get.md
@@ -25,6 +25,7 @@ kasapi-cli subdomains get <subdomain-name> [flags]
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
+  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_subdomains_list.md
+++ b/docs/cli/kasapi-cli_subdomains_list.md
@@ -25,6 +25,7 @@ kasapi-cli subdomains list [flags]
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
+  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_tlds.md
+++ b/docs/cli/kasapi-cli_tlds.md
@@ -21,6 +21,7 @@ Inspect the catalog of registrable top-level domains
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
+  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_tlds_list.md
+++ b/docs/cli/kasapi-cli_tlds_list.md
@@ -25,6 +25,7 @@ kasapi-cli tlds list [flags]
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
+  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_usage.md
+++ b/docs/cli/kasapi-cli_usage.md
@@ -21,6 +21,7 @@ Inspect webspace and traffic counters
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
+  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_usage_space-detail.md
+++ b/docs/cli/kasapi-cli_usage_space-detail.md
@@ -26,6 +26,7 @@ kasapi-cli usage space-detail [flags]
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
+  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_usage_space.md
+++ b/docs/cli/kasapi-cli_usage_space.md
@@ -25,6 +25,7 @@ kasapi-cli usage space [flags]
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
+  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/cli/kasapi-cli_usage_traffic.md
+++ b/docs/cli/kasapi-cli_usage_traffic.md
@@ -27,6 +27,7 @@ kasapi-cli usage traffic [flags]
       --session-lifetime int             session_lifetime in seconds passed to KasAuth (1..30000); 0 keeps the server default. Requires auth_type=session.
       --session-update-lifetime string   session_update_lifetime passed to KasAuth ('Y' = sliding window, 'N' = fixed). Empty omits the parameter. Requires auth_type=session.
   -v, --verbose                          enable verbose logging on stderr
+  -y, --yes                              skip confirmation prompts on destructive operations
 ```
 
 ### SEE ALSO

--- a/docs/usage/README.md
+++ b/docs/usage/README.md
@@ -17,6 +17,10 @@ For installation, configuration (TOML profiles, env vars, flag precedence), and 
 - [usage](usage.md) — webspace and traffic counters
 - [hosting](hosting.md) — FTP / Samba users, cronjobs, directory protection, software installs, DDNS users
 
+## Safety
+
+- [destructive-writes](destructive-writes.md) — the confirmation contract for irreversible write commands (`[y/N]` prompt, `--yes`/`-y` bypass, non-interactive behaviour, exit codes).
+
 ## Conventions used in the examples
 
 - `-o json` / `-o yaml` / `-o table` selects the output format. Default is `table`.

--- a/docs/usage/destructive-writes.md
+++ b/docs/usage/destructive-writes.md
@@ -1,0 +1,55 @@
+# Destructive-write safety contract
+
+The write surface of the KAS API is irreversible: `delete_*`, `reset_*`,
+`move_*`, `update_chown` and similar actions cannot be undone from the
+client. `kasapi-cli` therefore gates every destructive subcommand behind
+an explicit confirmation before the SOAP call is dispatched.
+
+This page documents the behavioural contract (issue
+[#109](https://github.com/chmmou/kasapi-cli/issues/109), part of the
+v0.2.0 write phase, [#13](https://github.com/chmmou/kasapi-cli/issues/13)).
+The read commands shipping today are non-destructive and are not gated.
+
+## The contract
+
+Before a destructive call leaves the machine, the command prints a
+one-line summary of the pending change and asks for confirmation:
+
+```
+About to delete mail account "m0000001". This cannot be undone.
+Proceed? [y/N]:
+```
+
+- Only an explicit `y` / `yes` (case-insensitive) proceeds. Empty input
+  or anything else aborts.
+- Declining exits with code **1** (user error); nothing is sent to KAS.
+
+## `--yes` / `-y`
+
+The global `--yes` (`-y`) flag bypasses the prompt for automation that
+has already decided to proceed:
+
+```sh
+kasapi-cli <destructive-command> --yes
+```
+
+## Non-interactive stdin
+
+If stdin is not a terminal (pipe, cron, CI) **and** `--yes` was not
+given, the command refuses with exit code **1** rather than blocking on
+a prompt that can never be answered. Pass `--yes` to run such a command
+non-interactively.
+
+| stdin | `--yes` | result |
+|-------|---------|--------|
+| TTY   | no      | prompt; proceed only on `y`/`yes`, else exit 1 |
+| TTY   | yes     | proceed without prompting |
+| not a TTY | no  | exit 1 (`refusing destructive operation`) |
+| not a TTY | yes | proceed without prompting |
+
+## Previewing instead of confirming
+
+A `--dry-run` flag that prints the exact KAS action and parameter map
+without dispatching anything is planned separately
+([#132](https://github.com/chmmou/kasapi-cli/issues/132)); it will
+short-circuit this prompt because nothing destructive happens.

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -141,12 +141,12 @@ type configIO struct {
 }
 
 func defaultConfigIO() configIO {
-	//nolint:gosec // G115: file descriptors fit in int on every platform Go targets; term.IsTerminal/term.ReadPassword take int.
+	//nolint:gosec // G115: file descriptors fit in int on every platform Go targets; term.ReadPassword takes int.
 	stdinFD := int(os.Stdin.Fd())
 	return configIO{
 		In:    os.Stdin,
 		Out:   os.Stdout,
-		IsTTY: func() bool { return term.IsTerminal(stdinFD) },
+		IsTTY: stdinIsTTY,
 		ReadPassword: func() (string, error) {
 			b, err := term.ReadPassword(stdinFD)
 			if _, perr := fmt.Fprintln(os.Stdout); perr != nil && err == nil {

--- a/internal/cli/confirm.go
+++ b/internal/cli/confirm.go
@@ -5,7 +5,10 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"strings"
+
+	"golang.org/x/term"
 )
 
 // Confirm prompts the user on out with prompt + " [y/N]: " and reads a
@@ -30,4 +33,66 @@ func Confirm(in io.Reader, out io.Writer, prompt string) (bool, error) {
 	default:
 		return false, nil
 	}
+}
+
+// stdinIsTTY reports whether the process stdin is an interactive
+// terminal. It is the single source of truth for TTY detection in this
+// package (config init/add-profile and the destructive-write gate all
+// share it) so the platform-specific cast lives in exactly one place.
+func stdinIsTTY() bool {
+	//nolint:gosec // G115: file descriptors fit in int on every platform Go targets; term.IsTerminal takes int.
+	return term.IsTerminal(int(os.Stdin.Fd()))
+}
+
+// ErrConfirmationDeclined is returned by GateDestructive when the user
+// answered the [y/N] prompt with anything other than yes. It is wrapped
+// in an ExitError(ExitUserError); callers may errors.Is against it to
+// distinguish a deliberate abort from an input/transport failure.
+var ErrConfirmationDeclined = errors.New("cli: destructive operation cancelled by user")
+
+// ErrConfirmationRequired is returned by GateDestructive when stdin is
+// not an interactive terminal and --yes was not given, so no prompt can
+// be shown. It maps to ExitUserError: the caller must either run
+// interactively or pass --yes to proceed non-interactively.
+var ErrConfirmationRequired = errors.New("cli: refusing destructive operation: stdin is not a TTY and --yes was not given")
+
+// ConfirmAction is the one-line description of a pending destructive
+// change, shown to the user before the [y/N] prompt: "About to <Verb>
+// <Resource> \"<ID>\". This cannot be undone."
+type ConfirmAction struct {
+	Verb     string // imperative, e.g. "delete", "reset", "move"
+	Resource string // human resource type, e.g. "mail account", "DNS record"
+	ID       string // identifier of the target resource
+}
+
+func (a ConfirmAction) summary() string {
+	return fmt.Sprintf("About to %s %s %q. This cannot be undone.", a.Verb, a.Resource, a.ID)
+}
+
+// GateDestructive enforces the confirmation contract for a destructive
+// command before its SOAP call is dispatched. yes is opts.Yes; isTTY is
+// stdinIsTTY() (injected so tests need no real terminal).
+//
+//   - yes == true            → proceed silently (automation opted in).
+//   - !isTTY (and !yes)      → ErrConfirmationRequired, no prompt.
+//   - interactive, declined  → ErrConfirmationDeclined.
+//   - interactive, accepted  → nil.
+//
+// The non-nil returns are *ExitError(ExitUserError) so CodeFor maps a
+// declined or impossible confirmation to exit code 1.
+func GateDestructive(in io.Reader, out io.Writer, isTTY, yes bool, a ConfirmAction) error {
+	if yes {
+		return nil
+	}
+	if !isTTY {
+		return UserError(ErrConfirmationRequired, "")
+	}
+	ok, err := Confirm(in, out, a.summary())
+	if err != nil {
+		return UserError(err, "confirm")
+	}
+	if !ok {
+		return UserError(ErrConfirmationDeclined, "")
+	}
+	return nil
 }

--- a/internal/cli/confirm_test.go
+++ b/internal/cli/confirm_test.go
@@ -2,6 +2,7 @@ package cli_test
 
 import (
 	"bytes"
+	"errors"
 	"strings"
 	"testing"
 
@@ -38,5 +39,48 @@ func TestConfirm(t *testing.T) {
 		if !strings.Contains(out.String(), "delete? [y/N]:") {
 			t.Errorf("Confirm(%q) prompt missing: %q", tt.input, out.String())
 		}
+	}
+}
+
+func TestGateDestructive(t *testing.T) {
+	t.Parallel()
+	action := cli.ConfirmAction{Verb: "delete", Resource: "mail account", ID: "m0000001"}
+
+	tests := []struct {
+		name       string
+		input      string
+		isTTY      bool
+		yes        bool
+		wantErr    error // nil = proceed
+		wantPrompt bool  // whether the [y/N] summary must appear on out
+	}{
+		{name: "accepted", input: "y\n", isTTY: true, yes: false, wantErr: nil, wantPrompt: true},
+		{name: "declined", input: "n\n", isTTY: true, yes: false, wantErr: cli.ErrConfirmationDeclined, wantPrompt: true},
+		{name: "empty declines", input: "\n", isTTY: true, yes: false, wantErr: cli.ErrConfirmationDeclined, wantPrompt: true},
+		{name: "yes bypasses prompt", input: "", isTTY: false, yes: true, wantErr: nil, wantPrompt: false},
+		{name: "non-tty without yes", input: "", isTTY: false, yes: false, wantErr: cli.ErrConfirmationRequired, wantPrompt: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var out bytes.Buffer
+			err := cli.GateDestructive(strings.NewReader(tt.input), &out, tt.isTTY, tt.yes, action)
+			if tt.wantErr == nil {
+				if err != nil {
+					t.Errorf("GateDestructive() = %v, want nil (proceed)", err)
+				}
+			} else {
+				if !errors.Is(err, tt.wantErr) {
+					t.Errorf("GateDestructive() = %v, want wrapped %v", err, tt.wantErr)
+				}
+				if got := cli.CodeFor(err); got != cli.ExitUserError {
+					t.Errorf("CodeFor = %d, want ExitUserError (%d)", got, cli.ExitUserError)
+				}
+			}
+			hasPrompt := strings.Contains(out.String(), `About to delete mail account "m0000001". This cannot be undone.`)
+			if hasPrompt != tt.wantPrompt {
+				t.Errorf("prompt shown = %v, want %v; out=%q", hasPrompt, tt.wantPrompt, out.String())
+			}
+		})
 	}
 }

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -91,14 +91,13 @@ func NewRootCmd() (*cobra.Command, *RootOptions) {
 	pf.BoolVarP(&opts.Verbose, "verbose", "v", false, "enable verbose logging on stderr")
 	pf.BoolVarP(&opts.Yes, "yes", "y", false, "skip confirmation prompts on destructive operations")
 
-	// --no-color and --yes are reserved but not yet wired: no colourised
-	// output is emitted today, and the destructive-write confirmation
-	// gate is tracked in issue #109. Keep them parseable (so a future
-	// release can honour them without a breaking flag re-introduction)
-	// but hidden, so --help and the generated docs do not advertise
-	// flags that currently do nothing.
+	// --yes is wired: it is honoured by the destructive-write
+	// confirmation gate (issue #109, cli.GateDestructive). --no-color
+	// stays reserved but hidden: no colourised output is emitted yet, so
+	// advertising it would imply behaviour that does not exist. It stays
+	// parseable so a future release can honour it without a breaking
+	// flag re-introduction.
 	_ = pf.MarkHidden("no-color")
-	_ = pf.MarkHidden("yes")
 
 	return cmd, opts
 }

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -21,19 +21,18 @@ func TestRootHelpListsVisiblePersistentFlags(t *testing.T) {
 	got := out.String()
 	for _, flag := range []string{
 		"--config", "--profile", "--login", "--auth-data", "--auth-type",
-		"--output", "--verbose",
+		"--output", "--verbose", "--yes",
 	} {
 		if !strings.Contains(got, flag) {
 			t.Errorf("help is missing flag %s; got:\n%s", flag, got)
 		}
 	}
-	// --no-color and --yes are reserved but unwired (issue #109): they
-	// stay parseable but must not be advertised in --help until they do
-	// something. TestRootBindsFlagsToOptions still proves they parse.
-	for _, hidden := range []string{"--no-color", "--yes"} {
-		if strings.Contains(got, hidden) {
-			t.Errorf("help advertises unwired flag %s; want it hidden until implemented; got:\n%s", hidden, got)
-		}
+	// --yes is now wired (issue #109, destructive-write gate) so it is
+	// advertised again. --no-color stays reserved/unwired and must not
+	// be advertised in --help yet. TestRootBindsFlagsToOptions still
+	// proves --no-color parses.
+	if strings.Contains(got, "--no-color") {
+		t.Errorf("help advertises unwired flag --no-color; want it hidden until implemented; got:\n%s", got)
 	}
 }
 


### PR DESCRIPTION
Wires the global `--yes`/`-y` flag (un-hidden) and adds `cli.GateDestructive` — a reusable confirmation gate future #13 destructive commands call before dispatch. Default: explicit `[y/N]` prompt; `--yes` bypasses; non-interactive stdin without `--yes` refuses with exit 1 (errors.Is-able sentinels `ErrConfirmationDeclined`/`ErrConfirmationRequired`). TTY detection consolidated into one shared helper. Safety contract in `docs/usage/destructive-writes.md`; `docs/cli` regenerated.

No end-to-end command wiring yet (no #13 write endpoint exists; `sessions delete` is intentionally prompt-free) — that acceptance box transfers to the first write-command PR.

Refs #109.