### PR TITLE
feat(cli): --dry-run for write commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `--dry-run` for destructive commands (#132, v0.2.0 write-phase
+  prerequisite): the new global `--dry-run` flag previews the KAS
+  request a destructive command would send (action + redacted
+  parameter map, via `--output` table/json/yaml) and exits 0 without
+  dispatching. It short-circuits the #109 confirmation prompt — even
+  combined with `--yes` it only previews — and still emits a #131
+  audit record with `outcome=dry-run` so the trace exists. The shared
+  `cli.ResolveDestructive` seam composes the dry-run preview, the
+  confirmation gate and the audit log so every future write command
+  consults one entry point. Documented in
+  `docs/usage/destructive-writes.md`. Per-command wiring lands with the
+  first write endpoint (#13).
+
 - Structured write-action audit log (#131, v0.2.0 write-phase
   prerequisite): `cli.AuditRecord` + `cli.WriteAudit` emit one
   `logfmt`-style line per dispatched write action to stderr — always

--- a/docs/cli/kasapi-cli.md
+++ b/docs/cli/kasapi-cli.md
@@ -17,6 +17,7 @@ kasapi-cli [flags]
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
+      --dry-run                          preview a destructive command's KAS request (action + redacted parameters) and exit 0 without dispatching or prompting; honours --output
   -h, --help                             help for kasapi-cli
       --login string                     KAS login (overrides config and KAS_LOGIN)
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.

--- a/docs/cli/kasapi-cli_accounts.md
+++ b/docs/cli/kasapi-cli_accounts.md
@@ -15,6 +15,7 @@ Inspect KAS accounts owned by the authenticated login
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
+      --dry-run                          preview a destructive command's KAS request (action + redacted parameters) and exit 0 without dispatching or prompting; honours --output
       --login string                     KAS login (overrides config and KAS_LOGIN)
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)

--- a/docs/cli/kasapi-cli_accounts_get.md
+++ b/docs/cli/kasapi-cli_accounts_get.md
@@ -19,6 +19,7 @@ kasapi-cli accounts get <account-login> [flags]
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
+      --dry-run                          preview a destructive command's KAS request (action + redacted parameters) and exit 0 without dispatching or prompting; honours --output
       --login string                     KAS login (overrides config and KAS_LOGIN)
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)

--- a/docs/cli/kasapi-cli_accounts_list.md
+++ b/docs/cli/kasapi-cli_accounts_list.md
@@ -19,6 +19,7 @@ kasapi-cli accounts list [flags]
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
+      --dry-run                          preview a destructive command's KAS request (action + redacted parameters) and exit 0 without dispatching or prompting; honours --output
       --login string                     KAS login (overrides config and KAS_LOGIN)
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)

--- a/docs/cli/kasapi-cli_accounts_resources.md
+++ b/docs/cli/kasapi-cli_accounts_resources.md
@@ -19,6 +19,7 @@ kasapi-cli accounts resources [flags]
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
+      --dry-run                          preview a destructive command's KAS request (action + redacted parameters) and exit 0 without dispatching or prompting; honours --output
       --login string                     KAS login (overrides config and KAS_LOGIN)
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)

--- a/docs/cli/kasapi-cli_accounts_settings.md
+++ b/docs/cli/kasapi-cli_accounts_settings.md
@@ -19,6 +19,7 @@ kasapi-cli accounts settings [flags]
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
+      --dry-run                          preview a destructive command's KAS request (action + redacted parameters) and exit 0 without dispatching or prompting; honours --output
       --login string                     KAS login (overrides config and KAS_LOGIN)
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)

--- a/docs/cli/kasapi-cli_completion.md
+++ b/docs/cli/kasapi-cli_completion.md
@@ -21,6 +21,7 @@ See each sub-command's help for details on how to use the generated script.
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
+      --dry-run                          preview a destructive command's KAS request (action + redacted parameters) and exit 0 without dispatching or prompting; honours --output
       --login string                     KAS login (overrides config and KAS_LOGIN)
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)

--- a/docs/cli/kasapi-cli_completion_bash.md
+++ b/docs/cli/kasapi-cli_completion_bash.md
@@ -44,6 +44,7 @@ kasapi-cli completion bash
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
+      --dry-run                          preview a destructive command's KAS request (action + redacted parameters) and exit 0 without dispatching or prompting; honours --output
       --login string                     KAS login (overrides config and KAS_LOGIN)
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)

--- a/docs/cli/kasapi-cli_completion_fish.md
+++ b/docs/cli/kasapi-cli_completion_fish.md
@@ -35,6 +35,7 @@ kasapi-cli completion fish [flags]
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
+      --dry-run                          preview a destructive command's KAS request (action + redacted parameters) and exit 0 without dispatching or prompting; honours --output
       --login string                     KAS login (overrides config and KAS_LOGIN)
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)

--- a/docs/cli/kasapi-cli_completion_powershell.md
+++ b/docs/cli/kasapi-cli_completion_powershell.md
@@ -32,6 +32,7 @@ kasapi-cli completion powershell [flags]
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
+      --dry-run                          preview a destructive command's KAS request (action + redacted parameters) and exit 0 without dispatching or prompting; honours --output
       --login string                     KAS login (overrides config and KAS_LOGIN)
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)

--- a/docs/cli/kasapi-cli_completion_zsh.md
+++ b/docs/cli/kasapi-cli_completion_zsh.md
@@ -46,6 +46,7 @@ kasapi-cli completion zsh [flags]
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
+      --dry-run                          preview a destructive command's KAS request (action + redacted parameters) and exit 0 without dispatching or prompting; honours --output
       --login string                     KAS login (overrides config and KAS_LOGIN)
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)

