### PR TITLE
feat(cli): structured write-action audit log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Structured write-action audit log (#131, v0.2.0 write-phase
+  prerequisite): `cli.AuditRecord` + `cli.WriteAudit` emit one
+  `logfmt`-style line per dispatched write action to stderr — always
+  on, independent of `--verbose` — with RFC 3339 timestamp, resolved
+  login, KAS action, target, `outcome` (`success` /
+  `failure:<kas_code>` / `failure`), and correlating fields. The new
+  global `--audit-log <path>` flag (and `KAS_AUDIT_LOG`; the flag wins)
+  additionally appends each record as JSON Lines to a `0600` file.
+  Secret parameters (`auth_data`, `*password`, `*token`, `*secret`, …)
+  are redacted in both sinks via `cli.RedactParams`. Documented in
+  `docs/usage/destructive-writes.md`. Per-command emission lands with
+  the first write endpoint (#13); read commands are unaffected.
+
 - Destructive-write confirmation gate (#109, v0.2.0 write-phase
   prerequisite): the global `--yes` / `-y` flag is now wired and
   advertised again. New `cli.GateDestructive` enforces an explicit

--- a/docs/cli/kasapi-cli.md
+++ b/docs/cli/kasapi-cli.md
@@ -13,6 +13,7 @@ kasapi-cli [flags]
 ### Options
 
 ```
+      --audit-log string                 append a JSON-Lines audit record for each write action to this file (also KAS_AUDIT_LOG); a logfmt line always goes to stderr regardless
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)

--- a/docs/cli/kasapi-cli_accounts.md
+++ b/docs/cli/kasapi-cli_accounts.md
@@ -11,6 +11,7 @@ Inspect KAS accounts owned by the authenticated login
 ### Options inherited from parent commands
 
 ```
+      --audit-log string                 append a JSON-Lines audit record for each write action to this file (also KAS_AUDIT_LOG); a logfmt line always goes to stderr regardless
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)

--- a/docs/cli/kasapi-cli_accounts_get.md
+++ b/docs/cli/kasapi-cli_accounts_get.md
@@ -15,6 +15,7 @@ kasapi-cli accounts get <account-login> [flags]
 ### Options inherited from parent commands
 
 ```
+      --audit-log string                 append a JSON-Lines audit record for each write action to this file (also KAS_AUDIT_LOG); a logfmt line always goes to stderr regardless
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)

--- a/docs/cli/kasapi-cli_accounts_list.md
+++ b/docs/cli/kasapi-cli_accounts_list.md
@@ -15,6 +15,7 @@ kasapi-cli accounts list [flags]
 ### Options inherited from parent commands
 
 ```
+      --audit-log string                 append a JSON-Lines audit record for each write action to this file (also KAS_AUDIT_LOG); a logfmt line always goes to stderr regardless
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)

--- a/docs/cli/kasapi-cli_accounts_resources.md
+++ b/docs/cli/kasapi-cli_accounts_resources.md
@@ -15,6 +15,7 @@ kasapi-cli accounts resources [flags]
 ### Options inherited from parent commands
 
 ```
+      --audit-log string                 append a JSON-Lines audit record for each write action to this file (also KAS_AUDIT_LOG); a logfmt line always goes to stderr regardless
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)

--- a/docs/cli/kasapi-cli_accounts_settings.md
+++ b/docs/cli/kasapi-cli_accounts_settings.md
@@ -15,6 +15,7 @@ kasapi-cli accounts settings [flags]
 ### Options inherited from parent commands
 
 ```
+      --audit-log string                 append a JSON-Lines audit record for each write action to this file (also KAS_AUDIT_LOG); a logfmt line always goes to stderr regardless
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)

--- a/docs/cli/kasapi-cli_completion.md
+++ b/docs/cli/kasapi-cli_completion.md
@@ -17,6 +17,7 @@ See each sub-command's help for details on how to use the generated script.
 ### Options inherited from parent commands
 
 ```
+      --audit-log string                 append a JSON-Lines audit record for each write action to this file (also KAS_AUDIT_LOG); a logfmt line always goes to stderr regardless
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)

--- a/docs/cli/kasapi-cli_completion_bash.md
+++ b/docs/cli/kasapi-cli_completion_bash.md
@@ -40,6 +40,7 @@ kasapi-cli completion bash
 ### Options inherited from parent commands
 
 ```
+      --audit-log string                 append a JSON-Lines audit record for each write action to this file (also KAS_AUDIT_LOG); a logfmt line always goes to stderr regardless
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)

--- a/docs/cli/kasapi-cli_completion_fish.md
+++ b/docs/cli/kasapi-cli_completion_fish.md
@@ -31,6 +31,7 @@ kasapi-cli completion fish [flags]
 ### Options inherited from parent commands
 
 ```
+      --audit-log string                 append a JSON-Lines audit record for each write action to this file (also KAS_AUDIT_LOG); a logfmt line always goes to stderr regardless
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)

--- a/docs/cli/kasapi-cli_completion_powershell.md
+++ b/docs/cli/kasapi-cli_completion_powershell.md
@@ -28,6 +28,7 @@ kasapi-cli completion powershell [flags]
 ### Options inherited from parent commands
 
 ```
+      --audit-log string                 append a JSON-Lines audit record for each write action to this file (also KAS_AUDIT_LOG); a logfmt line always goes to stderr regardless
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)

--- a/docs/cli/kasapi-cli_completion_zsh.md
+++ b/docs/cli/kasapi-cli_completion_zsh.md
@@ -42,6 +42,7 @@ kasapi-cli completion zsh [flags]
 ### Options inherited from parent commands
 
 ```
+      --audit-log string                 append a JSON-Lines audit record for each write action to this file (also KAS_AUDIT_LOG); a logfmt line always goes to stderr regardless
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)

--- a/docs/cli/kasapi-cli_config.md
+++ b/docs/cli/kasapi-cli_config.md
@@ -11,6 +11,7 @@ Inspect and bootstrap the kasapi-cli configuration
 ### Options inherited from parent commands
 
 ```
