### PR TITLE
feat(mail): mailforward write endpoints — add / update / delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Mail-forward write endpoints (#115, first #13 write slice):
+  `kasapi-cli mail forwards add <addr> --target … `,
+  `… update <addr> --target …` and `… delete <addr>` wire
+  `add_mailforward` / `update_mailforward` / `delete_mailforward`.
+  `delete` and `update` are gated by the #109 confirmation prompt
+  (`update_mailforward` replaces the full target list and is
+  irreversible); `add` is reversible and not prompted. All three
+  honour `--dry-run` (#132) and emit a #131 audit record. This is the
+  first command to exercise the gate/audit/dry-run seam end to end,
+  via the shared `cli.runWriteE` runner and the new non-gated
+  `cli.ResolveWrite` counterpart of `cli.ResolveDestructive`.
+
 - `--dry-run` for destructive commands (#132, v0.2.0 write-phase
   prerequisite): the new global `--dry-run` flag previews the KAS
   request a destructive command would send (action + redacted
@@ -19,8 +31,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `cli.ResolveDestructive` seam composes the dry-run preview, the
   confirmation gate and the audit log so every future write command
   consults one entry point. Documented in
-  `docs/usage/destructive-writes.md`. Per-command wiring lands with the
-  first write endpoint (#13).
+  `docs/usage/destructive-writes.md`. Wired by the mail-forward write
+  slice (#115).
 
 - Structured write-action audit log (#131, v0.2.0 write-phase
   prerequisite): `cli.AuditRecord` + `cli.WriteAudit` emit one
@@ -32,8 +44,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   additionally appends each record as JSON Lines to a `0600` file.
   Secret parameters (`auth_data`, `*password`, `*token`, `*secret`, …)
   are redacted in both sinks via `cli.RedactParams`. Documented in
-  `docs/usage/destructive-writes.md`. Per-command emission lands with
-  the first write endpoint (#13); read commands are unaffected.
+  `docs/usage/destructive-writes.md`. Wired by the mail-forward write
+  slice (#115); read commands are unaffected.
 
 - Destructive-write confirmation gate (#109, v0.2.0 write-phase
   prerequisite): the global `--yes` / `-y` flag is now wired and
@@ -44,8 +56,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `cli.ErrConfirmationRequired`, `errors.Is`-able). `--yes` bypasses
   the prompt for automation. TTY detection is now shared by `config
   init`/`add-profile` and the gate. The safety contract is documented
-  in `docs/usage/destructive-writes.md`. Per-command wiring lands with
-  the first write endpoint (#13); read commands are unaffected.
+  in `docs/usage/destructive-writes.md`. Wired by the mail-forward
+  write slice (#115); read commands are unaffected.
 
 - Exported sentinel `session.ErrUnexpectedReturnString` (review
   follow-up): `session.Client.Delete` now wraps it with `%w` when

--- a/docs/cli/kasapi-cli_mail.md
+++ b/docs/cli/kasapi-cli_mail.md
@@ -31,6 +31,6 @@ Inspect mail accounts, forwards, filters, and mailing lists
 * [kasapi-cli](kasapi-cli.md)	 - Command-line client for the All-Inkl KAS API
 * [kasapi-cli mail accounts](kasapi-cli_mail_accounts.md)	 - Inspect mail accounts (get_mailaccounts)
 * [kasapi-cli mail filters](kasapi-cli_mail_filters.md)	 - Inspect mail standard filters (get_mailstandardfilter)
-* [kasapi-cli mail forwards](kasapi-cli_mail_forwards.md)	 - Inspect mail forwards (get_mailforwards)
+* [kasapi-cli mail forwards](kasapi-cli_mail_forwards.md)	 - Inspect and manage mail forwards (get/add/update/delete_mailforward)
 * [kasapi-cli mail lists](kasapi-cli_mail_lists.md)	 - Inspect mailing lists (get_mailinglists)
 

--- a/docs/cli/kasapi-cli_mail_forwards_add.md
+++ b/docs/cli/kasapi-cli_mail_forwards_add.md
@@ -1,11 +1,16 @@
-## kasapi-cli mail forwards
+## kasapi-cli mail forwards add
 
-Inspect and manage mail forwards (get/add/update/delete_mailforward)
+Create a mail forward (add_mailforward)
+
+```
+kasapi-cli mail forwards add <address> --target <addr> [--target <addr>...] [flags]
+```
 
 ### Options
 
 ```
-  -h, --help   help for forwards
+  -h, --help                 help for add
+      --target stringArray   forward target address (repeatable; replaces the full target list)
 ```
 
 ### Options inherited from parent commands
@@ -28,10 +33,5 @@ Inspect and manage mail forwards (get/add/update/delete_mailforward)
 
 ### SEE ALSO
 
-* [kasapi-cli mail](kasapi-cli_mail.md)	 - Inspect mail accounts, forwards, filters, and mailing lists
-* [kasapi-cli mail forwards add](kasapi-cli_mail_forwards_add.md)	 - Create a mail forward (add_mailforward)
-* [kasapi-cli mail forwards delete](kasapi-cli_mail_forwards_delete.md)	 - Delete a mail forward (delete_mailforward)
-* [kasapi-cli mail forwards get](kasapi-cli_mail_forwards_get.md)	 - Show details for a single mail forward (get_mailforwards with mail_forward)
-* [kasapi-cli mail forwards list](kasapi-cli_mail_forwards_list.md)	 - List all mail forwards (get_mailforwards)
-* [kasapi-cli mail forwards update](kasapi-cli_mail_forwards_update.md)	 - Replace the targets of a mail forward (update_mailforward)
+* [kasapi-cli mail forwards](kasapi-cli_mail_forwards.md)	 - Inspect and manage mail forwards (get/add/update/delete_mailforward)
 

--- a/docs/cli/kasapi-cli_mail_forwards_delete.md
+++ b/docs/cli/kasapi-cli_mail_forwards_delete.md
@@ -1,11 +1,15 @@
-## kasapi-cli mail forwards
+## kasapi-cli mail forwards delete
 
-Inspect and manage mail forwards (get/add/update/delete_mailforward)
+Delete a mail forward (delete_mailforward)
+
+```
+kasapi-cli mail forwards delete <address> [flags]
+```
 
 ### Options
 
 ```
-  -h, --help   help for forwards
+  -h, --help   help for delete
 ```
 
 ### Options inherited from parent commands
@@ -28,10 +32,5 @@ Inspect and manage mail forwards (get/add/update/delete_mailforward)
 
 ### SEE ALSO
 
-* [kasapi-cli mail](kasapi-cli_mail.md)	 - Inspect mail accounts, forwards, filters, and mailing lists
-* [kasapi-cli mail forwards add](kasapi-cli_mail_forwards_add.md)	 - Create a mail forward (add_mailforward)
-* [kasapi-cli mail forwards delete](kasapi-cli_mail_forwards_delete.md)	 - Delete a mail forward (delete_mailforward)
-* [kasapi-cli mail forwards get](kasapi-cli_mail_forwards_get.md)	 - Show details for a single mail forward (get_mailforwards with mail_forward)
-* [kasapi-cli mail forwards list](kasapi-cli_mail_forwards_list.md)	 - List all mail forwards (get_mailforwards)
-* [kasapi-cli mail forwards update](kasapi-cli_mail_forwards_update.md)	 - Replace the targets of a mail forward (update_mailforward)
+* [kasapi-cli mail forwards](kasapi-cli_mail_forwards.md)	 - Inspect and manage mail forwards (get/add/update/delete_mailforward)
 

--- a/docs/cli/kasapi-cli_mail_forwards_get.md
+++ b/docs/cli/kasapi-cli_mail_forwards_get.md
@@ -32,5 +32,5 @@ kasapi-cli mail forwards get <mail-forward> [flags]
 
 ### SEE ALSO
 
-* [kasapi-cli mail forwards](kasapi-cli_mail_forwards.md)	 - Inspect mail forwards (get_mailforwards)
+* [kasapi-cli mail forwards](kasapi-cli_mail_forwards.md)	 - Inspect and manage mail forwards (get/add/update/delete_mailforward)
 

--- a/docs/cli/kasapi-cli_mail_forwards_list.md
+++ b/docs/cli/kasapi-cli_mail_forwards_list.md
@@ -32,5 +32,5 @@ kasapi-cli mail forwards list [flags]
 
 ### SEE ALSO
 
-* [kasapi-cli mail forwards](kasapi-cli_mail_forwards.md)	 - Inspect mail forwards (get_mailforwards)
+* [kasapi-cli mail forwards](kasapi-cli_mail_forwards.md)	 - Inspect and manage mail forwards (get/add/update/delete_mailforward)
 

--- a/docs/cli/kasapi-cli_mail_forwards_update.md
+++ b/docs/cli/kasapi-cli_mail_forwards_update.md
@@ -1,11 +1,16 @@
-## kasapi-cli mail forwards
+## kasapi-cli mail forwards update
 
-Inspect and manage mail forwards (get/add/update/delete_mailforward)
+Replace the targets of a mail forward (update_mailforward)
+
+```
+kasapi-cli mail forwards update <address> --target <addr> [--target <addr>...] [flags]
+```
 
 ### Options
 
 ```
-  -h, --help   help for forwards
+  -h, --help                 help for update
+      --target stringArray   forward target address (repeatable; replaces the full target list)
 ```
 
 ### Options inherited from parent commands
@@ -28,10 +33,5 @@ Inspect and manage mail forwards (get/add/update/delete_mailforward)
 
 ### SEE ALSO
 
-* [kasapi-cli mail](kasapi-cli_mail.md)	 - Inspect mail accounts, forwards, filters, and mailing lists
-* [kasapi-cli mail forwards add](kasapi-cli_mail_forwards_add.md)	 - Create a mail forward (add_mailforward)
-* [kasapi-cli mail forwards delete](kasapi-cli_mail_forwards_delete.md)	 - Delete a mail forward (delete_mailforward)
-* [kasapi-cli mail forwards get](kasapi-cli_mail_forwards_get.md)	 - Show details for a single mail forward (get_mailforwards with mail_forward)
-* [kasapi-cli mail forwards list](kasapi-cli_mail_forwards_list.md)	 - List all mail forwards (get_mailforwards)
-* [kasapi-cli mail forwards update](kasapi-cli_mail_forwards_update.md)	 - Replace the targets of a mail forward (update_mailforward)
+* [kasapi-cli mail forwards](kasapi-cli_mail_forwards.md)	 - Inspect and manage mail forwards (get/add/update/delete_mailforward)
 

--- a/docs/usage/destructive-writes.md
+++ b/docs/usage/destructive-writes.md
@@ -8,7 +8,15 @@ an explicit confirmation before the SOAP call is dispatched.
 This page documents the behavioural contract (issue
 [#109](https://github.com/chmmou/kasapi-cli/issues/109), part of the
 v0.2.0 write phase, [#13](https://github.com/chmmou/kasapi-cli/issues/13)).
-The read commands shipping today are non-destructive and are not gated.
+The read commands are non-destructive and are not gated.
+
+The first write endpoints —
+[`mail forwards`](https://github.com/chmmou/kasapi-cli/issues/115)
+`add` / `update` / `delete` — wire this contract. `delete` and
+`update` are gated by the confirmation prompt (an `update_mailforward`
+replaces the whole target list and is therefore irreversible); `add`
+creates and is reversible, so it is **not** prompted. All three honour
+`--dry-run` and emit an audit record.
 
 ## The contract
 
@@ -91,20 +99,23 @@ the KAS action and its parameter map are printed, and the command exits
   trace exists and is distinguishable from a real call.
 
 ```console
-$ kasapi-cli mail accounts delete m0000001 --dry-run
-FIELD              VALUE
-action             delete_mailaccount
-target             m0000001
-param.mail_login   m0000001
+$ kasapi-cli mail forwards delete info@example.de --dry-run
+FIELD               VALUE
+action              delete_mailforward
+target              info@example.de
+param.mail_forward  info@example.de
 
-$ kasapi-cli mail accounts delete m0000001 --dry-run -o json
+$ kasapi-cli mail forwards add info@example.de --target a@b.de --dry-run -o json
 {
-  "action": "delete_mailaccount",
-  "target": "m0000001",
-  "params": { "mail_login": "m0000001" }
+  "action": "add_mailforward",
+  "target": "info@example.de",
+  "params": {
+    "domain_part": "example.de",
+    "local_part": "info",
+    "target_0": "a@b.de"
+  }
 }
 ```
 
-(The example command is illustrative — the per-resource write
-subcommands land with the #13 write endpoints; the flag and its
-machinery are already in place.)
+`add` is not prompted but `--dry-run` and the audit record still apply
+to it, exactly as for the gated `update` / `delete`.

--- a/internal/cli/dryrun.go
+++ b/internal/cli/dryrun.go
@@ -48,7 +48,55 @@ func (p DryRunPreview) TableRows() [][]string {
 	return rows
 }
 
-// ResolveDestructive is the shared dispatch gate every destructive
+// WriteResolver is the common shape of ResolveDestructive and
+// ResolveWrite so a write runner can hold either behind one variable
+// and dispatch uniformly. ResolveWrite ignores in/isTTY (no prompt);
+// the parameters stay for signature parity.
+type WriteResolver func(
+	opts *RootOptions,
+	in io.Reader,
+	out, stderr, auditFile io.Writer,
+	isTTY bool,
+	login, kasAction string,
+	confirm ConfirmAction,
+	params map[string]any,
+) (proceed bool, err error)
+
+// previewAndAudit runs the shared --dry-run short-circuit (#132 + #131)
+// every write consults: when opts.DryRun is set it renders the request
+// to out in opts.Output and writes an audit record with outcome
+// "dry-run", reporting handled=true so the caller returns without
+// dispatching. When opts.DryRun is unset it reports handled=false and
+// the caller proceeds to its own gate / dispatch.
+func previewAndAudit(
+	opts *RootOptions,
+	out, stderr, auditFile io.Writer,
+	login, kasAction string,
+	confirm ConfirmAction,
+	params map[string]any,
+) (handled bool, err error) {
+	if opts == nil || !opts.DryRun {
+		return false, nil
+	}
+	preview := NewDryRunPreview(kasAction, confirm.ID, params)
+	if rerr := Render(out, opts.Output, preview); rerr != nil {
+		return true, UserError(rerr, "dry-run preview")
+	}
+	rec := AuditRecord{
+		Time:    time.Now().UTC(),
+		Login:   login,
+		Action:  kasAction,
+		Target:  confirm.ID,
+		Outcome: AuditOutcomeDryRun,
+		Fields:  preview.Params,
+	}
+	if aerr := WriteAudit(stderr, auditFile, rec); aerr != nil {
+		return true, UserError(aerr, "dry-run audit")
+	}
+	return true, nil
+}
+
+// ResolveDestructive is the shared dispatch gate every *destructive*
 // command consults before its SOAP call. It composes the --dry-run
 // preview (#132), the confirmation gate (#109) and the audit log
 // (#131):
@@ -73,26 +121,34 @@ func ResolveDestructive(
 	confirm ConfirmAction,
 	params map[string]any,
 ) (proceed bool, err error) {
-	if opts != nil && opts.DryRun {
-		preview := NewDryRunPreview(kasAction, confirm.ID, params)
-		if rerr := Render(out, opts.Output, preview); rerr != nil {
-			return false, UserError(rerr, "dry-run preview")
-		}
-		rec := AuditRecord{
-			Time:    time.Now().UTC(),
-			Login:   login,
-			Action:  kasAction,
-			Target:  confirm.ID,
-			Outcome: AuditOutcomeDryRun,
-			Fields:  preview.Params,
-		}
-		if aerr := WriteAudit(stderr, auditFile, rec); aerr != nil {
-			return false, UserError(aerr, "dry-run audit")
-		}
-		return false, nil
+	if handled, herr := previewAndAudit(opts, out, stderr, auditFile, login, kasAction, confirm, params); handled {
+		return false, herr
 	}
 	if gerr := GateDestructive(in, out, isTTY, opts != nil && opts.Yes, confirm); gerr != nil {
 		return false, gerr
+	}
+	return true, nil
+}
+
+// ResolveWrite is the non-destructive counterpart of
+// ResolveDestructive for write actions that mutate but are reversible
+// (e.g. add_mailforward): the #131 audit log and #132 --dry-run still
+// apply to every write, but no #109 confirmation prompt is shown.
+// Under --dry-run it behaves exactly like ResolveDestructive
+// (preview + dry-run audit, no dispatch); otherwise it returns
+// (true, nil) for the caller to dispatch and audit. in and isTTY are
+// unused and present only for WriteResolver signature parity.
+func ResolveWrite(
+	opts *RootOptions,
+	_ io.Reader,
+	out, stderr, auditFile io.Writer,
+	_ bool,
+	login, kasAction string,
+	confirm ConfirmAction,
+	params map[string]any,
+) (proceed bool, err error) {
+	if handled, herr := previewAndAudit(opts, out, stderr, auditFile, login, kasAction, confirm, params); handled {
+		return false, herr
 	}
 	return true, nil
 }

--- a/internal/cli/dryrun_test.go
+++ b/internal/cli/dryrun_test.go
@@ -97,6 +97,54 @@ func TestResolveDestructiveDryRunShortCircuits(t *testing.T) {
 	}
 }
 
+func TestResolveWrite(t *testing.T) {
+	t.Parallel()
+	confirm := cli.ConfirmAction{Verb: "create", Resource: "mail forward", ID: "info@example.de"}
+	params := map[string]any{"local_part": "info", "domain_part": "example.de", "target_0": "a@b.de"}
+
+	t.Run("dry-run short-circuits with audit, no prompt", func(t *testing.T) {
+		t.Parallel()
+		opts := &cli.RootOptions{DryRun: true, Output: cli.FormatJSON}
+		var out, stderr, auditFile bytes.Buffer
+		proceed, err := cli.ResolveWrite(
+			opts, strings.NewReader("y\n"), &out, &stderr, &auditFile,
+			false, "w0000001", "add_mailforward", confirm, params)
+		if proceed || err != nil {
+			t.Fatalf("proceed=%v err=%v, want false/nil", proceed, err)
+		}
+		if strings.Contains(out.String(), "[y/N]") {
+			t.Errorf("dry-run prompted; out=%q", out.String())
+		}
+		if !strings.Contains(stderr.String(), "outcome=dry-run") {
+			t.Errorf("audit stderr missing dry-run marker: %q", stderr.String())
+		}
+		var rec cli.AuditRecord
+		if jerr := json.Unmarshal(bytes.TrimSpace(auditFile.Bytes()), &rec); jerr != nil {
+			t.Fatalf("audit file line not JSON: %v\n%s", jerr, auditFile.String())
+		}
+		if rec.Outcome != cli.AuditOutcomeDryRun || rec.Action != "add_mailforward" {
+			t.Errorf("audit rec = %+v", rec)
+		}
+	})
+
+	// The defining difference from ResolveDestructive: a non-destructive
+	// write never prompts, so it proceeds even on a non-TTY without --yes.
+	t.Run("proceeds without a prompt (non-tty, no --yes)", func(t *testing.T) {
+		t.Parallel()
+		opts := &cli.RootOptions{DryRun: false}
+		var out, stderr bytes.Buffer
+		proceed, err := cli.ResolveWrite(
+			opts, strings.NewReader(""), &out, &stderr, nil,
+			false, "w0000001", "add_mailforward", confirm, params)
+		if !proceed || err != nil {
+			t.Fatalf("proceed=%v err=%v, want true/nil", proceed, err)
+		}
+		if strings.Contains(out.String(), "[y/N]") {
+			t.Errorf("non-destructive write must not prompt; out=%q", out.String())
+		}
+	})
+}
+
 func TestResolveDestructiveDelegatesToGate(t *testing.T) {
 	t.Parallel()
 	confirm := cli.ConfirmAction{Verb: "delete", Resource: "mail account", ID: "m0000001"}

--- a/internal/cli/mail.go
+++ b/internal/cli/mail.go
@@ -2,6 +2,8 @@ package cli
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -120,13 +122,112 @@ func newMailAccountsGetCmd(opts *RootOptions) *cobra.Command {
 func newMailForwardsCmd(opts *RootOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "forwards",
-		Short: "Inspect mail forwards (get_mailforwards)",
+		Short: "Inspect and manage mail forwards (get/add/update/delete_mailforward)",
 	}
 	cmd.AddCommand(
 		newMailForwardsListCmd(opts),
 		newMailForwardsGetCmd(opts),
+		newMailForwardsAddCmd(opts),
+		newMailForwardsUpdateCmd(opts),
+		newMailForwardsDeleteCmd(opts),
 	)
 	return cmd
+}
+
+// splitMailAddress splits "local@domain" on the last '@' into the
+// local_part / domain_part add_mailforward expects. get/update/delete
+// take the full address verbatim; only add needs it decomposed.
+func splitMailAddress(addr string) (local, domain string, err error) {
+	at := strings.LastIndex(addr, "@")
+	if at <= 0 || at == len(addr)-1 {
+		return "", "", fmt.Errorf("invalid mail forward address %q: want local@domain", addr)
+	}
+	return addr[:at], addr[at+1:], nil
+}
+
+func newMailForwardsAddCmd(opts *RootOptions) *cobra.Command {
+	var targets []string
+	cmd := &cobra.Command{
+		Use:   "add <address> --target <addr> [--target <addr>...]",
+		Short: "Create a mail forward (add_mailforward)",
+		Args:  cobra.ExactArgs(1),
+		RunE: runWriteE(opts, func(args []string) (writeSpec, error) {
+			local, domain, err := splitMailAddress(args[0])
+			if err != nil {
+				return writeSpec{}, err
+			}
+			if len(targets) == 0 {
+				return writeSpec{}, fmt.Errorf("at least one --target is required")
+			}
+			return writeSpec{
+				action:      "add_mailforward",
+				destructive: false,
+				confirm:     ConfirmAction{Verb: "create", Resource: "mail forward", ID: args[0]},
+				params:      mailforward.AddParams(local, domain, targets),
+				dispatch: func(c *api.Client, ctx context.Context) (string, error) {
+					addr, derr := mailforward.NewClient(c).Add(ctx, local, domain, targets)
+					if derr != nil {
+						return "", derr
+					}
+					return "created mail forward " + addr, nil
+				},
+			}, nil
+		}),
+	}
+	cmd.Flags().StringArrayVar(&targets, "target", nil, "forward target address (repeatable; replaces the full target list)")
+	return cmd
+}
+
+func newMailForwardsUpdateCmd(opts *RootOptions) *cobra.Command {
+	var targets []string
+	cmd := &cobra.Command{
+		Use:   "update <address> --target <addr> [--target <addr>...]",
+		Short: "Replace the targets of a mail forward (update_mailforward)",
+		Args:  cobra.ExactArgs(1),
+		RunE: runWriteE(opts, func(args []string) (writeSpec, error) {
+			if len(targets) == 0 {
+				return writeSpec{}, fmt.Errorf("at least one --target is required")
+			}
+			address := args[0]
+			return writeSpec{
+				action:      "update_mailforward",
+				destructive: true,
+				confirm:     ConfirmAction{Verb: "replace the targets of", Resource: "mail forward", ID: address},
+				params:      mailforward.UpdateParams(address, targets),
+				dispatch: func(c *api.Client, ctx context.Context) (string, error) {
+					if derr := mailforward.NewClient(c).Update(ctx, address, targets); derr != nil {
+						return "", derr
+					}
+					return "updated mail forward " + address, nil
+				},
+			}, nil
+		}),
+	}
+	cmd.Flags().StringArrayVar(&targets, "target", nil, "forward target address (repeatable; replaces the full target list)")
+	return cmd
+}
+
+func newMailForwardsDeleteCmd(opts *RootOptions) *cobra.Command {
+	return &cobra.Command{
+		Use:   "delete <address>",
+		Short: "Delete a mail forward (delete_mailforward)",
+		Args:  cobra.ExactArgs(1),
+		RunE: runWriteE(opts, func(args []string) (writeSpec, error) {
+			address := args[0]
+			return writeSpec{
+				action:      "delete_mailforward",
+				destructive: true,
+				confirm:     ConfirmAction{Verb: "delete", Resource: "mail forward", ID: address},
+				params:      mailforward.DeleteParams(address),
+				dispatch: func(c *api.Client, ctx context.Context) (string, error) {
+					if derr := mailforward.NewClient(c).Delete(ctx, address); derr != nil {
+						return "", derr
+					}
+					return "deleted mail forward " + address, nil
+				},
+			}, nil
+		}),
+	}
 }
 
 func newMailForwardsListCmd(opts *RootOptions) *cobra.Command {

--- a/internal/cli/mail_test.go
+++ b/internal/cli/mail_test.go
@@ -2,6 +2,7 @@ package cli_test
 
 import (
 	"bytes"
+	"errors"
 	"strings"
 	"testing"
 
@@ -61,10 +62,69 @@ func TestMailForwardsHelpListsSubcommands(t *testing.T) {
 		t.Fatalf("Execute: %v", err)
 	}
 	out := buf.String()
-	for _, want := range []string{"list", "get"} {
+	for _, want := range []string{"list", "get", "add", "update", "delete"} {
 		if !strings.Contains(out, want) {
 			t.Errorf("--help output missing %q\n%s", want, out)
 		}
+	}
+}
+
+func TestMailForwardsAddRejectsBadInput(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		args []string
+	}{
+		{"address without @", []string{"mail", "forwards", "add", "notanemail", "--target", "a@b.de"}},
+		{"missing --target", []string{"mail", "forwards", "add", "info@example.de"}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			root, opts := cli.NewRootCmd()
+			root.AddCommand(cli.NewMailCmd(opts))
+			var buf bytes.Buffer
+			root.SetOut(&buf)
+			root.SetErr(&buf)
+			root.SetArgs(c.args)
+			err := root.Execute()
+			if err == nil {
+				t.Fatalf("Execute %v: want error, got nil", c.args)
+			}
+			if cli.CodeFor(err) != cli.ExitUserError {
+				t.Errorf("exit code = %d, want ExitUserError", cli.CodeFor(err))
+			}
+		})
+	}
+}
+
+// The destructive forwards subcommands (update/delete) must refuse on a
+// non-interactive stdin without --yes rather than dispatch unconfirmed.
+// SetIn with a non-terminal reader exercises the !isTTY path.
+func TestMailForwardsDestructiveRefuseNonTTY(t *testing.T) {
+	t.Parallel()
+	for _, args := range [][]string{
+		{"mail", "forwards", "delete", "info@example.de"},
+		{"mail", "forwards", "update", "info@example.de", "--target", "a@b.de"},
+	} {
+		t.Run(args[2], func(t *testing.T) {
+			t.Parallel()
+			root, opts := cli.NewRootCmd()
+			root.AddCommand(cli.NewMailCmd(opts))
+			var buf bytes.Buffer
+			root.SetOut(&buf)
+			root.SetErr(&buf)
+			root.SetIn(strings.NewReader(""))
+			root.SetArgs(append(args,
+				"--login", "w0000000", "--auth-data", "x", "--auth-type", "plain"))
+			err := root.Execute()
+			if err == nil {
+				t.Fatalf("Execute %v: want refusal error, got nil", args)
+			}
+			if !errors.Is(err, cli.ErrConfirmationRequired) {
+				t.Errorf("err = %v, want ErrConfirmationRequired", err)
+			}
+		})
 	}
 }
 

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -2,6 +2,9 @@ package cli
 
 import (
 	"context"
+	"fmt"
+	"io"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -67,6 +70,92 @@ func runGetE[T any](
 		}
 		if err := Render(cmd.OutOrStdout(), opts.Output, v); err != nil {
 			return UserError(err, "render")
+		}
+		return nil
+	}
+}
+
+// writeSpec describes one dispatched write action. build (see
+// runWriteE) turns the parsed args/flags into it: the KAS action name,
+// whether it is destructive (→ #109 confirmation gate vs. a plain
+// audited write), the ConfirmAction/target for the prompt and audit
+// trace, the request parameter map, and the dispatch closure that runs
+// the module client method and returns the human success line.
+type writeSpec struct {
+	action      string
+	destructive bool
+	confirm     ConfirmAction
+	params      map[string]any
+	dispatch    func(c *api.Client, ctx context.Context) (string, error)
+}
+
+// runWriteE is the write-subcommand counterpart of runListE/runGetE and
+// the single seam every write command flows through. It resolves the
+// login (for the audit trace), opens the optional --audit-log sink,
+// consults ResolveDestructive (gated) or ResolveWrite (non-gated)
+// depending on spec.destructive — which also handles --dry-run (#132)
+// and the dry-run audit (#131) — and only then builds the API client
+// and dispatches. After dispatch it always emits the success/failure
+// audit record via OutcomeFor, then prints the result line on success.
+func runWriteE(opts *RootOptions, build func(args []string) (writeSpec, error)) func(*cobra.Command, []string) error {
+	return func(cmd *cobra.Command, args []string) error {
+		spec, err := build(args)
+		if err != nil {
+			return UserError(err, "")
+		}
+
+		creds, err := resolveCreds(opts)
+		if err != nil {
+			return err
+		}
+
+		var auditFile io.Writer
+		if path := AuditLogPath(opts); path != "" {
+			f, oerr := OpenAuditFile(path)
+			if oerr != nil {
+				return UserError(oerr, "")
+			}
+			defer func() { _ = f.Close() }()
+			auditFile = f
+		}
+
+		out := cmd.OutOrStdout()
+		stderr := cmd.ErrOrStderr()
+
+		var resolve WriteResolver = ResolveWrite
+		if spec.destructive {
+			resolve = ResolveDestructive
+		}
+		proceed, err := resolve(opts, cmd.InOrStdin(), out, stderr, auditFile, stdinIsTTY(),
+			creds.Login, spec.action, spec.confirm, spec.params)
+		if !proceed {
+			// --dry-run → (false, nil): exit 0; declined/refused → (false, err).
+			return err
+		}
+
+		c, err := BuildAPIClient(opts)
+		if err != nil {
+			return err
+		}
+		result, derr := spec.dispatch(c, cmd.Context())
+
+		rec := AuditRecord{
+			Time:    time.Now().UTC(),
+			Login:   creds.Login,
+			Action:  spec.action,
+			Target:  spec.confirm.ID,
+			Outcome: OutcomeFor(derr),
+			Fields:  RedactParams(spec.params),
+		}
+		if werr := WriteAudit(stderr, auditFile, rec); werr != nil {
+			return UserError(werr, "audit")
+		}
+
+		if derr != nil {
+			return APIError(derr, spec.action)
+		}
+		if _, perr := fmt.Fprintln(out, result); perr != nil {
+			return UserError(perr, "render")
 		}
 		return nil
 	}

--- a/internal/mailforward/mailforward.go
+++ b/internal/mailforward/mailforward.go
@@ -33,22 +33,29 @@ type MailForward struct {
 // cli.Tabular.
 type MailForwardList []MailForward
 
-// Client groups the read endpoints scoped to mail forwards:
-// get_mailforwards (list and singular).
+// Client groups the read endpoints scoped to mail forwards
+// (get_mailforwards, list and singular) and the write endpoints
+// add_mailforward / update_mailforward / delete_mailforward (see
+// write.go). The raw Caller is kept alongside the read helper so the
+// write methods can dispatch their own KAS actions.
 type Client struct {
 	lg kasread.ListGet[MailForwardList, MailForward]
+	c  Caller
 }
 
 // NewClient returns a Client backed by the given Caller.
 func NewClient(c Caller) *Client {
-	return &Client{lg: kasread.ListGet[MailForwardList, MailForward]{
-		Caller:    c,
-		Action:    "get_mailforwards",
-		Label:     "mailforward",
-		ArgName:   "address",
-		FilterKey: "mail_forward",
-		Decoder:   DecodeMailForwards,
-	}}
+	return &Client{
+		lg: kasread.ListGet[MailForwardList, MailForward]{
+			Caller:    c,
+			Action:    "get_mailforwards",
+			Label:     "mailforward",
+			ArgName:   "address",
+			FilterKey: "mail_forward",
+			Decoder:   DecodeMailForwards,
+		},
+		c: c,
+	}
 }
 
 // List calls get_mailforwards without parameters and decodes the

--- a/internal/mailforward/write.go
+++ b/internal/mailforward/write.go
@@ -1,0 +1,124 @@
+package mailforward
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+
+	"github.com/chmmou/kasapi-cli/internal/soap"
+)
+
+// ErrUnexpectedReturnString is returned by the write methods when the
+// KAS call succeeds at the transport level (no SOAP fault) but the
+// server's ReturnString is not "TRUE" — an API-drift / contract
+// violation. Callers may errors.Is against it to tell a protocol-shape
+// regression apart from a transport or KAS-fault error; the wrapped
+// message carries the action and the observed value. Mirrors
+// session.ErrUnexpectedReturnString.
+var ErrUnexpectedReturnString = errors.New("mailforward: unexpected ReturnString (want TRUE)")
+
+const (
+	addAction    = "add_mailforward"
+	updateAction = "update_mailforward"
+	deleteAction = "delete_mailforward"
+)
+
+// Add creates a mail forward from localPart@domainPart to the given
+// targets (add_mailforward). It returns the created forward address as
+// echoed by the server in ReturnInfo (e.g. "info@example.de").
+//
+// localPart, domainPart and at least one target are required; an empty
+// value is rejected before any SOAP call so the CLI can surface a fast
+// validation error.
+func (cl *Client) Add(ctx context.Context, localPart, domainPart string, targets []string) (string, error) {
+	if localPart == "" || domainPart == "" {
+		return "", errors.New("mailforward: add_mailforward requires a non-empty local and domain part")
+	}
+	if len(targets) == 0 {
+		return "", errors.New("mailforward: add_mailforward requires at least one target")
+	}
+	resp, err := cl.call(ctx, addAction, AddParams(localPart, domainPart, targets))
+	if err != nil {
+		return "", err
+	}
+	return resp.Body.ReturnInfo.AsString(), nil
+}
+
+// AddParams builds the add_mailforward KAS request parameter map. It is
+// the single source of truth for the request shape so the CLI dry-run
+// preview / audit record and the dispatched call cannot diverge.
+func AddParams(localPart, domainPart string, targets []string) map[string]any {
+	params := map[string]any{
+		"local_part":  localPart,
+		"domain_part": domainPart,
+	}
+	addTargets(params, targets)
+	return params
+}
+
+// Update replaces the full target list of an existing mail forward
+// (update_mailforward). The KAS API does not append: the supplied
+// targets become the new complete set, so at least one is required.
+func (cl *Client) Update(ctx context.Context, address string, targets []string) error {
+	if address == "" {
+		return errors.New("mailforward: update_mailforward requires a non-empty mail forward address")
+	}
+	if len(targets) == 0 {
+		return errors.New("mailforward: update_mailforward requires at least one target")
+	}
+	_, err := cl.call(ctx, updateAction, UpdateParams(address, targets))
+	return err
+}
+
+// UpdateParams builds the update_mailforward KAS request parameter map
+// (single source of truth, see AddParams).
+func UpdateParams(address string, targets []string) map[string]any {
+	params := map[string]any{"mail_forward": address}
+	addTargets(params, targets)
+	return params
+}
+
+// Delete removes a mail forward (delete_mailforward). A SOAP fault
+// (e.g. mail_forward_not_found_in_kas, in_progress) is surfaced
+// verbatim by the Caller so the caller can classify it via the api
+// error helpers.
+func (cl *Client) Delete(ctx context.Context, address string) error {
+	if address == "" {
+		return errors.New("mailforward: delete_mailforward requires a non-empty mail forward address")
+	}
+	_, err := cl.call(ctx, deleteAction, DeleteParams(address))
+	return err
+}
+
+// DeleteParams builds the delete_mailforward KAS request parameter map
+// (single source of truth, see AddParams).
+func DeleteParams(address string) map[string]any {
+	return map[string]any{"mail_forward": address}
+}
+
+// call dispatches a write action and enforces the shared post-call
+// contract: a non-fault response must echo ReturnString="TRUE";
+// anything else wraps ErrUnexpectedReturnString so a future API drift
+// fails the mapping test instead of silently passing.
+func (cl *Client) call(ctx context.Context, action string, params map[string]any) (*soap.Response, error) {
+	resp, err := cl.c.Call(ctx, action, params)
+	if err != nil {
+		return nil, err
+	}
+	if resp == nil {
+		return nil, fmt.Errorf("mailforward: %s: nil response without error from Caller", action)
+	}
+	if got := resp.Body.ReturnString; got != "TRUE" {
+		return nil, fmt.Errorf("%w: %s got %q", ErrUnexpectedReturnString, action, got)
+	}
+	return resp, nil
+}
+
+// addTargets writes the targets slice into params as the KAS-numbered
+// target_0, target_1, … keys.
+func addTargets(params map[string]any, targets []string) {
+	for i, t := range targets {
+		params["target_"+strconv.Itoa(i)] = t
+	}
+}

--- a/internal/mailforward/write_test.go
+++ b/internal/mailforward/write_test.go
@@ -1,0 +1,188 @@
+package mailforward_test
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/chmmou/kasapi-cli/internal/mailforward"
+	"github.com/chmmou/kasapi-cli/internal/soap"
+	"github.com/chmmou/kasapi-cli/internal/testutil"
+)
+
+func TestClientAdd(t *testing.T) {
+	t.Parallel()
+	resp := testutil.DecodeFixture(t, "mailforward/add_mailforward_response_success.xml")
+	fc := &testutil.FakeCaller{Resp: resp}
+	addr, err := mailforward.NewClient(fc).Add(
+		context.Background(), "info", "example.de", []string{"to@example.de", "backup@example.de"})
+	if err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if fc.GotAction != "add_mailforward" {
+		t.Errorf("action = %q, want add_mailforward", fc.GotAction)
+	}
+	if fc.GotParams["local_part"] != "info" || fc.GotParams["domain_part"] != "example.de" {
+		t.Errorf("local/domain params = %v", fc.GotParams)
+	}
+	if fc.GotParams["target_0"] != "to@example.de" || fc.GotParams["target_1"] != "backup@example.de" {
+		t.Errorf("target params = %v", fc.GotParams)
+	}
+	if addr != "info@example.de" {
+		t.Errorf("returned address = %q, want info@example.de (fixture ReturnInfo)", addr)
+	}
+}
+
+func TestClientUpdate(t *testing.T) {
+	t.Parallel()
+	resp := testutil.DecodeFixture(t, "mailforward/update_mailforward_response_success.xml")
+	fc := &testutil.FakeCaller{Resp: resp}
+	if err := mailforward.NewClient(fc).Update(
+		context.Background(), "info@example.de", []string{"new-target@example.de"}); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if fc.GotAction != "update_mailforward" {
+		t.Errorf("action = %q, want update_mailforward", fc.GotAction)
+	}
+	if fc.GotParams["mail_forward"] != "info@example.de" || fc.GotParams["target_0"] != "new-target@example.de" {
+		t.Errorf("params = %v", fc.GotParams)
+	}
+}
+
+func TestClientDelete(t *testing.T) {
+	t.Parallel()
+	resp := testutil.DecodeFixture(t, "mailforward/delete_mailforward_response_success.xml")
+	fc := &testutil.FakeCaller{Resp: resp}
+	if err := mailforward.NewClient(fc).Delete(context.Background(), "info@example.de"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if fc.GotAction != "delete_mailforward" {
+		t.Errorf("action = %q, want delete_mailforward", fc.GotAction)
+	}
+	if fc.GotParams["mail_forward"] != "info@example.de" {
+		t.Errorf("params = %v", fc.GotParams)
+	}
+}
+
+func TestWriteValidation(t *testing.T) {
+	t.Parallel()
+	c := mailforward.NewClient(&testutil.FakeCaller{})
+	ctx := context.Background()
+	if _, err := c.Add(ctx, "", "example.de", []string{"a@b.de"}); err == nil {
+		t.Error("Add empty local part: err = nil, want validation error")
+	}
+	if _, err := c.Add(ctx, "info", "example.de", nil); err == nil {
+		t.Error("Add no targets: err = nil, want validation error")
+	}
+	if err := c.Update(ctx, "", []string{"a@b.de"}); err == nil {
+		t.Error("Update empty address: err = nil, want validation error")
+	}
+	if err := c.Update(ctx, "info@example.de", nil); err == nil {
+		t.Error("Update no targets: err = nil, want validation error")
+	}
+	if err := c.Delete(ctx, ""); err == nil {
+		t.Error("Delete empty address: err = nil, want validation error")
+	}
+}
+
+func TestUnexpectedReturnString(t *testing.T) {
+	t.Parallel()
+	resp := &soap.Response{Body: soap.ResponseBody{ReturnString: "FALSE"}}
+	c := mailforward.NewClient(&testutil.FakeCaller{Resp: resp})
+	ctx := context.Background()
+	if _, err := c.Add(ctx, "info", "example.de", []string{"a@b.de"}); !errors.Is(err, mailforward.ErrUnexpectedReturnString) {
+		t.Errorf("Add err = %v, want ErrUnexpectedReturnString", err)
+	}
+	if err := c.Update(ctx, "info@example.de", []string{"a@b.de"}); !errors.Is(err, mailforward.ErrUnexpectedReturnString) {
+		t.Errorf("Update err = %v, want ErrUnexpectedReturnString", err)
+	}
+	if err := c.Delete(ctx, "info@example.de"); !errors.Is(err, mailforward.ErrUnexpectedReturnString) {
+		t.Errorf("Delete err = %v, want ErrUnexpectedReturnString", err)
+	}
+}
+
+func TestWritePropagatesError(t *testing.T) {
+	t.Parallel()
+	want := errors.New("boom")
+	c := mailforward.NewClient(&testutil.FakeCaller{Err: want})
+	ctx := context.Background()
+	if _, err := c.Add(ctx, "info", "example.de", []string{"a@b.de"}); !errors.Is(err, want) {
+		t.Errorf("Add err = %v, want %v", err, want)
+	}
+	if err := c.Update(ctx, "info@example.de", []string{"a@b.de"}); !errors.Is(err, want) {
+		t.Errorf("Update err = %v, want %v", err, want)
+	}
+	if err := c.Delete(ctx, "info@example.de"); !errors.Is(err, want) {
+		t.Errorf("Delete err = %v, want %v", err, want)
+	}
+}
+
+func TestParamBuilders(t *testing.T) {
+	t.Parallel()
+	add := mailforward.AddParams("info", "example.de", []string{"a@b.de", "c@d.de"})
+	if add["local_part"] != "info" || add["domain_part"] != "example.de" ||
+		add["target_0"] != "a@b.de" || add["target_1"] != "c@d.de" {
+		t.Errorf("AddParams = %v", add)
+	}
+	upd := mailforward.UpdateParams("info@example.de", []string{"a@b.de"})
+	if upd["mail_forward"] != "info@example.de" || upd["target_0"] != "a@b.de" {
+		t.Errorf("UpdateParams = %v", upd)
+	}
+	del := mailforward.DeleteParams("info@example.de")
+	if len(del) != 1 || del["mail_forward"] != "info@example.de" {
+		t.Errorf("DeleteParams = %v", del)
+	}
+}
+
+// TestFaultFixturesDecodeToDocumentedCodes binds the captured
+// *_response_failed_*.xml fixtures to the KAS contract: each must
+// decode to a *soap.FaultError carrying a non-empty fault code, and a
+// representative documented sample must carry the exact code. This is
+// the fixture↔contract anchor for the write slice (faults reach the
+// domain layer as Caller errors in production).
+func TestFaultFixturesDecodeToDocumentedCodes(t *testing.T) {
+	t.Parallel()
+	dir := filepath.Join(testutil.RepoRoot(t), "testdata", "mailforward")
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read fixture dir: %v", err)
+	}
+	want := map[string]string{
+		"add_mailforward_response_failed_missing_parameter.xml":                "missing_parameter",
+		"add_mailforward_response_failed_mail_forward_exists_as_forward.xml":   "mail_forward_exists_as_forward",
+		"update_mailforward_response_failed_nothing_to_do.xml":                 "nothing_to_do",
+		"delete_mailforward_response_failed_mail_forward_not_found_in_kas.xml": "mail_forward_not_found_in_kas",
+	}
+	seen := 0
+	for _, e := range entries {
+		name := e.Name()
+		if !strings.Contains(name, "_response_failed_") {
+			continue
+		}
+		seen++
+		//nolint:gosec // G304: fixture path is rooted at the repo testdata/ dir.
+		f, oerr := os.Open(filepath.Join(dir, name))
+		if oerr != nil {
+			t.Fatalf("open %s: %v", name, oerr)
+		}
+		_, derr := soap.Decode(f)
+		_ = f.Close()
+		var fe *soap.FaultError
+		if !errors.As(derr, &fe) {
+			t.Errorf("%s: decode err = %v, want *soap.FaultError", name, derr)
+			continue
+		}
+		if fe.Fault.String == "" {
+			t.Errorf("%s: empty fault code", name)
+		}
+		if code, ok := want[name]; ok && fe.Fault.String != code {
+			t.Errorf("%s: fault = %q, want %q", name, fe.Fault.String, code)
+		}
+	}
+	if seen == 0 {
+		t.Fatal("no fault fixtures found under testdata/mailforward/")
+	}
+}


### PR DESCRIPTION
First #13 write slice — `add_mailforward` / `update_mailforward` / `delete_mailforward`:

- `kasapi-cli mail forwards add <addr> --target … `, `… update <addr> --target …`, `… delete <addr>`.
- `delete` and `update` are gated by the #109 confirmation prompt (`update_mailforward` replaces the whole target list and is irreversible); `add` is reversible and not prompted.
- All three honour `--dry-run` (#132) and emit a #131 audit record.
- Wired through the shared `cli.runWriteE` runner and the new non-gated `cli.ResolveWrite` counterpart of `cli.ResolveDestructive` — first end-to-end exercise of the gate/audit/dry-run seam.

Commands live in `internal/cli/mail.go` (the `forwards` tree already lives there), not a separate `internal/cli/mailforward.go` as the issue text predated the consolidation.

Closes #115
Closes #109
Closes #131
Closes #132