--- a/docs/cli/kasapi-cli_config.md
+++ b/docs/cli/kasapi-cli_config.md
@@ -15,6 +15,7 @@ Inspect and bootstrap the kasapi-cli configuration
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
+      --dry-run                          preview a destructive command's KAS request (action + redacted parameters) and exit 0 without dispatching or prompting; honours --output
       --login string                     KAS login (overrides config and KAS_LOGIN)
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)

--- a/docs/cli/kasapi-cli_config_add-profile.md
+++ b/docs/cli/kasapi-cli_config_add-profile.md
@@ -20,6 +20,7 @@ kasapi-cli config add-profile <name> [flags]
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
+      --dry-run                          preview a destructive command's KAS request (action + redacted parameters) and exit 0 without dispatching or prompting; honours --output
       --login string                     KAS login (overrides config and KAS_LOGIN)
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)

--- a/docs/cli/kasapi-cli_config_init.md
+++ b/docs/cli/kasapi-cli_config_init.md
@@ -21,6 +21,7 @@ kasapi-cli config init [flags]
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
+      --dry-run                          preview a destructive command's KAS request (action + redacted parameters) and exit 0 without dispatching or prompting; honours --output
       --login string                     KAS login (overrides config and KAS_LOGIN)
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)

--- a/docs/cli/kasapi-cli_config_list-profiles.md
+++ b/docs/cli/kasapi-cli_config_list-profiles.md
@@ -19,6 +19,7 @@ kasapi-cli config list-profiles [flags]
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
+      --dry-run                          preview a destructive command's KAS request (action + redacted parameters) and exit 0 without dispatching or prompting; honours --output
       --login string                     KAS login (overrides config and KAS_LOGIN)
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)

--- a/docs/cli/kasapi-cli_config_path.md
+++ b/docs/cli/kasapi-cli_config_path.md
@@ -19,6 +19,7 @@ kasapi-cli config path [flags]
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
+      --dry-run                          preview a destructive command's KAS request (action + redacted parameters) and exit 0 without dispatching or prompting; honours --output
       --login string                     KAS login (overrides config and KAS_LOGIN)
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)

--- a/docs/cli/kasapi-cli_config_show.md
+++ b/docs/cli/kasapi-cli_config_show.md
@@ -19,6 +19,7 @@ kasapi-cli config show [flags]
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
+      --dry-run                          preview a destructive command's KAS request (action + redacted parameters) and exit 0 without dispatching or prompting; honours --output
       --login string                     KAS login (overrides config and KAS_LOGIN)
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)

--- a/docs/cli/kasapi-cli_config_use-profile.md
+++ b/docs/cli/kasapi-cli_config_use-profile.md
@@ -19,6 +19,7 @@ kasapi-cli config use-profile <name> [flags]
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
+      --dry-run                          preview a destructive command's KAS request (action + redacted parameters) and exit 0 without dispatching or prompting; honours --output
       --login string                     KAS login (overrides config and KAS_LOGIN)
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)

--- a/docs/cli/kasapi-cli_cronjobs.md
+++ b/docs/cli/kasapi-cli_cronjobs.md
@@ -15,6 +15,7 @@ Inspect cronjobs visible to the login (get_cronjobs)
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
+      --dry-run                          preview a destructive command's KAS request (action + redacted parameters) and exit 0 without dispatching or prompting; honours --output
       --login string                     KAS login (overrides config and KAS_LOGIN)
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)

--- a/docs/cli/kasapi-cli_cronjobs_get.md
+++ b/docs/cli/kasapi-cli_cronjobs_get.md
@@ -19,6 +19,7 @@ kasapi-cli cronjobs get <cronjob-id> [flags]
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
+      --dry-run                          preview a destructive command's KAS request (action + redacted parameters) and exit 0 without dispatching or prompting; honours --output
       --login string                     KAS login (overrides config and KAS_LOGIN)
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)

--- a/docs/cli/kasapi-cli_cronjobs_list.md
+++ b/docs/cli/kasapi-cli_cronjobs_list.md
@@ -19,6 +19,7 @@ kasapi-cli cronjobs list [flags]
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
+      --dry-run                          preview a destructive command's KAS request (action + redacted parameters) and exit 0 without dispatching or prompting; honours --output
       --login string                     KAS login (overrides config and KAS_LOGIN)
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)

--- a/docs/cli/kasapi-cli_databases.md
+++ b/docs/cli/kasapi-cli_databases.md
@@ -15,6 +15,7 @@ Inspect databases visible to the login (get_databases)
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
+      --dry-run                          preview a destructive command's KAS request (action + redacted parameters) and exit 0 without dispatching or prompting; honours --output
       --login string                     KAS login (overrides config and KAS_LOGIN)
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)

--- a/docs/cli/kasapi-cli_databases_get.md
+++ b/docs/cli/kasapi-cli_databases_get.md
@@ -19,6 +19,7 @@ kasapi-cli databases get <database-login> [flags]
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
+      --dry-run                          preview a destructive command's KAS request (action + redacted parameters) and exit 0 without dispatching or prompting; honours --output
       --login string                     KAS login (overrides config and KAS_LOGIN)
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)

--- a/docs/cli/kasapi-cli_databases_list.md
+++ b/docs/cli/kasapi-cli_databases_list.md
@@ -19,6 +19,7 @@ kasapi-cli databases list [flags]
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
+      --dry-run                          preview a destructive command's KAS request (action + redacted parameters) and exit 0 without dispatching or prompting; honours --output
       --login string                     KAS login (overrides config and KAS_LOGIN)
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)

--- a/docs/cli/kasapi-cli_ddnsusers.md
+++ b/docs/cli/kasapi-cli_ddnsusers.md
@@ -15,6 +15,7 @@ Inspect DDNS users visible to the login (get_ddnsusers)
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
+      --dry-run                          preview a destructive command's KAS request (action + redacted parameters) and exit 0 without dispatching or prompting; honours --output
       --login string                     KAS login (overrides config and KAS_LOGIN)
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)