+      --audit-log string                 append a JSON-Lines audit record for each write action to this file (also KAS_AUDIT_LOG); a logfmt line always goes to stderr regardless
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)

--- a/docs/cli/kasapi-cli_config_add-profile.md
+++ b/docs/cli/kasapi-cli_config_add-profile.md
@@ -16,6 +16,7 @@ kasapi-cli config add-profile <name> [flags]
 ### Options inherited from parent commands
 
 ```
+      --audit-log string                 append a JSON-Lines audit record for each write action to this file (also KAS_AUDIT_LOG); a logfmt line always goes to stderr regardless
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)

--- a/docs/cli/kasapi-cli_config_init.md
+++ b/docs/cli/kasapi-cli_config_init.md
@@ -17,6 +17,7 @@ kasapi-cli config init [flags]
 ### Options inherited from parent commands
 
 ```
+      --audit-log string                 append a JSON-Lines audit record for each write action to this file (also KAS_AUDIT_LOG); a logfmt line always goes to stderr regardless
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)

--- a/docs/cli/kasapi-cli_config_list-profiles.md
+++ b/docs/cli/kasapi-cli_config_list-profiles.md
@@ -15,6 +15,7 @@ kasapi-cli config list-profiles [flags]
 ### Options inherited from parent commands
 
 ```
+      --audit-log string                 append a JSON-Lines audit record for each write action to this file (also KAS_AUDIT_LOG); a logfmt line always goes to stderr regardless
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)

--- a/docs/cli/kasapi-cli_config_path.md
+++ b/docs/cli/kasapi-cli_config_path.md
@@ -15,6 +15,7 @@ kasapi-cli config path [flags]
 ### Options inherited from parent commands
 
 ```
+      --audit-log string                 append a JSON-Lines audit record for each write action to this file (also KAS_AUDIT_LOG); a logfmt line always goes to stderr regardless
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)

--- a/docs/cli/kasapi-cli_config_show.md
+++ b/docs/cli/kasapi-cli_config_show.md
@@ -15,6 +15,7 @@ kasapi-cli config show [flags]
 ### Options inherited from parent commands
 
 ```
+      --audit-log string                 append a JSON-Lines audit record for each write action to this file (also KAS_AUDIT_LOG); a logfmt line always goes to stderr regardless
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)

--- a/docs/cli/kasapi-cli_config_use-profile.md
+++ b/docs/cli/kasapi-cli_config_use-profile.md
@@ -15,6 +15,7 @@ kasapi-cli config use-profile <name> [flags]
 ### Options inherited from parent commands
 
 ```
+      --audit-log string                 append a JSON-Lines audit record for each write action to this file (also KAS_AUDIT_LOG); a logfmt line always goes to stderr regardless
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)

--- a/docs/cli/kasapi-cli_cronjobs.md
+++ b/docs/cli/kasapi-cli_cronjobs.md
@@ -11,6 +11,7 @@ Inspect cronjobs visible to the login (get_cronjobs)
 ### Options inherited from parent commands
 
 ```
+      --audit-log string                 append a JSON-Lines audit record for each write action to this file (also KAS_AUDIT_LOG); a logfmt line always goes to stderr regardless
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)

--- a/docs/cli/kasapi-cli_cronjobs_get.md
+++ b/docs/cli/kasapi-cli_cronjobs_get.md
@@ -15,6 +15,7 @@ kasapi-cli cronjobs get <cronjob-id> [flags]
 ### Options inherited from parent commands
 
 ```
+      --audit-log string                 append a JSON-Lines audit record for each write action to this file (also KAS_AUDIT_LOG); a logfmt line always goes to stderr regardless
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)

--- a/docs/cli/kasapi-cli_cronjobs_list.md
+++ b/docs/cli/kasapi-cli_cronjobs_list.md
@@ -15,6 +15,7 @@ kasapi-cli cronjobs list [flags]
 ### Options inherited from parent commands
 
 ```
+      --audit-log string                 append a JSON-Lines audit record for each write action to this file (also KAS_AUDIT_LOG); a logfmt line always goes to stderr regardless
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)

--- a/docs/cli/kasapi-cli_databases.md
+++ b/docs/cli/kasapi-cli_databases.md
@@ -11,6 +11,7 @@ Inspect databases visible to the login (get_databases)
 ### Options inherited from parent commands
 
 ```
+      --audit-log string                 append a JSON-Lines audit record for each write action to this file (also KAS_AUDIT_LOG); a logfmt line always goes to stderr regardless
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)

--- a/docs/cli/kasapi-cli_databases_get.md
+++ b/docs/cli/kasapi-cli_databases_get.md
@@ -15,6 +15,7 @@ kasapi-cli databases get <database-login> [flags]
 ### Options inherited from parent commands
 
 ```
+      --audit-log string                 append a JSON-Lines audit record for each write action to this file (also KAS_AUDIT_LOG); a logfmt line always goes to stderr regardless
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)

--- a/docs/cli/kasapi-cli_databases_list.md
+++ b/docs/cli/kasapi-cli_databases_list.md
@@ -15,6 +15,7 @@ kasapi-cli databases list [flags]
 ### Options inherited from parent commands
 
 ```
+      --audit-log string                 append a JSON-Lines audit record for each write action to this file (also KAS_AUDIT_LOG); a logfmt line always goes to stderr regardless
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)

--- a/docs/cli/kasapi-cli_ddnsusers.md
+++ b/docs/cli/kasapi-cli_ddnsusers.md
@@ -11,6 +11,7 @@ Inspect DDNS users visible to the login (get_ddnsusers)
 ### Options inherited from parent commands
 
 ```
+      --audit-log string                 append a JSON-Lines audit record for each write action to this file (also KAS_AUDIT_LOG); a logfmt line always goes to stderr regardless
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)

--- a/docs/cli/kasapi-cli_ddnsusers_get.md
+++ b/docs/cli/kasapi-cli_ddnsusers_get.md
@@ -15,6 +15,7 @@ kasapi-cli ddnsusers get <ddns-login> [flags]
 ### Options inherited from parent commands
 
 ```
+      --audit-log string                 append a JSON-Lines audit record for each write action to this file (also KAS_AUDIT_LOG); a logfmt line always goes to stderr regardless
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)

--- a/docs/cli/kasapi-cli_ddnsusers_list.md
+++ b/docs/cli/kasapi-cli_ddnsusers_list.md
@@ -15,6 +15,7 @@ kasapi-cli ddnsusers list [flags]
 ### Options inherited from parent commands
 
 ```
+      --audit-log string                 append a JSON-Lines audit record for each write action to this file (also KAS_AUDIT_LOG); a logfmt line always goes to stderr regardless
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)

--- a/docs/cli/kasapi-cli_directoryprotection.md
+++ b/docs/cli/kasapi-cli_directoryprotection.md
@@ -11,6 +11,7 @@ Inspect directory (htaccess) protections (get_directoryprotection)
 ### Options inherited from parent commands
 
 ```
+      --audit-log string                 append a JSON-Lines audit record for each write action to this file (also KAS_AUDIT_LOG); a logfmt line always goes to stderr regardless
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)

--- a/docs/cli/kasapi-cli_directoryprotection_list.md
+++ b/docs/cli/kasapi-cli_directoryprotection_list.md
@@ -16,6 +16,7 @@ kasapi-cli directoryprotection list [flags]
 ### Options inherited from parent commands
 
 ```
+      --audit-log string                 append a JSON-Lines audit record for each write action to this file (also KAS_AUDIT_LOG); a logfmt line always goes to stderr regardless
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)

--- a/docs/cli/kasapi-cli_dns.md
+++ b/docs/cli/kasapi-cli_dns.md
@@ -11,6 +11,7 @@ Inspect DNS records for a zone
 ### Options inherited from parent commands
 
 ```
+      --audit-log string                 append a JSON-Lines audit record for each write action to this file (also KAS_AUDIT_LOG); a logfmt line always goes to stderr regardless
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)

--- a/docs/cli/kasapi-cli_dns_list.md
+++ b/docs/cli/kasapi-cli_dns_list.md
@@ -17,6 +17,7 @@ kasapi-cli dns list [flags]
 ### Options inherited from parent commands
 
 ```
+      --audit-log string                 append a JSON-Lines audit record for each write action to this file (also KAS_AUDIT_LOG); a logfmt line always goes to stderr regardless
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)

--- a/docs/cli/kasapi-cli_domains.md
+++ b/docs/cli/kasapi-cli_domains.md
@@ -11,6 +11,7 @@ Inspect domains owned by the authenticated account
 ### Options inherited from parent commands
 
 ```
+      --audit-log string                 append a JSON-Lines audit record for each write action to this file (also KAS_AUDIT_LOG); a logfmt line always goes to stderr regardless
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)

--- a/docs/cli/kasapi-cli_domains_get.md
+++ b/docs/cli/kasapi-cli_domains_get.md
@@ -15,6 +15,7 @@ kasapi-cli domains get <domain-name> [flags]
 ### Options inherited from parent commands
 
 ```
+      --audit-log string                 append a JSON-Lines audit record for each write action to this file (also KAS_AUDIT_LOG); a logfmt line always goes to stderr regardless
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)

--- a/docs/cli/kasapi-cli_domains_list.md
+++ b/docs/cli/kasapi-cli_domains_list.md
@@ -15,6 +15,7 @@ kasapi-cli domains list [flags]
 ### Options inherited from parent commands
 
 ```
+      --audit-log string                 append a JSON-Lines audit record for each write action to this file (also KAS_AUDIT_LOG); a logfmt line always goes to stderr regardless
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)

--- a/docs/cli/kasapi-cli_ftpusers.md
+++ b/docs/cli/kasapi-cli_ftpusers.md
@@ -11,6 +11,7 @@ Inspect FTP users visible to the login (get_ftpusers)
 ### Options inherited from parent commands
 
 ```
+      --audit-log string                 append a JSON-Lines audit record for each write action to this file (also KAS_AUDIT_LOG); a logfmt line always goes to stderr regardless
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)

--- a/docs/cli/kasapi-cli_ftpusers_get.md
+++ b/docs/cli/kasapi-cli_ftpusers_get.md
@@ -15,6 +15,7 @@ kasapi-cli ftpusers get <ftp-login> [flags]
 ### Options inherited from parent commands
 
 ```
+      --audit-log string                 append a JSON-Lines audit record for each write action to this file (also KAS_AUDIT_LOG); a logfmt line always goes to stderr regardless
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)

--- a/docs/cli/kasapi-cli_ftpusers_list.md
+++ b/docs/cli/kasapi-cli_ftpusers_list.md
@@ -15,6 +15,7 @@ kasapi-cli ftpusers list [flags]
 ### Options inherited from parent commands
 
 ```
+      --audit-log string                 append a JSON-Lines audit record for each write action to this file (also KAS_AUDIT_LOG); a logfmt line always goes to stderr regardless
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)

--- a/docs/cli/kasapi-cli_mail.md
+++ b/docs/cli/kasapi-cli_mail.md
@@ -11,6 +11,7 @@ Inspect mail accounts, forwards, filters, and mailing lists
 ### Options inherited from parent commands
 
 ```
+      --audit-log string                 append a JSON-Lines audit record for each write action to this file (also KAS_AUDIT_LOG); a logfmt line always goes to stderr regardless
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)

--- a/docs/cli/kasapi-cli_mail_accounts.md
+++ b/docs/cli/kasapi-cli_mail_accounts.md
@@ -11,6 +11,7 @@ Inspect mail accounts (get_mailaccounts)
 ### Options inherited from parent commands
 
 ```
+      --audit-log string                 append a JSON-Lines audit record for each write action to this file (also KAS_AUDIT_LOG); a logfmt line always goes to stderr regardless
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)

--- a/docs/cli/kasapi-cli_mail_accounts_get.md
+++ b/docs/cli/kasapi-cli_mail_accounts_get.md
@@ -15,6 +15,7 @@ kasapi-cli mail accounts get <mail-login> [flags]
 ### Options inherited from parent commands
 
 ```