--- a/docs/cli/kasapi-cli_ddnsusers_get.md
+++ b/docs/cli/kasapi-cli_ddnsusers_get.md
@@ -19,6 +19,7 @@ kasapi-cli ddnsusers get <ddns-login> [flags]
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
+      --dry-run                          preview a destructive command's KAS request (action + redacted parameters) and exit 0 without dispatching or prompting; honours --output
       --login string                     KAS login (overrides config and KAS_LOGIN)
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)

--- a/docs/cli/kasapi-cli_ddnsusers_list.md
+++ b/docs/cli/kasapi-cli_ddnsusers_list.md
@@ -19,6 +19,7 @@ kasapi-cli ddnsusers list [flags]
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
+      --dry-run                          preview a destructive command's KAS request (action + redacted parameters) and exit 0 without dispatching or prompting; honours --output
       --login string                     KAS login (overrides config and KAS_LOGIN)
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)

--- a/docs/cli/kasapi-cli_directoryprotection.md
+++ b/docs/cli/kasapi-cli_directoryprotection.md
@@ -15,6 +15,7 @@ Inspect directory (htaccess) protections (get_directoryprotection)
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
+      --dry-run                          preview a destructive command's KAS request (action + redacted parameters) and exit 0 without dispatching or prompting; honours --output
       --login string                     KAS login (overrides config and KAS_LOGIN)
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)

--- a/docs/cli/kasapi-cli_directoryprotection_list.md
+++ b/docs/cli/kasapi-cli_directoryprotection_list.md
@@ -20,6 +20,7 @@ kasapi-cli directoryprotection list [flags]
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
+      --dry-run                          preview a destructive command's KAS request (action + redacted parameters) and exit 0 without dispatching or prompting; honours --output
       --login string                     KAS login (overrides config and KAS_LOGIN)
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)

--- a/docs/cli/kasapi-cli_dns.md
+++ b/docs/cli/kasapi-cli_dns.md
@@ -15,6 +15,7 @@ Inspect DNS records for a zone
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
+      --dry-run                          preview a destructive command's KAS request (action + redacted parameters) and exit 0 without dispatching or prompting; honours --output
       --login string                     KAS login (overrides config and KAS_LOGIN)
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)

--- a/docs/cli/kasapi-cli_dns_list.md
+++ b/docs/cli/kasapi-cli_dns_list.md
@@ -21,6 +21,7 @@ kasapi-cli dns list [flags]
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
+      --dry-run                          preview a destructive command's KAS request (action + redacted parameters) and exit 0 without dispatching or prompting; honours --output
       --login string                     KAS login (overrides config and KAS_LOGIN)
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)

--- a/docs/cli/kasapi-cli_domains.md
+++ b/docs/cli/kasapi-cli_domains.md
@@ -15,6 +15,7 @@ Inspect domains owned by the authenticated account
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
+      --dry-run                          preview a destructive command's KAS request (action + redacted parameters) and exit 0 without dispatching or prompting; honours --output
       --login string                     KAS login (overrides config and KAS_LOGIN)
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)

--- a/docs/cli/kasapi-cli_domains_get.md
+++ b/docs/cli/kasapi-cli_domains_get.md
@@ -19,6 +19,7 @@ kasapi-cli domains get <domain-name> [flags]
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
+      --dry-run                          preview a destructive command's KAS request (action + redacted parameters) and exit 0 without dispatching or prompting; honours --output
       --login string                     KAS login (overrides config and KAS_LOGIN)
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)

--- a/docs/cli/kasapi-cli_domains_list.md
+++ b/docs/cli/kasapi-cli_domains_list.md
@@ -19,6 +19,7 @@ kasapi-cli domains list [flags]
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
+      --dry-run                          preview a destructive command's KAS request (action + redacted parameters) and exit 0 without dispatching or prompting; honours --output
       --login string                     KAS login (overrides config and KAS_LOGIN)
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)

--- a/docs/cli/kasapi-cli_ftpusers.md
+++ b/docs/cli/kasapi-cli_ftpusers.md
@@ -15,6 +15,7 @@ Inspect FTP users visible to the login (get_ftpusers)
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
+      --dry-run                          preview a destructive command's KAS request (action + redacted parameters) and exit 0 without dispatching or prompting; honours --output
       --login string                     KAS login (overrides config and KAS_LOGIN)
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)

--- a/docs/cli/kasapi-cli_ftpusers_get.md
+++ b/docs/cli/kasapi-cli_ftpusers_get.md
@@ -19,6 +19,7 @@ kasapi-cli ftpusers get <ftp-login> [flags]
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
+      --dry-run                          preview a destructive command's KAS request (action + redacted parameters) and exit 0 without dispatching or prompting; honours --output
       --login string                     KAS login (overrides config and KAS_LOGIN)
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)

--- a/docs/cli/kasapi-cli_ftpusers_list.md
+++ b/docs/cli/kasapi-cli_ftpusers_list.md
@@ -19,6 +19,7 @@ kasapi-cli ftpusers list [flags]
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
+      --dry-run                          preview a destructive command's KAS request (action + redacted parameters) and exit 0 without dispatching or prompting; honours --output
       --login string                     KAS login (overrides config and KAS_LOGIN)
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)

--- a/docs/cli/kasapi-cli_mail.md
+++ b/docs/cli/kasapi-cli_mail.md
@@ -15,6 +15,7 @@ Inspect mail accounts, forwards, filters, and mailing lists
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
+      --dry-run                          preview a destructive command's KAS request (action + redacted parameters) and exit 0 without dispatching or prompting; honours --output
       --login string                     KAS login (overrides config and KAS_LOGIN)
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)