+      --audit-log string                 append a JSON-Lines audit record for each write action to this file (also KAS_AUDIT_LOG); a logfmt line always goes to stderr regardless
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)

--- a/docs/cli/kasapi-cli_mail_accounts_list.md
+++ b/docs/cli/kasapi-cli_mail_accounts_list.md
@@ -15,6 +15,7 @@ kasapi-cli mail accounts list [flags]
 ### Options inherited from parent commands
 
 ```
+      --audit-log string                 append a JSON-Lines audit record for each write action to this file (also KAS_AUDIT_LOG); a logfmt line always goes to stderr regardless
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)

--- a/docs/cli/kasapi-cli_mail_filters.md
+++ b/docs/cli/kasapi-cli_mail_filters.md
@@ -11,6 +11,7 @@ Inspect mail standard filters (get_mailstandardfilter)
 ### Options inherited from parent commands
 
 ```
+      --audit-log string                 append a JSON-Lines audit record for each write action to this file (also KAS_AUDIT_LOG); a logfmt line always goes to stderr regardless
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)

--- a/docs/cli/kasapi-cli_mail_filters_list.md
+++ b/docs/cli/kasapi-cli_mail_filters_list.md
@@ -15,6 +15,7 @@ kasapi-cli mail filters list [flags]
 ### Options inherited from parent commands
 
 ```
+      --audit-log string                 append a JSON-Lines audit record for each write action to this file (also KAS_AUDIT_LOG); a logfmt line always goes to stderr regardless
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)

--- a/docs/cli/kasapi-cli_mail_forwards.md
+++ b/docs/cli/kasapi-cli_mail_forwards.md
@@ -11,6 +11,7 @@ Inspect mail forwards (get_mailforwards)
 ### Options inherited from parent commands
 
 ```
+      --audit-log string                 append a JSON-Lines audit record for each write action to this file (also KAS_AUDIT_LOG); a logfmt line always goes to stderr regardless
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)

--- a/docs/cli/kasapi-cli_mail_forwards_get.md
+++ b/docs/cli/kasapi-cli_mail_forwards_get.md
@@ -15,6 +15,7 @@ kasapi-cli mail forwards get <mail-forward> [flags]
 ### Options inherited from parent commands
 
 ```
+      --audit-log string                 append a JSON-Lines audit record for each write action to this file (also KAS_AUDIT_LOG); a logfmt line always goes to stderr regardless
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)

--- a/docs/cli/kasapi-cli_mail_forwards_list.md
+++ b/docs/cli/kasapi-cli_mail_forwards_list.md
@@ -15,6 +15,7 @@ kasapi-cli mail forwards list [flags]
 ### Options inherited from parent commands
 
 ```
+      --audit-log string                 append a JSON-Lines audit record for each write action to this file (also KAS_AUDIT_LOG); a logfmt line always goes to stderr regardless
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)

--- a/docs/cli/kasapi-cli_mail_lists.md
+++ b/docs/cli/kasapi-cli_mail_lists.md
@@ -11,6 +11,7 @@ Inspect mailing lists (get_mailinglists)
 ### Options inherited from parent commands
 
 ```
+      --audit-log string                 append a JSON-Lines audit record for each write action to this file (also KAS_AUDIT_LOG); a logfmt line always goes to stderr regardless
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)

--- a/docs/cli/kasapi-cli_mail_lists_get.md
+++ b/docs/cli/kasapi-cli_mail_lists_get.md
@@ -15,6 +15,7 @@ kasapi-cli mail lists get <mailinglist-name> [flags]
 ### Options inherited from parent commands
 
 ```
+      --audit-log string                 append a JSON-Lines audit record for each write action to this file (also KAS_AUDIT_LOG); a logfmt line always goes to stderr regardless
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)

--- a/docs/cli/kasapi-cli_mail_lists_list.md
+++ b/docs/cli/kasapi-cli_mail_lists_list.md
@@ -15,6 +15,7 @@ kasapi-cli mail lists list [flags]
 ### Options inherited from parent commands
 
 ```
+      --audit-log string                 append a JSON-Lines audit record for each write action to this file (also KAS_AUDIT_LOG); a logfmt line always goes to stderr regardless
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)

--- a/docs/cli/kasapi-cli_sambausers.md
+++ b/docs/cli/kasapi-cli_sambausers.md
@@ -11,6 +11,7 @@ Inspect Samba/CIFS users visible to the login (get_sambausers)
 ### Options inherited from parent commands
 
 ```
+      --audit-log string                 append a JSON-Lines audit record for each write action to this file (also KAS_AUDIT_LOG); a logfmt line always goes to stderr regardless
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)

--- a/docs/cli/kasapi-cli_sambausers_get.md
+++ b/docs/cli/kasapi-cli_sambausers_get.md
@@ -15,6 +15,7 @@ kasapi-cli sambausers get <samba-login> [flags]
 ### Options inherited from parent commands
 
 ```
+      --audit-log string                 append a JSON-Lines audit record for each write action to this file (also KAS_AUDIT_LOG); a logfmt line always goes to stderr regardless
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)

--- a/docs/cli/kasapi-cli_sambausers_list.md
+++ b/docs/cli/kasapi-cli_sambausers_list.md
@@ -15,6 +15,7 @@ kasapi-cli sambausers list [flags]
 ### Options inherited from parent commands
 
 ```
+      --audit-log string                 append a JSON-Lines audit record for each write action to this file (also KAS_AUDIT_LOG); a logfmt line always goes to stderr regardless
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)

--- a/docs/cli/kasapi-cli_server.md
+++ b/docs/cli/kasapi-cli_server.md
@@ -11,6 +11,7 @@ Inspect the host server kasapi-cli is talking to
 ### Options inherited from parent commands
 
 ```
+      --audit-log string                 append a JSON-Lines audit record for each write action to this file (also KAS_AUDIT_LOG); a logfmt line always goes to stderr regardless
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)

--- a/docs/cli/kasapi-cli_server_info.md
+++ b/docs/cli/kasapi-cli_server_info.md
@@ -15,6 +15,7 @@ kasapi-cli server info [flags]
 ### Options inherited from parent commands
 
 ```
+      --audit-log string                 append a JSON-Lines audit record for each write action to this file (also KAS_AUDIT_LOG); a logfmt line always goes to stderr regardless
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)

--- a/docs/cli/kasapi-cli_sessions.md
+++ b/docs/cli/kasapi-cli_sessions.md
@@ -17,6 +17,7 @@ add_session is not a separate endpoint — it is the KasAuth credential-token fl
 ### Options inherited from parent commands
 
 ```
+      --audit-log string                 append a JSON-Lines audit record for each write action to this file (also KAS_AUDIT_LOG); a logfmt line always goes to stderr regardless
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)

--- a/docs/cli/kasapi-cli_sessions_delete.md
+++ b/docs/cli/kasapi-cli_sessions_delete.md
@@ -21,6 +21,7 @@ kasapi-cli sessions delete [flags]
 ### Options inherited from parent commands
 
 ```
+      --audit-log string                 append a JSON-Lines audit record for each write action to this file (also KAS_AUDIT_LOG); a logfmt line always goes to stderr regardless
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)

--- a/docs/cli/kasapi-cli_softwareinstalls.md
+++ b/docs/cli/kasapi-cli_softwareinstalls.md
@@ -11,6 +11,7 @@ Inspect installable software templates (get_softwareinstall)
 ### Options inherited from parent commands
 
 ```
+      --audit-log string                 append a JSON-Lines audit record for each write action to this file (also KAS_AUDIT_LOG); a logfmt line always goes to stderr regardless
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)

--- a/docs/cli/kasapi-cli_softwareinstalls_get.md
+++ b/docs/cli/kasapi-cli_softwareinstalls_get.md
@@ -15,6 +15,7 @@ kasapi-cli softwareinstalls get <software-id> [flags]
 ### Options inherited from parent commands
 
 ```
+      --audit-log string                 append a JSON-Lines audit record for each write action to this file (also KAS_AUDIT_LOG); a logfmt line always goes to stderr regardless
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)

--- a/docs/cli/kasapi-cli_softwareinstalls_list.md
+++ b/docs/cli/kasapi-cli_softwareinstalls_list.md
@@ -15,6 +15,7 @@ kasapi-cli softwareinstalls list [flags]
 ### Options inherited from parent commands
 
 ```
+      --audit-log string                 append a JSON-Lines audit record for each write action to this file (also KAS_AUDIT_LOG); a logfmt line always goes to stderr regardless
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)

--- a/docs/cli/kasapi-cli_subdomains.md
+++ b/docs/cli/kasapi-cli_subdomains.md
@@ -11,6 +11,7 @@ Inspect subdomains owned by the authenticated account
 ### Options inherited from parent commands
 
 ```
+      --audit-log string                 append a JSON-Lines audit record for each write action to this file (also KAS_AUDIT_LOG); a logfmt line always goes to stderr regardless
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)

--- a/docs/cli/kasapi-cli_subdomains_get.md
+++ b/docs/cli/kasapi-cli_subdomains_get.md
@@ -15,6 +15,7 @@ kasapi-cli subdomains get <subdomain-name> [flags]
 ### Options inherited from parent commands
 
 ```
+      --audit-log string                 append a JSON-Lines audit record for each write action to this file (also KAS_AUDIT_LOG); a logfmt line always goes to stderr regardless
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)

--- a/docs/cli/kasapi-cli_subdomains_list.md
+++ b/docs/cli/kasapi-cli_subdomains_list.md
@@ -15,6 +15,7 @@ kasapi-cli subdomains list [flags]
 ### Options inherited from parent commands
 
 ```
+      --audit-log string                 append a JSON-Lines audit record for each write action to this file (also KAS_AUDIT_LOG); a logfmt line always goes to stderr regardless
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)

--- a/docs/cli/kasapi-cli_tlds.md
+++ b/docs/cli/kasapi-cli_tlds.md
@@ -11,6 +11,7 @@ Inspect the catalog of registrable top-level domains
 ### Options inherited from parent commands
 
 ```
+      --audit-log string                 append a JSON-Lines audit record for each write action to this file (also KAS_AUDIT_LOG); a logfmt line always goes to stderr regardless
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)

--- a/docs/cli/kasapi-cli_tlds_list.md
+++ b/docs/cli/kasapi-cli_tlds_list.md
@@ -15,6 +15,7 @@ kasapi-cli tlds list [flags]
 ### Options inherited from parent commands
 
 ```
+      --audit-log string                 append a JSON-Lines audit record for each write action to this file (also KAS_AUDIT_LOG); a logfmt line always goes to stderr regardless
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)

--- a/docs/cli/kasapi-cli_usage.md
+++ b/docs/cli/kasapi-cli_usage.md
@@ -11,6 +11,7 @@ Inspect webspace and traffic counters
 ### Options inherited from parent commands
 
 ```
+      --audit-log string                 append a JSON-Lines audit record for each write action to this file (also KAS_AUDIT_LOG); a logfmt line always goes to stderr regardless
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)

--- a/docs/cli/kasapi-cli_usage_space-detail.md
+++ b/docs/cli/kasapi-cli_usage_space-detail.md
@@ -16,6 +16,7 @@ kasapi-cli usage space-detail [flags]
 ### Options inherited from parent commands
 
 ```
+      --audit-log string                 append a JSON-Lines audit record for each write action to this file (also KAS_AUDIT_LOG); a logfmt line always goes to stderr regardless
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)