--- a/docs/cli/kasapi-cli_mail_accounts.md
+++ b/docs/cli/kasapi-cli_mail_accounts.md
@@ -15,6 +15,7 @@ Inspect mail accounts (get_mailaccounts)
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
+      --dry-run                          preview a destructive command's KAS request (action + redacted parameters) and exit 0 without dispatching or prompting; honours --output
       --login string                     KAS login (overrides config and KAS_LOGIN)
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)

--- a/docs/cli/kasapi-cli_mail_accounts_get.md
+++ b/docs/cli/kasapi-cli_mail_accounts_get.md
@@ -19,6 +19,7 @@ kasapi-cli mail accounts get <mail-login> [flags]
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
+      --dry-run                          preview a destructive command's KAS request (action + redacted parameters) and exit 0 without dispatching or prompting; honours --output
       --login string                     KAS login (overrides config and KAS_LOGIN)
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)

--- a/docs/cli/kasapi-cli_mail_accounts_list.md
+++ b/docs/cli/kasapi-cli_mail_accounts_list.md
@@ -19,6 +19,7 @@ kasapi-cli mail accounts list [flags]
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
+      --dry-run                          preview a destructive command's KAS request (action + redacted parameters) and exit 0 without dispatching or prompting; honours --output
       --login string                     KAS login (overrides config and KAS_LOGIN)
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)

--- a/docs/cli/kasapi-cli_mail_filters.md
+++ b/docs/cli/kasapi-cli_mail_filters.md
@@ -15,6 +15,7 @@ Inspect mail standard filters (get_mailstandardfilter)
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
+      --dry-run                          preview a destructive command's KAS request (action + redacted parameters) and exit 0 without dispatching or prompting; honours --output
       --login string                     KAS login (overrides config and KAS_LOGIN)
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)

--- a/docs/cli/kasapi-cli_mail_filters_list.md
+++ b/docs/cli/kasapi-cli_mail_filters_list.md
@@ -19,6 +19,7 @@ kasapi-cli mail filters list [flags]
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
+      --dry-run                          preview a destructive command's KAS request (action + redacted parameters) and exit 0 without dispatching or prompting; honours --output
       --login string                     KAS login (overrides config and KAS_LOGIN)
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)

--- a/docs/cli/kasapi-cli_mail_forwards.md
+++ b/docs/cli/kasapi-cli_mail_forwards.md
@@ -15,6 +15,7 @@ Inspect mail forwards (get_mailforwards)
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
+      --dry-run                          preview a destructive command's KAS request (action + redacted parameters) and exit 0 without dispatching or prompting; honours --output
       --login string                     KAS login (overrides config and KAS_LOGIN)
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)

--- a/docs/cli/kasapi-cli_mail_forwards_get.md
+++ b/docs/cli/kasapi-cli_mail_forwards_get.md
@@ -19,6 +19,7 @@ kasapi-cli mail forwards get <mail-forward> [flags]
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
+      --dry-run                          preview a destructive command's KAS request (action + redacted parameters) and exit 0 without dispatching or prompting; honours --output
       --login string                     KAS login (overrides config and KAS_LOGIN)
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)

--- a/docs/cli/kasapi-cli_mail_forwards_list.md
+++ b/docs/cli/kasapi-cli_mail_forwards_list.md
@@ -19,6 +19,7 @@ kasapi-cli mail forwards list [flags]
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
+      --dry-run                          preview a destructive command's KAS request (action + redacted parameters) and exit 0 without dispatching or prompting; honours --output
       --login string                     KAS login (overrides config and KAS_LOGIN)
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)

--- a/docs/cli/kasapi-cli_mail_lists.md
+++ b/docs/cli/kasapi-cli_mail_lists.md
@@ -15,6 +15,7 @@ Inspect mailing lists (get_mailinglists)
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
+      --dry-run                          preview a destructive command's KAS request (action + redacted parameters) and exit 0 without dispatching or prompting; honours --output
       --login string                     KAS login (overrides config and KAS_LOGIN)
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)

--- a/docs/cli/kasapi-cli_mail_lists_get.md
+++ b/docs/cli/kasapi-cli_mail_lists_get.md
@@ -19,6 +19,7 @@ kasapi-cli mail lists get <mailinglist-name> [flags]
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
+      --dry-run                          preview a destructive command's KAS request (action + redacted parameters) and exit 0 without dispatching or prompting; honours --output
       --login string                     KAS login (overrides config and KAS_LOGIN)
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)

--- a/docs/cli/kasapi-cli_mail_lists_list.md
+++ b/docs/cli/kasapi-cli_mail_lists_list.md
@@ -19,6 +19,7 @@ kasapi-cli mail lists list [flags]
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
+      --dry-run                          preview a destructive command's KAS request (action + redacted parameters) and exit 0 without dispatching or prompting; honours --output
       --login string                     KAS login (overrides config and KAS_LOGIN)
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)

--- a/docs/cli/kasapi-cli_sambausers.md
+++ b/docs/cli/kasapi-cli_sambausers.md
@@ -15,6 +15,7 @@ Inspect Samba/CIFS users visible to the login (get_sambausers)
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
+      --dry-run                          preview a destructive command's KAS request (action + redacted parameters) and exit 0 without dispatching or prompting; honours --output
       --login string                     KAS login (overrides config and KAS_LOGIN)
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)

--- a/docs/cli/kasapi-cli_sambausers_get.md
+++ b/docs/cli/kasapi-cli_sambausers_get.md
@@ -19,6 +19,7 @@ kasapi-cli sambausers get <samba-login> [flags]
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
+      --dry-run                          preview a destructive command's KAS request (action + redacted parameters) and exit 0 without dispatching or prompting; honours --output
       --login string                     KAS login (overrides config and KAS_LOGIN)
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)