--- a/docs/cli/kasapi-cli_usage_space.md
+++ b/docs/cli/kasapi-cli_usage_space.md
@@ -15,6 +15,7 @@ kasapi-cli usage space [flags]
 ### Options inherited from parent commands
 
 ```
+      --audit-log string                 append a JSON-Lines audit record for each write action to this file (also KAS_AUDIT_LOG); a logfmt line always goes to stderr regardless
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)

--- a/docs/cli/kasapi-cli_usage_traffic.md
+++ b/docs/cli/kasapi-cli_usage_traffic.md
@@ -17,6 +17,7 @@ kasapi-cli usage traffic [flags]
 ### Options inherited from parent commands
 
 ```
+      --audit-log string                 append a JSON-Lines audit record for each write action to this file (also KAS_AUDIT_LOG); a logfmt line always goes to stderr regardless
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)

--- a/docs/usage/destructive-writes.md
+++ b/docs/usage/destructive-writes.md
@@ -47,6 +47,31 @@ non-interactively.
 | not a TTY | no  | exit 1 (`refusing destructive operation`) |
 | not a TTY | yes | proceed without prompting |
 
+## Audit log
+
+Independently of the confirmation prompt and of `--verbose`, every
+dispatched write action leaves a structured trace
+([#131](https://github.com/chmmou/kasapi-cli/issues/131)). The record is
+emitted **after** the SOAP call returns, regardless of success or
+failure.
+
+A `logfmt`-style line always goes to **stderr**:
+
+```
+ts=2026-05-16T12:00:00Z login=w0000001 action=delete_dns_settings target="record 42" outcome=success record_id=42
+```
+
+`outcome` is `success`, `failure:<kas_code>` for a typed KAS fault, or a
+bare `failure` for a transport/decode error.
+
+Passing `--audit-log <path>` (or setting `KAS_AUDIT_LOG`; the flag wins)
+additionally appends the same record as one JSON object per line
+(JSON Lines) to that file, which is created with mode `0600`.
+
+Secret request parameters (`auth_data`, `*password`, `*token`,
+`*secret`, …) are replaced with `<redacted>` in **both** sinks and never
+written. Read commands produce no audit record.
+
 ## Previewing instead of confirming
 
 A `--dry-run` flag that prints the exact KAS action and parameter map

--- a/internal/cli/audit.go
+++ b/internal/cli/audit.go
@@ -1,0 +1,186 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/chmmou/kasapi-cli/internal/api"
+)
+
+// AuditRecord is the structured trace emitted for one dispatched write
+// action. It is written after the SOAP call returns, regardless of
+// outcome — a failed write is at least as important to log as a
+// successful one. Fields holds already-redacted correlating values
+// (e.g. record_id from add_dns_settings); secret request parameters
+// must be filtered with RedactParams before they reach this struct.
+type AuditRecord struct {
+	Time    time.Time         `json:"time"`
+	Login   string            `json:"login"`
+	Action  string            `json:"action"`
+	Target  string            `json:"target"`
+	Outcome string            `json:"outcome"`
+	Fields  map[string]string `json:"fields,omitempty"`
+}
+
+// OutcomeFor maps a write call's error to the audit outcome string:
+// "success" on nil, "failure:<kas_code>" for a typed KAS fault, and a
+// bare "failure" for any other (transport/decode) error.
+func OutcomeFor(err error) string {
+	if err == nil {
+		return "success"
+	}
+	if e := api.AsError(err); e != nil {
+		return "failure:" + e.Code
+	}
+	return "failure"
+}
+
+// auditSecretParams are request-parameter keys whose values must never
+// reach the audit log. The list is intentionally conservative and grows
+// as the #13 write endpoints land; the substring rule in redactParam
+// additionally catches the common *password / *_token / *secret shapes
+// so a newly wired endpoint is redaction-safe by default.
+var auditSecretParams = map[string]struct{}{
+	"auth_data":         {},
+	"kas_auth_data":     {},
+	"password":          {},
+	"new_password":      {},
+	"mail_password":     {},
+	"database_password": {},
+	"ftp_password":      {},
+	"samba_password":    {},
+	"session":           {},
+	"token":             {},
+}
+
+const auditRedacted = "<redacted>"
+
+// redactParam reports whether the value of parameter key must be
+// redacted before it is logged.
+func redactParam(key string) bool {
+	k := strings.ToLower(key)
+	if _, ok := auditSecretParams[k]; ok {
+		return true
+	}
+	for _, frag := range []string{"password", "passwd", "secret", "token", "auth_data"} {
+		if strings.Contains(k, frag) {
+			return true
+		}
+	}
+	return false
+}
+
+// RedactParams converts a KAS request/response parameter map into the
+// string map stored on AuditRecord.Fields, replacing every secret value
+// (see redactParam) with auditRedacted. Non-string values are rendered
+// with %v. A nil/empty map yields nil so the field is omitted.
+func RedactParams(params map[string]any) map[string]string {
+	if len(params) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(params))
+	for k, v := range params {
+		if redactParam(k) {
+			out[k] = auditRedacted
+			continue
+		}
+		out[k] = fmt.Sprintf("%v", v)
+	}
+	return out
+}
+
+// logfmt renders the record as a single grep-friendly key=value line
+// without a trailing newline. Field keys are emitted in sorted order so
+// the output is deterministic.
+func (r AuditRecord) logfmt() string {
+	var b strings.Builder
+	b.WriteString("ts=")
+	b.WriteString(r.Time.UTC().Format(time.RFC3339Nano))
+	b.WriteString(" login=")
+	b.WriteString(quoteIfNeeded(r.Login))
+	b.WriteString(" action=")
+	b.WriteString(quoteIfNeeded(r.Action))
+	b.WriteString(" target=")
+	b.WriteString(quoteIfNeeded(r.Target))
+	b.WriteString(" outcome=")
+	b.WriteString(quoteIfNeeded(r.Outcome))
+	keys := make([]string, 0, len(r.Fields))
+	for k := range r.Fields {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		b.WriteByte(' ')
+		b.WriteString(k)
+		b.WriteByte('=')
+		b.WriteString(quoteIfNeeded(r.Fields[k]))
+	}
+	return b.String()
+}
+
+// quoteIfNeeded wraps v in double quotes (escaping \ and ") when it is
+// empty or contains whitespace, a quote, or '=' so the logfmt line
+// stays unambiguous to split on.
+func quoteIfNeeded(v string) string {
+	if v == "" {
+		return `""`
+	}
+	if strings.ContainsAny(v, " \t\"=") {
+		return `"` + strings.NewReplacer(`\`, `\\`, `"`, `\"`).Replace(v) + `"`
+	}
+	return v
+}
+
+// OpenAuditFile opens path for appending JSON-Lines audit records,
+// creating it with mode 0600. As in the session store, the create-mode
+// bits are advisory on Windows, so an explicit Chmod re-asserts 0600 on
+// an already-existing file.
+func OpenAuditFile(path string) (*os.File, error) {
+	//nolint:gosec // G304: the audit-log path is an explicit user-supplied --audit-log / KAS_AUDIT_LOG value; opening exactly that file is the feature.
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("cli: open audit log %s: %w", path, err)
+	}
+	if cherr := f.Chmod(0o600); cherr != nil {
+		_ = f.Close()
+		return nil, fmt.Errorf("cli: chmod audit log %s: %w", path, cherr)
+	}
+	return f, nil
+}
+
+// WriteAudit emits r to stderr as a logfmt line (always, independent of
+// --verbose) and, when file is non-nil, appends it as one JSON object
+// (JSON Lines) to file. The stderr line is written first so the trace
+// survives a broken --audit-log path. Secrets must already have been
+// removed from r.Fields via RedactParams.
+func WriteAudit(stderr io.Writer, file io.Writer, r AuditRecord) error {
+	if _, err := fmt.Fprintln(stderr, r.logfmt()); err != nil {
+		return fmt.Errorf("cli: write audit stderr: %w", err)
+	}
+	if file == nil {
+		return nil
+	}
+	line, err := json.Marshal(r)
+	if err != nil {
+		return fmt.Errorf("cli: marshal audit record: %w", err)
+	}
+	if _, err := file.Write(append(line, '\n')); err != nil {
+		return fmt.Errorf("cli: write audit file: %w", err)
+	}
+	return nil
+}
+
+// AuditLogPath resolves the audit-log file path: the --audit-log flag
+// wins, falling back to the KAS_AUDIT_LOG environment variable; ""
+// means stderr-only.
+func AuditLogPath(opts *RootOptions) string {
+	if opts != nil && opts.AuditLog != "" {
+		return opts.AuditLog
+	}
+	return os.Getenv("KAS_AUDIT_LOG")
+}

--- a/internal/cli/audit_test.go
+++ b/internal/cli/audit_test.go
@@ -1,0 +1,181 @@
+package cli_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/chmmou/kasapi-cli/internal/api"
+	"github.com/chmmou/kasapi-cli/internal/cli"
+)
+
+func TestRedactParams(t *testing.T) {
+	t.Parallel()
+	in := map[string]any{
+		"mail_login":    "m0000001",
+		"mail_password": "hunter2",
+		"auth_data":     "topsecret",
+		"new_password":  "p4ss",
+		"api_token":     "abc123",   // substring rule
+		"db_secret":     "shh",      // substring rule
+		"record_id":     42,         // non-string, kept
+		"comment":       "hi there", // kept verbatim
+	}
+	got := cli.RedactParams(in)
+	for _, secret := range []string{"mail_password", "auth_data", "new_password", "api_token", "db_secret"} {
+		if got[secret] != "<redacted>" {
+			t.Errorf("RedactParams[%q] = %q, want <redacted>", secret, got[secret])
+		}
+	}
+	if got["mail_login"] != "m0000001" {
+		t.Errorf("RedactParams[mail_login] = %q, want m0000001", got["mail_login"])
+	}
+	if got["record_id"] != "42" {
+		t.Errorf("RedactParams[record_id] = %q, want \"42\"", got["record_id"])
+	}
+	if got["comment"] != "hi there" {
+		t.Errorf("RedactParams[comment] = %q, want \"hi there\"", got["comment"])
+	}
+	// No secret value may survive anywhere in the rendered map.
+	for k, v := range got {
+		if strings.Contains(v, "hunter2") || strings.Contains(v, "topsecret") || strings.Contains(v, "abc123") {
+			t.Errorf("secret leaked via %q = %q", k, v)
+		}
+	}
+	if cli.RedactParams(nil) != nil {
+		t.Errorf("RedactParams(nil) = non-nil, want nil")
+	}
+}
+
+func TestOutcomeFor(t *testing.T) {
+	t.Parallel()
+	if got := cli.OutcomeFor(nil); got != "success" {
+		t.Errorf("OutcomeFor(nil) = %q, want success", got)
+	}
+	var faulted error = &api.Error{Code: "mailaccount_not_found"}
+	if got := cli.OutcomeFor(faulted); got != "failure:mailaccount_not_found" {
+		t.Errorf("OutcomeFor(api fault) = %q, want failure:mailaccount_not_found", got)
+	}
+	if got := cli.OutcomeFor(errTransport{}); got != "failure" {
+		t.Errorf("OutcomeFor(transport err) = %q, want failure", got)
+	}
+}
+
+type errTransport struct{}
+
+func (errTransport) Error() string { return "dial tcp: connection refused" }
+
+func TestAuditRecordLogfmt(t *testing.T) {
+	t.Parallel()
+	var stderr bytes.Buffer
+	rec := cli.AuditRecord{
+		Time:    time.Date(2026, 5, 16, 12, 0, 0, 0, time.UTC),
+		Login:   "w0000001",
+		Action:  "delete_dns_settings",
+		Target:  "record 42 in zone a b", // forces quoting
+		Outcome: "success",
+		Fields:  cli.RedactParams(map[string]any{"record_id": "42", "mail_password": "hunter2"}),
+	}
+	if err := cli.WriteAudit(&stderr, nil, rec); err != nil {
+		t.Fatalf("WriteAudit: %v", err)
+	}
+	line := stderr.String()
+	for _, want := range []string{
+		"ts=2026-05-16T12:00:00Z",
+		"login=w0000001",
+		"action=delete_dns_settings",
+		`target="record 42 in zone a b"`,
+		"outcome=success",
+		"record_id=42",
+		"mail_password=<redacted>",
+	} {
+		if !strings.Contains(line, want) {
+			t.Errorf("logfmt missing %q in:\n%s", want, line)
+		}
+	}
+	if strings.Contains(line, "hunter2") {
+		t.Errorf("secret leaked to stderr: %s", line)
+	}
+	if !strings.HasSuffix(line, "\n") {
+		t.Errorf("logfmt line not newline-terminated: %q", line)
+	}
+}
+
+func TestWriteAuditFileJSONL(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "audit.jsonl")
+	f, err := cli.OpenAuditFile(path)
+	if err != nil {
+		t.Fatalf("OpenAuditFile: %v", err)
+	}
+	var stderr bytes.Buffer
+	mk := func(action string) cli.AuditRecord {
+		return cli.AuditRecord{
+			Time:    time.Date(2026, 5, 16, 12, 0, 0, 0, time.UTC),
+			Login:   "w0000001",
+			Action:  action,
+			Target:  "m0000001",
+			Outcome: "success",
+			Fields:  cli.RedactParams(map[string]any{"mail_password": "hunter2"}),
+		}
+	}
+	if err = cli.WriteAudit(&stderr, f, mk("add_mailaccount")); err != nil {
+		t.Fatalf("WriteAudit 1: %v", err)
+	}
+	if err = cli.WriteAudit(&stderr, f, mk("delete_mailaccount")); err != nil {
+		t.Fatalf("WriteAudit 2: %v", err)
+	}
+	if err = f.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Errorf("audit file mode = %o, want 600", perm)
+	}
+
+	//nolint:gosec // G304: path is a test-controlled t.TempDir() file.
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if strings.Contains(string(data), "hunter2") {
+		t.Errorf("secret leaked to file:\n%s", data)
+	}
+	lines := strings.Split(strings.TrimRight(string(data), "\n"), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("file has %d JSON lines, want 2:\n%s", len(lines), data)
+	}
+	var first cli.AuditRecord
+	if err := json.Unmarshal([]byte(lines[0]), &first); err != nil {
+		t.Fatalf("line 0 not valid JSON: %v", err)
+	}
+	if first.Action != "add_mailaccount" || first.Fields["mail_password"] != "<redacted>" {
+		t.Errorf("decoded record 0 = %+v", first)
+	}
+}
+
+func TestAuditLogPathPrecedence(t *testing.T) {
+	t.Setenv("KAS_AUDIT_LOG", "/env/audit.log")
+	if got := cli.AuditLogPath(&cli.RootOptions{AuditLog: "/flag/audit.log"}); got != "/flag/audit.log" {
+		t.Errorf("flag should win: got %q", got)
+	}
+	if got := cli.AuditLogPath(&cli.RootOptions{}); got != "/env/audit.log" {
+		t.Errorf("env fallback: got %q, want /env/audit.log", got)
+	}
+	t.Setenv("KAS_AUDIT_LOG", "")
+	if got := cli.AuditLogPath(&cli.RootOptions{}); got != "" {
+		t.Errorf("no flag, no env: got %q, want \"\"", got)
+	}
+	if got := cli.AuditLogPath(nil); got != "" {
+		t.Errorf("nil opts, no env: got %q, want \"\"", got)
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -29,6 +29,8 @@ type RootOptions struct {
 	OutputRaw string
 	Output    Format
 
+	AuditLog string
+
 	NoColor bool
 	Verbose bool
 	Yes     bool
@@ -90,6 +92,9 @@ func NewRootCmd() (*cobra.Command, *RootOptions) {
 	pf.BoolVar(&opts.NoColor, "no-color", false, "disable coloured output")
 	pf.BoolVarP(&opts.Verbose, "verbose", "v", false, "enable verbose logging on stderr")
 	pf.BoolVarP(&opts.Yes, "yes", "y", false, "skip confirmation prompts on destructive operations")
+	pf.StringVar(&opts.AuditLog, "audit-log", "",
+		"append a JSON-Lines audit record for each write action to this file "+
+			"(also KAS_AUDIT_LOG); a logfmt line always goes to stderr regardless")
 
 	// --yes is wired: it is honoured by the destructive-write
 	// confirmation gate (issue #109, cli.GateDestructive). --no-color

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -21,7 +21,7 @@ func TestRootHelpListsVisiblePersistentFlags(t *testing.T) {
 	got := out.String()
 	for _, flag := range []string{
 		"--config", "--profile", "--login", "--auth-data", "--auth-type",
-		"--output", "--verbose", "--yes",
+		"--output", "--verbose", "--yes", "--audit-log",
 	} {
 		if !strings.Contains(got, flag) {
 			t.Errorf("help is missing flag %s; got:\n%s", flag, got)


### PR DESCRIPTION
Adds `cli.AuditRecord` + `cli.WriteAudit`: every dispatched write action emits a `logfmt` line on stderr (always on, independent of `--verbose`) with timestamp, resolved login, KAS action, target, `outcome` (`success`/`failure:<kas_code>`/`failure`) and correlating fields. New global `--audit-log` flag (and `KAS_AUDIT_LOG`; flag wins) appends each record as JSON Lines to a `0600` file. Secrets stripped by `cli.RedactParams` in both sinks. Safety doc + `docs/cli` regenerated.

No command emits a record yet (no #13 write endpoint exists; `sessions delete` is a session logout, not an audited write) — that acceptance box transfers to the first write-command PR.

Refs #131.