--- a/docs/cli/kasapi-cli_sambausers_list.md
+++ b/docs/cli/kasapi-cli_sambausers_list.md
@@ -19,6 +19,7 @@ kasapi-cli sambausers list [flags]
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
+      --dry-run                          preview a destructive command's KAS request (action + redacted parameters) and exit 0 without dispatching or prompting; honours --output
       --login string                     KAS login (overrides config and KAS_LOGIN)
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)

--- a/docs/cli/kasapi-cli_server.md
+++ b/docs/cli/kasapi-cli_server.md
@@ -15,6 +15,7 @@ Inspect the host server kasapi-cli is talking to
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
+      --dry-run                          preview a destructive command's KAS request (action + redacted parameters) and exit 0 without dispatching or prompting; honours --output
       --login string                     KAS login (overrides config and KAS_LOGIN)
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)

--- a/docs/cli/kasapi-cli_server_info.md
+++ b/docs/cli/kasapi-cli_server_info.md
@@ -19,6 +19,7 @@ kasapi-cli server info [flags]
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
+      --dry-run                          preview a destructive command's KAS request (action + redacted parameters) and exit 0 without dispatching or prompting; honours --output
       --login string                     KAS login (overrides config and KAS_LOGIN)
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)

--- a/docs/cli/kasapi-cli_sessions.md
+++ b/docs/cli/kasapi-cli_sessions.md
@@ -21,6 +21,7 @@ add_session is not a separate endpoint — it is the KasAuth credential-token fl
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
+      --dry-run                          preview a destructive command's KAS request (action + redacted parameters) and exit 0 without dispatching or prompting; honours --output
       --login string                     KAS login (overrides config and KAS_LOGIN)
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)

--- a/docs/cli/kasapi-cli_sessions_delete.md
+++ b/docs/cli/kasapi-cli_sessions_delete.md
@@ -25,6 +25,7 @@ kasapi-cli sessions delete [flags]
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
+      --dry-run                          preview a destructive command's KAS request (action + redacted parameters) and exit 0 without dispatching or prompting; honours --output
       --login string                     KAS login (overrides config and KAS_LOGIN)
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)

--- a/docs/cli/kasapi-cli_softwareinstalls.md
+++ b/docs/cli/kasapi-cli_softwareinstalls.md
@@ -15,6 +15,7 @@ Inspect installable software templates (get_softwareinstall)
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
+      --dry-run                          preview a destructive command's KAS request (action + redacted parameters) and exit 0 without dispatching or prompting; honours --output
       --login string                     KAS login (overrides config and KAS_LOGIN)
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)

--- a/docs/cli/kasapi-cli_softwareinstalls_get.md
+++ b/docs/cli/kasapi-cli_softwareinstalls_get.md
@@ -19,6 +19,7 @@ kasapi-cli softwareinstalls get <software-id> [flags]
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
+      --dry-run                          preview a destructive command's KAS request (action + redacted parameters) and exit 0 without dispatching or prompting; honours --output
       --login string                     KAS login (overrides config and KAS_LOGIN)
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)

--- a/docs/cli/kasapi-cli_softwareinstalls_list.md
+++ b/docs/cli/kasapi-cli_softwareinstalls_list.md
@@ -19,6 +19,7 @@ kasapi-cli softwareinstalls list [flags]
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
+      --dry-run                          preview a destructive command's KAS request (action + redacted parameters) and exit 0 without dispatching or prompting; honours --output
       --login string                     KAS login (overrides config and KAS_LOGIN)
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)

--- a/docs/cli/kasapi-cli_subdomains.md
+++ b/docs/cli/kasapi-cli_subdomains.md
@@ -15,6 +15,7 @@ Inspect subdomains owned by the authenticated account
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
+      --dry-run                          preview a destructive command's KAS request (action + redacted parameters) and exit 0 without dispatching or prompting; honours --output
       --login string                     KAS login (overrides config and KAS_LOGIN)
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)

--- a/docs/cli/kasapi-cli_subdomains_get.md
+++ b/docs/cli/kasapi-cli_subdomains_get.md
@@ -19,6 +19,7 @@ kasapi-cli subdomains get <subdomain-name> [flags]
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
+      --dry-run                          preview a destructive command's KAS request (action + redacted parameters) and exit 0 without dispatching or prompting; honours --output
       --login string                     KAS login (overrides config and KAS_LOGIN)
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)

--- a/docs/cli/kasapi-cli_subdomains_list.md
+++ b/docs/cli/kasapi-cli_subdomains_list.md
@@ -19,6 +19,7 @@ kasapi-cli subdomains list [flags]
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
+      --dry-run                          preview a destructive command's KAS request (action + redacted parameters) and exit 0 without dispatching or prompting; honours --output
       --login string                     KAS login (overrides config and KAS_LOGIN)
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)

--- a/docs/cli/kasapi-cli_tlds.md
+++ b/docs/cli/kasapi-cli_tlds.md
@@ -15,6 +15,7 @@ Inspect the catalog of registrable top-level domains
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
+      --dry-run                          preview a destructive command's KAS request (action + redacted parameters) and exit 0 without dispatching or prompting; honours --output
       --login string                     KAS login (overrides config and KAS_LOGIN)
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)

--- a/docs/cli/kasapi-cli_tlds_list.md
+++ b/docs/cli/kasapi-cli_tlds_list.md
@@ -19,6 +19,7 @@ kasapi-cli tlds list [flags]
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
+      --dry-run                          preview a destructive command's KAS request (action + redacted parameters) and exit 0 without dispatching or prompting; honours --output
       --login string                     KAS login (overrides config and KAS_LOGIN)
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)

--- a/docs/cli/kasapi-cli_usage.md
+++ b/docs/cli/kasapi-cli_usage.md
@@ -15,6 +15,7 @@ Inspect webspace and traffic counters
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
+      --dry-run                          preview a destructive command's KAS request (action + redacted parameters) and exit 0 without dispatching or prompting; honours --output
       --login string                     KAS login (overrides config and KAS_LOGIN)
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)

--- a/docs/cli/kasapi-cli_usage_space-detail.md
+++ b/docs/cli/kasapi-cli_usage_space-detail.md
@@ -20,6 +20,7 @@ kasapi-cli usage space-detail [flags]
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
+      --dry-run                          preview a destructive command's KAS request (action + redacted parameters) and exit 0 without dispatching or prompting; honours --output
       --login string                     KAS login (overrides config and KAS_LOGIN)
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)

--- a/docs/cli/kasapi-cli_usage_space.md
+++ b/docs/cli/kasapi-cli_usage_space.md
@@ -19,6 +19,7 @@ kasapi-cli usage space [flags]
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
+      --dry-run                          preview a destructive command's KAS request (action + redacted parameters) and exit 0 without dispatching or prompting; honours --output
       --login string                     KAS login (overrides config and KAS_LOGIN)
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)

--- a/docs/cli/kasapi-cli_usage_traffic.md
+++ b/docs/cli/kasapi-cli_usage_traffic.md
@@ -21,6 +21,7 @@ kasapi-cli usage traffic [flags]
       --auth-data string                 KAS auth data (overrides config and KAS_AUTHDATA)
       --auth-type string                 KAS auth strategy: 'plain' = send password on each KasApi call (no KasAuth, no 2FA support); 'session' = bootstrap via KasAuth and reuse the credential token. Overrides config and KAS_AUTHTYPE.
       --config string                    path to the kasapi-cli config file (overrides the default location)
+      --dry-run                          preview a destructive command's KAS request (action + redacted parameters) and exit 0 without dispatching or prompting; honours --output
       --login string                     KAS login (overrides config and KAS_LOGIN)
       --otp string                       2FA one-time PIN — sent to KasAuth as session_2fa during the credential-token bootstrap. Requires auth_type=session; the KAS API does not document 2FA on direct kas_auth_type=plain calls.
   -o, --output string                    output format: json|yaml|table (default table)

--- a/docs/usage/destructive-writes.md
+++ b/docs/usage/destructive-writes.md
@@ -72,9 +72,39 @@ Secret request parameters (`auth_data`, `*password`, `*token`,
 `*secret`, …) are replaced with `<redacted>` in **both** sinks and never
 written. Read commands produce no audit record.
 
-## Previewing instead of confirming
+## `--dry-run`: preview without dispatching
 
-A `--dry-run` flag that prints the exact KAS action and parameter map
-without dispatching anything is planned separately
-([#132](https://github.com/chmmou/kasapi-cli/issues/132)); it will
-short-circuit this prompt because nothing destructive happens.
+`--dry-run` runs every step of a destructive command **except** the
+SOAP call ([#132](https://github.com/chmmou/kasapi-cli/issues/132)).
+Credentials and the request are resolved exactly as for a real call,
+the KAS action and its parameter map are printed, and the command exits
+**0** without contacting KAS.
+
+- It **short-circuits the confirmation prompt** — nothing destructive
+  happens, so there is nothing to confirm. `--dry-run` together with
+  `--yes` still only previews (exit 0, no prompt, no dispatch).
+- The preview honours `--output` (`table` default, `json`, `yaml`) so
+  it is grep-/jq-/yq-friendly.
+- Secret parameters are redacted with the **same** rule as the audit
+  log (`<redacted>`).
+- An audit record is still emitted, with `outcome=dry-run`, so the
+  trace exists and is distinguishable from a real call.
+
+```console
+$ kasapi-cli mail accounts delete m0000001 --dry-run
+FIELD              VALUE
+action             delete_mailaccount
+target             m0000001
+param.mail_login   m0000001
+
+$ kasapi-cli mail accounts delete m0000001 --dry-run -o json
+{
+  "action": "delete_mailaccount",
+  "target": "m0000001",
+  "params": { "mail_login": "m0000001" }
+}
+```
+
+(The example command is illustrative — the per-resource write
+subcommands land with the #13 write endpoints; the flag and its
+machinery are already in place.)

--- a/internal/cli/audit.go
+++ b/internal/cli/audit.go
@@ -27,6 +27,12 @@ type AuditRecord struct {
 	Fields  map[string]string `json:"fields,omitempty"`
 }
 
+// AuditOutcomeDryRun is the AuditRecord.Outcome value written for a
+// --dry-run invocation (#132): the request shape was previewed but no
+// SOAP call was dispatched, so it must be distinguishable in the log
+// from a real success or failure.
+const AuditOutcomeDryRun = "dry-run"
+
 // OutcomeFor maps a write call's error to the audit outcome string:
 // "success" on nil, "failure:<kas_code>" for a typed KAS fault, and a
 // bare "failure" for any other (transport/decode) error.

--- a/internal/cli/dryrun.go
+++ b/internal/cli/dryrun.go
@@ -1,0 +1,98 @@
+package cli
+
+import (
+	"io"
+	"sort"
+	"time"
+)
+
+// DryRunPreview is the structured description of the KAS request a
+// destructive command would have dispatched, shown to the user under
+// --dry-run instead of contacting the API. Params is already redacted
+// (see RedactParams); rendering honours --output (table/json/yaml).
+type DryRunPreview struct {
+	Action string            `json:"action" yaml:"action"`
+	Target string            `json:"target" yaml:"target"`
+	Params map[string]string `json:"params,omitempty" yaml:"params,omitempty"`
+}
+
+// NewDryRunPreview builds a preview for the given KAS action and target
+// resource, redacting secret request parameters with RedactParams so a
+// password or auth token never reaches stdout or a piped log.
+func NewDryRunPreview(kasAction, target string, params map[string]any) DryRunPreview {
+	return DryRunPreview{
+		Action: kasAction,
+		Target: target,
+		Params: RedactParams(params),
+	}
+}
+
+// TableHeaders implements Tabular for --output=table.
+func (DryRunPreview) TableHeaders() []string { return []string{"FIELD", "VALUE"} }
+
+// TableRows implements Tabular: the action and target first, then one
+// row per redacted parameter (sorted) as "param.<key>".
+func (p DryRunPreview) TableRows() [][]string {
+	rows := [][]string{
+		{"action", p.Action},
+		{"target", p.Target},
+	}
+	keys := make([]string, 0, len(p.Params))
+	for k := range p.Params {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		rows = append(rows, []string{"param." + k, p.Params[k]})
+	}
+	return rows
+}
+
+// ResolveDestructive is the shared dispatch gate every destructive
+// command consults before its SOAP call. It composes the --dry-run
+// preview (#132), the confirmation gate (#109) and the audit log
+// (#131):
+//
+//   - opts.DryRun: render the request to out in opts.Output, write an
+//     audit record with outcome "dry-run", and return (false, nil). No
+//     prompt and no dispatch happen — even when --yes is also set.
+//   - otherwise: run GateDestructive. A declined or non-interactive
+//     confirmation returns (false, err); a pass returns (true, nil) and
+//     the caller dispatches, then emits its own success/failure audit
+//     record via OutcomeFor.
+//
+// login and kasAction plus confirm.ID identify the target for the
+// preview and the audit trace. auditFile is the optional --audit-log
+// sink (nil = stderr only).
+func ResolveDestructive(
+	opts *RootOptions,
+	in io.Reader,
+	out, stderr, auditFile io.Writer,
+	isTTY bool,
+	login, kasAction string,
+	confirm ConfirmAction,
+	params map[string]any,
+) (proceed bool, err error) {
+	if opts != nil && opts.DryRun {
+		preview := NewDryRunPreview(kasAction, confirm.ID, params)
+		if rerr := Render(out, opts.Output, preview); rerr != nil {
+			return false, UserError(rerr, "dry-run preview")
+		}
+		rec := AuditRecord{
+			Time:    time.Now().UTC(),
+			Login:   login,
+			Action:  kasAction,
+			Target:  confirm.ID,
+			Outcome: AuditOutcomeDryRun,
+			Fields:  preview.Params,
+		}
+		if aerr := WriteAudit(stderr, auditFile, rec); aerr != nil {
+			return false, UserError(aerr, "dry-run audit")
+		}
+		return false, nil
+	}
+	if gerr := GateDestructive(in, out, isTTY, opts != nil && opts.Yes, confirm); gerr != nil {
+		return false, gerr
+	}
+	return true, nil
+}

--- a/internal/cli/dryrun_test.go
+++ b/internal/cli/dryrun_test.go
@@ -1,0 +1,157 @@
+package cli_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/chmmou/kasapi-cli/internal/cli"
+)
+
+func TestDryRunPreviewRedactsAndRenders(t *testing.T) {
+	t.Parallel()
+	p := cli.NewDryRunPreview("add_mailaccount", "m0000001", map[string]any{
+		"mail_login":    "m0000001",
+		"mail_password": "hunter2",
+	})
+	for _, format := range []cli.Format{cli.FormatTable, cli.FormatJSON, cli.FormatYAML} {
+		var buf bytes.Buffer
+		if err := cli.Render(&buf, format, p); err != nil {
+			t.Fatalf("Render(%s): %v", format, err)
+		}
+		out := buf.String()
+		if !strings.Contains(out, "add_mailaccount") || !strings.Contains(out, "m0000001") {
+			t.Errorf("%s output missing action/target:\n%s", format, out)
+		}
+		// The mail_password key must survive (redacted, not dropped) and
+		// its secret value must never appear, in any format. The exact
+		// "<redacted>" marker is asserted format-free in TestRedactParams;
+		// the JSON encoder additionally HTML-escapes the angle brackets,
+		// so do not string-match the marker here.
+		if !strings.Contains(out, "mail_password") {
+			t.Errorf("%s output dropped the mail_password key:\n%s", format, out)
+		}
+		if strings.Contains(out, "hunter2") {
+			t.Errorf("%s output leaked the password:\n%s", format, out)
+		}
+	}
+}
+
+func TestResolveDestructiveDryRunShortCircuits(t *testing.T) {
+	t.Parallel()
+	confirm := cli.ConfirmAction{Verb: "delete", Resource: "mail account", ID: "m0000001"}
+	params := map[string]any{"mail_login": "m0000001", "mail_password": "hunter2"}
+
+	cases := []struct {
+		name  string
+		yes   bool
+		isTTY bool
+	}{
+		{"interactive, no --yes", false, true},
+		{"with --yes", true, false},
+		{"non-tty, no --yes", false, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			opts := &cli.RootOptions{DryRun: true, Output: cli.FormatJSON, Yes: c.yes}
+			var out, stderr, auditFile bytes.Buffer
+			// The reader provides "y\n" but must never be consumed: dry-run
+			// short-circuits the prompt entirely.
+			proceed, err := cli.ResolveDestructive(
+				opts, strings.NewReader("y\n"), &out, &stderr, &auditFile,
+				c.isTTY, "w0000001", "delete_mailaccount", confirm, params)
+			if proceed || err != nil {
+				t.Fatalf("proceed=%v err=%v, want false/nil (no dispatch)", proceed, err)
+			}
+			if strings.Contains(out.String(), "[y/N]") {
+				t.Errorf("dry-run prompted; out=%q", out.String())
+			}
+			var preview cli.DryRunPreview
+			if jerr := json.Unmarshal(out.Bytes(), &preview); jerr != nil {
+				t.Fatalf("preview not valid JSON: %v\n%s", jerr, out.String())
+			}
+			if preview.Action != "delete_mailaccount" || preview.Target != "m0000001" {
+				t.Errorf("preview = %+v", preview)
+			}
+			if preview.Params["mail_password"] != "<redacted>" {
+				t.Errorf("password not redacted in preview: %+v", preview.Params)
+			}
+			if !strings.Contains(stderr.String(), "outcome=dry-run") {
+				t.Errorf("audit stderr missing dry-run marker: %q", stderr.String())
+			}
+			if strings.Contains(out.String()+stderr.String()+auditFile.String(), "hunter2") {
+				t.Errorf("password leaked somewhere; out=%q stderr=%q file=%q",
+					out.String(), stderr.String(), auditFile.String())
+			}
+			var rec cli.AuditRecord
+			if jerr := json.Unmarshal(bytes.TrimSpace(auditFile.Bytes()), &rec); jerr != nil {
+				t.Fatalf("audit file line not JSON: %v\n%s", jerr, auditFile.String())
+			}
+			if rec.Outcome != cli.AuditOutcomeDryRun {
+				t.Errorf("audit outcome = %q, want %q", rec.Outcome, cli.AuditOutcomeDryRun)
+			}
+		})
+	}
+}
+
+func TestResolveDestructiveDelegatesToGate(t *testing.T) {
+	t.Parallel()
+	confirm := cli.ConfirmAction{Verb: "delete", Resource: "mail account", ID: "m0000001"}
+
+	t.Run("declined", func(t *testing.T) {
+		t.Parallel()
+		opts := &cli.RootOptions{DryRun: false}
+		var out, stderr bytes.Buffer
+		proceed, err := cli.ResolveDestructive(
+			opts, strings.NewReader("n\n"), &out, &stderr, nil,
+			true, "w0000001", "delete_mailaccount", confirm, nil)
+		if proceed || !errors.Is(err, cli.ErrConfirmationDeclined) {
+			t.Fatalf("proceed=%v err=%v, want false/ErrConfirmationDeclined", proceed, err)
+		}
+		if !strings.Contains(out.String(), "[y/N]") {
+			t.Errorf("expected a prompt; out=%q", out.String())
+		}
+	})
+
+	t.Run("accepted", func(t *testing.T) {
+		t.Parallel()
+		opts := &cli.RootOptions{DryRun: false}
+		var out, stderr bytes.Buffer
+		proceed, err := cli.ResolveDestructive(
+			opts, strings.NewReader("y\n"), &out, &stderr, nil,
+			true, "w0000001", "delete_mailaccount", confirm, nil)
+		if !proceed || err != nil {
+			t.Fatalf("proceed=%v err=%v, want true/nil", proceed, err)
+		}
+	})
+
+	t.Run("yes bypasses prompt", func(t *testing.T) {
+		t.Parallel()
+		opts := &cli.RootOptions{DryRun: false, Yes: true}
+		var out, stderr bytes.Buffer
+		proceed, err := cli.ResolveDestructive(
+			opts, strings.NewReader(""), &out, &stderr, nil,
+			false, "w0000001", "delete_mailaccount", confirm, nil)
+		if !proceed || err != nil {
+			t.Fatalf("proceed=%v err=%v, want true/nil", proceed, err)
+		}
+		if strings.Contains(out.String(), "[y/N]") {
+			t.Errorf("--yes should not prompt; out=%q", out.String())
+		}
+	})
+
+	t.Run("non-tty without yes", func(t *testing.T) {
+		t.Parallel()
+		opts := &cli.RootOptions{DryRun: false}
+		var out, stderr bytes.Buffer
+		proceed, err := cli.ResolveDestructive(
+			opts, strings.NewReader(""), &out, &stderr, nil,
+			false, "w0000001", "delete_mailaccount", confirm, nil)
+		if proceed || !errors.Is(err, cli.ErrConfirmationRequired) {
+			t.Fatalf("proceed=%v err=%v, want false/ErrConfirmationRequired", proceed, err)
+		}
+	})
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -34,6 +34,7 @@ type RootOptions struct {
 	NoColor bool
 	Verbose bool
 	Yes     bool
+	DryRun  bool
 }
 
 // NewRootCmd builds the kasapi-cli root command and registers all
@@ -95,6 +96,9 @@ func NewRootCmd() (*cobra.Command, *RootOptions) {
 	pf.StringVar(&opts.AuditLog, "audit-log", "",
 		"append a JSON-Lines audit record for each write action to this file "+
 			"(also KAS_AUDIT_LOG); a logfmt line always goes to stderr regardless")
+	pf.BoolVar(&opts.DryRun, "dry-run", false,
+		"preview a destructive command's KAS request (action + redacted parameters) "+
+			"and exit 0 without dispatching or prompting; honours --output")
 
 	// --yes is wired: it is honoured by the destructive-write
 	// confirmation gate (issue #109, cli.GateDestructive). --no-color

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -21,7 +21,7 @@ func TestRootHelpListsVisiblePersistentFlags(t *testing.T) {
 	got := out.String()
 	for _, flag := range []string{
 		"--config", "--profile", "--login", "--auth-data", "--auth-type",
-		"--output", "--verbose", "--yes", "--audit-log",
+		"--output", "--verbose", "--yes", "--audit-log", "--dry-run",
 	} {
 		if !strings.Contains(got, flag) {
 			t.Errorf("help is missing flag %s; got:\n%s", flag, got)


### PR DESCRIPTION
Adds the global `--dry-run` flag and `cli.ResolveDestructive`, the shared dispatch seam every future destructive command consults. With `--dry-run` it renders the KAS request (action + `RedactParams`-redacted parameter map) to stdout via `--output`, emits a #131 audit record with `outcome=dry-run`, and returns without prompting or dispatching — even with `--yes`. Without it, it delegates to the #109 confirmation gate.

No command wires it end-to-end yet (no #13 write endpoint exists); the helper-level contract (incl. `--dry-run` + `--yes`) is unit-tested. End-to-end boxes transfer to the first write-command PR.

Refs #132.