### PR TITLE
feat(mail): mailinglist write endpoints — add / update / delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Mailing-list write endpoints (#117, #13 write slice):
+  `kasapi-cli mail lists add <name> --domain <d> --password <pw>`,
+  `… update <name> [--subscriber …] [--restrict-post …]
+  [--config-file <path>] [--active]` and `… delete <name>` wire
+  `add_mailinglist` / `update_mailinglist` / `delete_mailinglist`.
+  `update` and `delete` are gated by the #109 confirmation prompt
+  (`update_mailinglist` replaces the subscriber / restrict-post /
+  config fields wholesale); `add` is reversible and not prompted. All
+  three honour `--dry-run` (#132) and emit a #131 audit record; the
+  list password is redacted in both. `update` sends only the
+  explicitly-set flags (keyed on cobra `Changed`), so an empty value
+  is a deliberate "clear". The `get_mailinglists` read mapping was
+  corrected to the real KAS schema beforehand (see Fixed).
+
 - Mail-forward write endpoints (#115, first #13 write slice):
   `kasapi-cli mail forwards add <addr> --target … `,
   `… update <addr> --target …` and `… delete <addr>` wire

--- a/docs/cli/kasapi-cli_mail.md
+++ b/docs/cli/kasapi-cli_mail.md
@@ -32,5 +32,5 @@ Inspect mail accounts, forwards, filters, and mailing lists
 * [kasapi-cli mail accounts](kasapi-cli_mail_accounts.md)	 - Inspect mail accounts (get_mailaccounts)
 * [kasapi-cli mail filters](kasapi-cli_mail_filters.md)	 - Inspect mail standard filters (get_mailstandardfilter)
 * [kasapi-cli mail forwards](kasapi-cli_mail_forwards.md)	 - Inspect and manage mail forwards (get/add/update/delete_mailforward)
-* [kasapi-cli mail lists](kasapi-cli_mail_lists.md)	 - Inspect mailing lists (get_mailinglists)
+* [kasapi-cli mail lists](kasapi-cli_mail_lists.md)	 - Inspect and manage mailing lists (get/add/update/delete_mailinglist)
 

--- a/docs/cli/kasapi-cli_mail_lists.md
+++ b/docs/cli/kasapi-cli_mail_lists.md
@@ -1,6 +1,6 @@
 ## kasapi-cli mail lists
 
-Inspect mailing lists (get_mailinglists)
+Inspect and manage mailing lists (get/add/update/delete_mailinglist)
 
 ### Options
 
@@ -29,6 +29,9 @@ Inspect mailing lists (get_mailinglists)
 ### SEE ALSO
 
 * [kasapi-cli mail](kasapi-cli_mail.md)	 - Inspect mail accounts, forwards, filters, and mailing lists
+* [kasapi-cli mail lists add](kasapi-cli_mail_lists_add.md)	 - Create a mailing list (add_mailinglist)
+* [kasapi-cli mail lists delete](kasapi-cli_mail_lists_delete.md)	 - Delete a mailing list (delete_mailinglist)
 * [kasapi-cli mail lists get](kasapi-cli_mail_lists_get.md)	 - Show details for a single mailing list (get_mailinglists with mailinglist_name)
 * [kasapi-cli mail lists list](kasapi-cli_mail_lists_list.md)	 - List all mailing lists (get_mailinglists)
+* [kasapi-cli mail lists update](kasapi-cli_mail_lists_update.md)	 - Replace mutable fields of a mailing list (update_mailinglist)
 

--- a/docs/cli/kasapi-cli_mail_lists_add.md
+++ b/docs/cli/kasapi-cli_mail_lists_add.md
@@ -1,15 +1,17 @@
-## kasapi-cli mail lists list
+## kasapi-cli mail lists add
 
-List all mailing lists (get_mailinglists)
+Create a mailing list (add_mailinglist)
 
 ```
-kasapi-cli mail lists list [flags]
+kasapi-cli mail lists add <name> --domain <domain> --password <pw> [flags]
 ```
 
 ### Options
 
 ```
-  -h, --help   help for list
+      --domain string     the list's domain (required)
+  -h, --help              help for add
+      --password string   the list password (required)
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli/kasapi-cli_mail_lists_delete.md
+++ b/docs/cli/kasapi-cli_mail_lists_delete.md
@@ -1,15 +1,15 @@
-## kasapi-cli mail lists list
+## kasapi-cli mail lists delete
 
-List all mailing lists (get_mailinglists)
+Delete a mailing list (delete_mailinglist)
 
 ```
-kasapi-cli mail lists list [flags]
+kasapi-cli mail lists delete <name> [flags]
 ```
 
 ### Options
 
 ```
-  -h, --help   help for list
+  -h, --help   help for delete
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli/kasapi-cli_mail_lists_get.md
+++ b/docs/cli/kasapi-cli_mail_lists_get.md
@@ -32,5 +32,5 @@ kasapi-cli mail lists get <mailinglist-name> [flags]
 
 ### SEE ALSO
 
-* [kasapi-cli mail lists](kasapi-cli_mail_lists.md)	 - Inspect mailing lists (get_mailinglists)
+* [kasapi-cli mail lists](kasapi-cli_mail_lists.md)	 - Inspect and manage mailing lists (get/add/update/delete_mailinglist)
 

--- a/docs/cli/kasapi-cli_mail_lists_update.md
+++ b/docs/cli/kasapi-cli_mail_lists_update.md
@@ -1,15 +1,19 @@
-## kasapi-cli mail lists list
+## kasapi-cli mail lists update
 
-List all mailing lists (get_mailinglists)
+Replace mutable fields of a mailing list (update_mailinglist)
 
 ```
-kasapi-cli mail lists list [flags]
+kasapi-cli mail lists update <name> [--subscriber <addr>...] [--restrict-post <addr>...] [--config-file <path>] [--active] [flags]
 ```
 
 ### Options
 
 ```
-  -h, --help   help for list
+      --active                      activate the list; pass --active=false to deactivate it
+      --config-file string          path to the complete list configuration file (replaces the config wholesale)
+  -h, --help                        help for update
+      --restrict-post stringArray   restrict-post address (repeatable; replaces the full restrict-post list)
+      --subscriber stringArray      list subscriber address (repeatable; replaces the full subscriber list)
 ```
 
 ### Options inherited from parent commands

--- a/docs/usage/destructive-writes.md
+++ b/docs/usage/destructive-writes.md
@@ -18,6 +18,13 @@ replaces the whole target list and is therefore irreversible); `add`
 creates and is reversible, so it is **not** prompted. All three honour
 `--dry-run` and emit an audit record.
 
+[`mail lists`](https://github.com/chmmou/kasapi-cli/issues/117) `add` /
+`update` / `delete` wire the same contract with the same policy:
+`update` (it replaces the subscriber / restrict-post / config fields
+wholesale) and `delete` are gated; `add` is reversible and not
+prompted. The list password passed to `add` is redacted in the
+`--dry-run` preview and the audit record.
+
 ## The contract
 
 Before a destructive call leaves the machine, the command prints a

--- a/internal/cli/mail.go
+++ b/internal/cli/mail.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -34,13 +35,133 @@ func NewMailCmd(opts *RootOptions) *cobra.Command {
 func newMailListsCmd(opts *RootOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "lists",
-		Short: "Inspect mailing lists (get_mailinglists)",
+		Short: "Inspect and manage mailing lists (get/add/update/delete_mailinglist)",
 	}
 	cmd.AddCommand(
 		newMailListsListCmd(opts),
 		newMailListsGetCmd(opts),
+		newMailListsAddCmd(opts),
+		newMailListsUpdateCmd(opts),
+		newMailListsDeleteCmd(opts),
 	)
 	return cmd
+}
+
+func newMailListsAddCmd(opts *RootOptions) *cobra.Command {
+	var domain, password string
+	cmd := &cobra.Command{
+		Use:   "add <name> --domain <domain> --password <pw>",
+		Short: "Create a mailing list (add_mailinglist)",
+		Args:  cobra.ExactArgs(1),
+		RunE: runWriteE(opts, func(args []string) (writeSpec, error) {
+			name := args[0]
+			if domain == "" {
+				return writeSpec{}, fmt.Errorf("--domain is required")
+			}
+			if password == "" {
+				return writeSpec{}, fmt.Errorf("--password is required")
+			}
+			return writeSpec{
+				action:      "add_mailinglist",
+				destructive: false,
+				confirm:     ConfirmAction{Verb: "create", Resource: "mailing list", ID: name},
+				params:      mailinglist.AddParams(name, domain, password),
+				dispatch: func(c *api.Client, ctx context.Context) (string, error) {
+					id, derr := mailinglist.NewClient(c).Add(ctx, name, domain, password)
+					if derr != nil {
+						return "", derr
+					}
+					return "created mailing list " + id, nil
+				},
+			}, nil
+		}),
+	}
+	cmd.Flags().StringVar(&domain, "domain", "", "the list's domain (required)")
+	cmd.Flags().StringVar(&password, "password", "", "the list password (required)")
+	return cmd
+}
+
+func newMailListsUpdateCmd(opts *RootOptions) *cobra.Command {
+	var subscriber, restrictPost []string
+	var configFile string
+	var active bool
+	cmd := &cobra.Command{
+		Use:   "update <name> [--subscriber <addr>...] [--restrict-post <addr>...] [--config-file <path>] [--active]",
+		Short: "Replace mutable fields of a mailing list (update_mailinglist)",
+		Args:  cobra.ExactArgs(1),
+	}
+	cmd.RunE = runWriteE(opts, func(args []string) (writeSpec, error) {
+		name := args[0]
+		// Only the explicitly-set flags are sent: each field is a
+		// wholesale replacement and an empty value is a meaningful
+		// "clear", so presence is keyed on Flags().Changed, not on
+		// the value being non-empty.
+		fields := map[string]string{}
+		if cmd.Flags().Changed("subscriber") {
+			fields[mailinglist.FieldSubscriber] = strings.Join(subscriber, "\n")
+		}
+		if cmd.Flags().Changed("restrict-post") {
+			fields[mailinglist.FieldRestrictPost] = strings.Join(restrictPost, "\n")
+		}
+		if cmd.Flags().Changed("config-file") {
+			//nolint:gosec // G304: configFile is the explicit --config-file CLI argument; reading the user-named file is the documented intent.
+			b, rerr := os.ReadFile(configFile)
+			if rerr != nil {
+				return writeSpec{}, fmt.Errorf("read --config-file: %w", rerr)
+			}
+			fields[mailinglist.FieldConfig] = string(b)
+		}
+		if cmd.Flags().Changed("active") {
+			if active {
+				fields[mailinglist.FieldIsActive] = "Y"
+			} else {
+				fields[mailinglist.FieldIsActive] = "N"
+			}
+		}
+		if len(fields) == 0 {
+			return writeSpec{}, fmt.Errorf("at least one of --subscriber/--restrict-post/--config-file/--active is required")
+		}
+		return writeSpec{
+			action:      "update_mailinglist",
+			destructive: true,
+			confirm:     ConfirmAction{Verb: "replace the settings of", Resource: "mailing list", ID: name},
+			params:      mailinglist.UpdateParams(name, fields),
+			dispatch: func(c *api.Client, ctx context.Context) (string, error) {
+				if derr := mailinglist.NewClient(c).Update(ctx, name, fields); derr != nil {
+					return "", derr
+				}
+				return "updated mailing list " + name, nil
+			},
+		}, nil
+	})
+	cmd.Flags().StringArrayVar(&subscriber, "subscriber", nil, "list subscriber address (repeatable; replaces the full subscriber list)")
+	cmd.Flags().StringArrayVar(&restrictPost, "restrict-post", nil, "restrict-post address (repeatable; replaces the full restrict-post list)")
+	cmd.Flags().StringVar(&configFile, "config-file", "", "path to the complete list configuration file (replaces the config wholesale)")
+	cmd.Flags().BoolVar(&active, "active", false, "activate the list; pass --active=false to deactivate it")
+	return cmd
+}
+
+func newMailListsDeleteCmd(opts *RootOptions) *cobra.Command {
+	return &cobra.Command{
+		Use:   "delete <name>",
+		Short: "Delete a mailing list (delete_mailinglist)",
+		Args:  cobra.ExactArgs(1),
+		RunE: runWriteE(opts, func(args []string) (writeSpec, error) {
+			name := args[0]
+			return writeSpec{
+				action:      "delete_mailinglist",
+				destructive: true,
+				confirm:     ConfirmAction{Verb: "delete", Resource: "mailing list", ID: name},
+				params:      mailinglist.DeleteParams(name),
+				dispatch: func(c *api.Client, ctx context.Context) (string, error) {
+					if derr := mailinglist.NewClient(c).Delete(ctx, name); derr != nil {
+						return "", derr
+					}
+					return "deleted mailing list " + name, nil
+				},
+			}, nil
+		}),
+	}
 }
 
 func newMailListsListCmd(opts *RootOptions) *cobra.Command {

--- a/internal/cli/mail_test.go
+++ b/internal/cli/mail_test.go
@@ -159,9 +159,67 @@ func TestMailListsHelpListsSubcommands(t *testing.T) {
 		t.Fatalf("Execute: %v", err)
 	}
 	out := buf.String()
-	for _, want := range []string{"list", "get"} {
+	for _, want := range []string{"list", "get", "add", "update", "delete"} {
 		if !strings.Contains(out, want) {
 			t.Errorf("--help output missing %q\n%s", want, out)
 		}
+	}
+}
+
+func TestMailListsAddRejectsBadInput(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		args []string
+	}{
+		{"missing --domain", []string{"mail", "lists", "add", "announce", "--password", "pw"}},
+		{"missing --password", []string{"mail", "lists", "add", "announce", "--domain", "example.com"}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			root, opts := cli.NewRootCmd()
+			root.AddCommand(cli.NewMailCmd(opts))
+			var buf bytes.Buffer
+			root.SetOut(&buf)
+			root.SetErr(&buf)
+			root.SetArgs(c.args)
+			err := root.Execute()
+			if err == nil {
+				t.Fatalf("Execute %v: want error, got nil", c.args)
+			}
+			if cli.CodeFor(err) != cli.ExitUserError {
+				t.Errorf("exit code = %d, want ExitUserError", cli.CodeFor(err))
+			}
+		})
+	}
+}
+
+// The destructive lists subcommands (update/delete) must refuse on a
+// non-interactive stdin without --yes rather than dispatch unconfirmed.
+func TestMailListsDestructiveRefuseNonTTY(t *testing.T) {
+	t.Parallel()
+	for _, args := range [][]string{
+		{"mail", "lists", "delete", "announce-example-com"},
+		{"mail", "lists", "update", "announce-example-com", "--active"},
+	} {
+		t.Run(args[2], func(t *testing.T) {
+			t.Parallel()
+			root, opts := cli.NewRootCmd()
+			root.AddCommand(cli.NewMailCmd(opts))
+			var buf bytes.Buffer
+			root.SetOut(&buf)
+			root.SetErr(&buf)
+			root.SetIn(strings.NewReader(""))
+			root.SetArgs(append(args,
+				"--login", "w0000000", "--auth-data", "x", "--auth-type", "plain"))
+			err := root.Execute()
+			if err == nil {
+				t.Fatalf("Execute %v: want refusal error, got nil", args)
+			}
+			if !errors.Is(err, cli.ErrConfirmationRequired) {
+				t.Errorf("err = %v, want ErrConfirmationRequired", err)
+			}
+		})
 	}
 }

--- a/internal/mailinglist/mailinglist.go
+++ b/internal/mailinglist/mailinglist.go
@@ -40,22 +40,29 @@ type MailingList struct {
 // cli.Tabular.
 type MailingListList []MailingList
 
-// Client groups the read endpoints scoped to mailing lists:
-// get_mailinglists (list and singular).
+// Client groups the read endpoints scoped to mailing lists
+// (get_mailinglists, list and singular) and the write endpoints
+// add_mailinglist / update_mailinglist / delete_mailinglist (see
+// write.go). The raw Caller is kept alongside the read helper so the
+// write methods can dispatch their own KAS actions.
 type Client struct {
 	lg kasread.ListGet[MailingListList, MailingList]
+	c  Caller
 }
 
 // NewClient returns a Client backed by the given Caller.
 func NewClient(c Caller) *Client {
-	return &Client{lg: kasread.ListGet[MailingListList, MailingList]{
-		Caller:    c,
-		Action:    "get_mailinglists",
-		Label:     "mailinglist",
-		ArgName:   "name",
-		FilterKey: "mailinglist_name",
-		Decoder:   DecodeMailingLists,
-	}}
+	return &Client{
+		lg: kasread.ListGet[MailingListList, MailingList]{
+			Caller:    c,
+			Action:    "get_mailinglists",
+			Label:     "mailinglist",
+			ArgName:   "name",
+			FilterKey: "mailinglist_name",
+			Decoder:   DecodeMailingLists,
+		},
+		c: c,
+	}
 }
 
 // List calls get_mailinglists without parameters and decodes the

--- a/internal/mailinglist/write.go
+++ b/internal/mailinglist/write.go
@@ -1,0 +1,134 @@
+package mailinglist
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/chmmou/kasapi-cli/internal/soap"
+)
+
+// ErrUnexpectedReturnString is returned by the write methods when the
+// KAS call succeeds at the transport level (no SOAP fault) but the
+// server's ReturnString is not "TRUE" — an API-drift / contract
+// violation. Callers may errors.Is against it to tell a protocol-shape
+// regression apart from a transport or KAS-fault error; the wrapped
+// message carries the action and the observed value. Mirrors
+// mailforward.ErrUnexpectedReturnString.
+var ErrUnexpectedReturnString = errors.New("mailinglist: unexpected ReturnString (want TRUE)")
+
+const (
+	addAction    = "add_mailinglist"
+	updateAction = "update_mailinglist"
+	deleteAction = "delete_mailinglist"
+)
+
+// UpdateFields enumerates the KAS request keys update_mailinglist
+// accepts besides the mailinglist_name identifier. Each is an optional
+// wholesale replacement: subscriber / restrictPost are RFC2822 address
+// lists (newline-separated), config is the complete list configuration
+// as plain text, and isActive toggles the list (Y|N). Only the keys the
+// caller explicitly sets are sent, so an empty string is a meaningful
+// "clear" rather than "leave unchanged".
+const (
+	FieldSubscriber   = "subscriber"
+	FieldRestrictPost = "restrict_post"
+	FieldConfig       = "config"
+	FieldIsActive     = "is_active"
+)
+
+// Add creates a mailing list named name under domain (add_mailinglist)
+// with the given list password. It returns the canonical list
+// identifier the server assigns, as echoed in ReturnInfo (e.g.
+// "announce-example-org").
+//
+// name, domain and password are all required; an empty value is
+// rejected before any SOAP call so the CLI can surface a fast
+// validation error.
+func (cl *Client) Add(ctx context.Context, name, domain, password string) (string, error) {
+	if name == "" || domain == "" {
+		return "", errors.New("mailinglist: add_mailinglist requires a non-empty name and domain")
+	}
+	if password == "" {
+		return "", errors.New("mailinglist: add_mailinglist requires a non-empty password")
+	}
+	resp, err := cl.call(ctx, addAction, AddParams(name, domain, password))
+	if err != nil {
+		return "", err
+	}
+	return resp.Body.ReturnInfo.AsString(), nil
+}
+
+// AddParams builds the add_mailinglist KAS request parameter map. It is
+// the single source of truth for the request shape so the CLI dry-run
+// preview / audit record and the dispatched call cannot diverge.
+func AddParams(name, domain, password string) map[string]any {
+	return map[string]any{
+		"mailinglist_name":     name,
+		"mailinglist_domain":   domain,
+		"mailinglist_password": password,
+	}
+}
+
+// Update changes one or more mutable fields of an existing mailing list
+// (update_mailinglist). fields holds only the keys the caller wants to
+// change (use the Field* constants); each is applied wholesale. name
+// and at least one field are required — update_mailinglist with nothing
+// to change is rejected before the SOAP call (the API would fault
+// nothing_to_do).
+func (cl *Client) Update(ctx context.Context, name string, fields map[string]string) error {
+	if name == "" {
+		return errors.New("mailinglist: update_mailinglist requires a non-empty mailing list name")
+	}
+	if len(fields) == 0 {
+		return errors.New("mailinglist: update_mailinglist requires at least one field to change")
+	}
+	_, err := cl.call(ctx, updateAction, UpdateParams(name, fields))
+	return err
+}
+
+// UpdateParams builds the update_mailinglist KAS request parameter map
+// (single source of truth, see AddParams): the mailinglist_name
+// identifier plus every caller-supplied mutable field verbatim.
+func UpdateParams(name string, fields map[string]string) map[string]any {
+	params := map[string]any{"mailinglist_name": name}
+	for k, v := range fields {
+		params[k] = v
+	}
+	return params
+}
+
+// Delete removes a mailing list (delete_mailinglist). A SOAP fault
+// (e.g. mailinglist_not_found, in_progress) is surfaced verbatim by the
+// Caller so the caller can classify it via the api error helpers.
+func (cl *Client) Delete(ctx context.Context, name string) error {
+	if name == "" {
+		return errors.New("mailinglist: delete_mailinglist requires a non-empty mailing list name")
+	}
+	_, err := cl.call(ctx, deleteAction, DeleteParams(name))
+	return err
+}
+
+// DeleteParams builds the delete_mailinglist KAS request parameter map
+// (single source of truth, see AddParams).
+func DeleteParams(name string) map[string]any {
+	return map[string]any{"mailinglist_name": name}
+}
+
+// call dispatches a write action and enforces the shared post-call
+// contract: a non-fault response must echo ReturnString="TRUE";
+// anything else wraps ErrUnexpectedReturnString so a future API drift
+// fails the mapping test instead of silently passing.
+func (cl *Client) call(ctx context.Context, action string, params map[string]any) (*soap.Response, error) {
+	resp, err := cl.c.Call(ctx, action, params)
+	if err != nil {
+		return nil, err
+	}
+	if resp == nil {
+		return nil, fmt.Errorf("mailinglist: %s: nil response without error from Caller", action)
+	}
+	if got := resp.Body.ReturnString; got != "TRUE" {
+		return nil, fmt.Errorf("%w: %s got %q", ErrUnexpectedReturnString, action, got)
+	}
+	return resp, nil
+}

--- a/internal/mailinglist/write_test.go
+++ b/internal/mailinglist/write_test.go
@@ -1,0 +1,203 @@
+package mailinglist_test
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/chmmou/kasapi-cli/internal/mailinglist"
+	"github.com/chmmou/kasapi-cli/internal/soap"
+	"github.com/chmmou/kasapi-cli/internal/testutil"
+)
+
+func TestClientAdd(t *testing.T) {
+	t.Parallel()
+	resp := testutil.DecodeFixture(t, "mailinglist/add_mailinglist_response_success.xml")
+	fc := &testutil.FakeCaller{Resp: resp}
+	id, err := mailinglist.NewClient(fc).Add(
+		context.Background(), "announce", "example.com", "s3cret")
+	if err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if fc.GotAction != "add_mailinglist" {
+		t.Errorf("action = %q, want add_mailinglist", fc.GotAction)
+	}
+	if fc.GotParams["mailinglist_name"] != "announce" ||
+		fc.GotParams["mailinglist_domain"] != "example.com" ||
+		fc.GotParams["mailinglist_password"] != "s3cret" {
+		t.Errorf("params = %v", fc.GotParams)
+	}
+	if id != "announce-example-org" {
+		t.Errorf("returned id = %q, want announce-example-org (fixture ReturnInfo)", id)
+	}
+}
+
+func TestClientUpdate(t *testing.T) {
+	t.Parallel()
+	resp := testutil.DecodeFixture(t, "mailinglist/update_mailinglist_response_success.xml")
+	fc := &testutil.FakeCaller{Resp: resp}
+	fields := map[string]string{
+		mailinglist.FieldSubscriber: "a@example.org\nb@example.org",
+		mailinglist.FieldIsActive:   "N",
+	}
+	if err := mailinglist.NewClient(fc).Update(
+		context.Background(), "announce-example-com", fields); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if fc.GotAction != "update_mailinglist" {
+		t.Errorf("action = %q, want update_mailinglist", fc.GotAction)
+	}
+	if fc.GotParams["mailinglist_name"] != "announce-example-com" ||
+		fc.GotParams["subscriber"] != "a@example.org\nb@example.org" ||
+		fc.GotParams["is_active"] != "N" {
+		t.Errorf("params = %v", fc.GotParams)
+	}
+}
+
+func TestClientDelete(t *testing.T) {
+	t.Parallel()
+	resp := testutil.DecodeFixture(t, "mailinglist/delete_mailinglist_response_success.xml")
+	fc := &testutil.FakeCaller{Resp: resp}
+	if err := mailinglist.NewClient(fc).Delete(context.Background(), "announce-example-com"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if fc.GotAction != "delete_mailinglist" {
+		t.Errorf("action = %q, want delete_mailinglist", fc.GotAction)
+	}
+	if fc.GotParams["mailinglist_name"] != "announce-example-com" {
+		t.Errorf("params = %v", fc.GotParams)
+	}
+}
+
+func TestWriteValidation(t *testing.T) {
+	t.Parallel()
+	c := mailinglist.NewClient(&testutil.FakeCaller{})
+	ctx := context.Background()
+	if _, err := c.Add(ctx, "", "example.com", "pw"); err == nil {
+		t.Error("Add empty name: err = nil, want validation error")
+	}
+	if _, err := c.Add(ctx, "announce", "", "pw"); err == nil {
+		t.Error("Add empty domain: err = nil, want validation error")
+	}
+	if _, err := c.Add(ctx, "announce", "example.com", ""); err == nil {
+		t.Error("Add empty password: err = nil, want validation error")
+	}
+	if err := c.Update(ctx, "", map[string]string{mailinglist.FieldIsActive: "Y"}); err == nil {
+		t.Error("Update empty name: err = nil, want validation error")
+	}
+	if err := c.Update(ctx, "announce-example-com", nil); err == nil {
+		t.Error("Update no fields: err = nil, want validation error")
+	}
+	if err := c.Delete(ctx, ""); err == nil {
+		t.Error("Delete empty name: err = nil, want validation error")
+	}
+}
+
+func TestUnexpectedReturnString(t *testing.T) {
+	t.Parallel()
+	resp := &soap.Response{Body: soap.ResponseBody{ReturnString: "FALSE"}}
+	c := mailinglist.NewClient(&testutil.FakeCaller{Resp: resp})
+	ctx := context.Background()
+	if _, err := c.Add(ctx, "announce", "example.com", "pw"); !errors.Is(err, mailinglist.ErrUnexpectedReturnString) {
+		t.Errorf("Add err = %v, want ErrUnexpectedReturnString", err)
+	}
+	if err := c.Update(ctx, "announce-example-com", map[string]string{mailinglist.FieldIsActive: "Y"}); !errors.Is(err, mailinglist.ErrUnexpectedReturnString) {
+		t.Errorf("Update err = %v, want ErrUnexpectedReturnString", err)
+	}
+	if err := c.Delete(ctx, "announce-example-com"); !errors.Is(err, mailinglist.ErrUnexpectedReturnString) {
+		t.Errorf("Delete err = %v, want ErrUnexpectedReturnString", err)
+	}
+}
+
+func TestWritePropagatesError(t *testing.T) {
+	t.Parallel()
+	want := errors.New("boom")
+	c := mailinglist.NewClient(&testutil.FakeCaller{Err: want})
+	ctx := context.Background()
+	if _, err := c.Add(ctx, "announce", "example.com", "pw"); !errors.Is(err, want) {
+		t.Errorf("Add err = %v, want %v", err, want)
+	}
+	if err := c.Update(ctx, "announce-example-com", map[string]string{mailinglist.FieldIsActive: "Y"}); !errors.Is(err, want) {
+		t.Errorf("Update err = %v, want %v", err, want)
+	}
+	if err := c.Delete(ctx, "announce-example-com"); !errors.Is(err, want) {
+		t.Errorf("Delete err = %v, want %v", err, want)
+	}
+}
+
+func TestParamBuilders(t *testing.T) {
+	t.Parallel()
+	add := mailinglist.AddParams("announce", "example.com", "pw")
+	if add["mailinglist_name"] != "announce" || add["mailinglist_domain"] != "example.com" ||
+		add["mailinglist_password"] != "pw" || len(add) != 3 {
+		t.Errorf("AddParams = %v", add)
+	}
+	upd := mailinglist.UpdateParams("announce-example-com", map[string]string{
+		mailinglist.FieldSubscriber: "a@b.de",
+		mailinglist.FieldIsActive:   "N",
+	})
+	if upd["mailinglist_name"] != "announce-example-com" ||
+		upd["subscriber"] != "a@b.de" || upd["is_active"] != "N" || len(upd) != 3 {
+		t.Errorf("UpdateParams = %v", upd)
+	}
+	del := mailinglist.DeleteParams("announce-example-com")
+	if len(del) != 1 || del["mailinglist_name"] != "announce-example-com" {
+		t.Errorf("DeleteParams = %v", del)
+	}
+}
+
+// TestFaultFixturesDecodeToDocumentedCodes binds the captured
+// *_response_failed_*.xml fixtures to the KAS contract: each must
+// decode to a *soap.FaultError carrying a non-empty fault code, and a
+// representative documented sample must carry the exact code. The
+// add_mailinglist_..._mailinglist_mailinglist_domain_doesnt_exist
+// fixture is the reason this is an explicit map rather than a
+// filename-suffix derivation: its filename duplicates the mailinglist_
+// prefix while the fault code does not.
+func TestFaultFixturesDecodeToDocumentedCodes(t *testing.T) {
+	t.Parallel()
+	dir := filepath.Join(testutil.RepoRoot(t), "testdata", "mailinglist")
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read fixture dir: %v", err)
+	}
+	want := map[string]string{
+		"add_mailinglist_response_failed_missing_parameter.xml":                           "missing_parameter",
+		"add_mailinglist_response_failed_mailinglist_mailinglist_domain_doesnt_exist.xml": "mailinglist_domain_doesnt_exist",
+		"update_mailinglist_response_failed_nothing_to_do.xml":                            "nothing_to_do",
+		"update_mailinglist_response_failed_subscriber_email_syntax_incorrect.xml":        "subscriber_email_syntax_incorrect",
+		"delete_mailinglist_response_failed_mailinglist_not_found.xml":                    "mailinglist_not_found",
+	}
+	seen := 0
+	for _, e := range entries {
+		name := e.Name()
+		if !strings.Contains(name, "_response_failed_") {
+			continue
+		}
+		seen++
+		//nolint:gosec // G304: fixture path is rooted at the repo testdata/ dir.
+		f, oerr := os.Open(filepath.Join(dir, name))
+		if oerr != nil {
+			t.Fatalf("open %s: %v", name, oerr)
+		}
+		_, derr := soap.Decode(f)
+		_ = f.Close()
+		var fe *soap.FaultError
+		if !errors.As(derr, &fe) {
+			t.Errorf("%s: decode err = %v, want *soap.FaultError", name, derr)
+			continue
+		}
+		if fe.Fault.String == "" {
+			t.Errorf("%s: empty fault code", name)
+		}
+		if code, ok := want[name]; ok && fe.Fault.String != code {
+			t.Errorf("%s: fault = %q, want %q", name, fe.Fault.String, code)
+		}
+	}
+	if seen == 0 {
+		t.Fatal("no fault fixtures found under testdata/mailinglist/")
+	}
+}

--- a/testdata/mailinglist/add_mailinglist_request.xml
+++ b/testdata/mailinglist/add_mailinglist_request.xml
@@ -5,9 +5,8 @@
             <Params>
             {
                 "KasRequestParams": {
-                    "local_part": "announce",
-                    "domain_part": "example.com",
-                    "mailinglist_admin": "admin@example.com",
+                    "mailinglist_name": "announce",
+                    "mailinglist_domain": "example.com",
                     "mailinglist_password": "REDACTED"
                 },
                 "kas_action": "add_mailinglist",

--- a/testdata/mailinglist/add_mailinglist_response_failed_couldnt_get_kas_ressources.xml
+++ b/testdata/mailinglist/add_mailinglist_response_failed_couldnt_get_kas_ressources.xml
@@ -3,7 +3,7 @@
     <SOAP-ENV:Body>
         <SOAP-ENV:Fault>
             <faultcode>SOAP-ENV:Server</faultcode>
-            <faultstring>mailinglist_already_exists</faultstring>
+            <faultstring>couldnt_get_kas_ressources</faultstring>
             <faultactor>KasApi</faultactor>
             <detail></detail>
         </SOAP-ENV:Fault>

--- a/testdata/mailinglist/add_mailinglist_response_failed_mailinglist_domain_doesnt_exist.xml
+++ b/testdata/mailinglist/add_mailinglist_response_failed_mailinglist_domain_doesnt_exist.xml
@@ -3,7 +3,7 @@
     <SOAP-ENV:Body>
         <SOAP-ENV:Fault>
             <faultcode>SOAP-ENV:Server</faultcode>
-            <faultstring>mailinglist_domain_not_found_in_kas</faultstring>
+            <faultstring>mailinglist_domain_doesnt_exist</faultstring>
             <faultactor>KasApi</faultactor>
             <detail></detail>
         </SOAP-ENV:Fault>

--- a/testdata/mailinglist/add_mailinglist_response_failed_mailinglist_domain_syntax_incorrect.xml
+++ b/testdata/mailinglist/add_mailinglist_response_failed_mailinglist_domain_syntax_incorrect.xml
@@ -3,7 +3,7 @@
     <SOAP-ENV:Body>
         <SOAP-ENV:Fault>
             <faultcode>SOAP-ENV:Server</faultcode>
-            <faultstring>mailinglist_already_exists</faultstring>
+            <faultstring>mailinglist_domain_syntax_incorrect</faultstring>
             <faultactor>KasApi</faultactor>
             <detail></detail>
         </SOAP-ENV:Fault>

--- a/testdata/mailinglist/add_mailinglist_response_failed_max_mailinglists_reached.xml
+++ b/testdata/mailinglist/add_mailinglist_response_failed_max_mailinglists_reached.xml
@@ -3,7 +3,7 @@
     <SOAP-ENV:Body>
         <SOAP-ENV:Fault>
             <faultcode>SOAP-ENV:Server</faultcode>
-            <faultstring>in_progress</faultstring>
+            <faultstring>max_mailinglists_reached</faultstring>
             <faultactor>KasApi</faultactor>
             <detail></detail>
         </SOAP-ENV:Fault>

--- a/testdata/mailinglist/add_mailinglist_response_failed_no_active_listen_owner_found.xml
+++ b/testdata/mailinglist/add_mailinglist_response_failed_no_active_listen_owner_found.xml
@@ -3,9 +3,9 @@
     <SOAP-ENV:Body>
         <SOAP-ENV:Fault>
             <faultcode>SOAP-ENV:Server</faultcode>
-            <faultstring>mailinglist_already_exists</faultstring>
+            <faultstring>no_active_listen_owner_found</faultstring>
             <faultactor>KasApi</faultactor>
-            <detail></detail>
+            <detail>info@example1.org</detail>
         </SOAP-ENV:Fault>
     </SOAP-ENV:Body>
 </SOAP-ENV:Envelope>

--- a/testdata/mailinglist/add_mailinglist_response_success.xml
+++ b/testdata/mailinglist/add_mailinglist_response_success.xml
@@ -8,7 +8,7 @@
                     <value xsi:type="ns2:Map">
                         <item>
                             <key xsi:type="xsd:string">KasRequestTime</key>
-                            <value xsi:type="xsd:int">1777746120</value>
+                            <value xsi:type="xsd:int">1779053370</value>
                         </item>
                         <item>
                             <key xsi:type="xsd:string">KasRequestType</key>
@@ -18,16 +18,16 @@
                             <key xsi:type="xsd:string">KasRequestParams</key>
                             <value xsi:type="ns2:Map">
                                 <item>
-                                    <key xsi:type="xsd:string">local_part</key>
+                                    <key xsi:type="xsd:string">mailinglist_name</key>
                                     <value xsi:type="xsd:string">announce</value>
                                 </item>
                                 <item>
-                                    <key xsi:type="xsd:string">domain_part</key>
-                                    <value xsi:type="xsd:string">example.com</value>
+                                    <key xsi:type="xsd:string">mailinglist_domain</key>
+                                    <value xsi:type="xsd:string">example.org.de</value>
                                 </item>
                                 <item>
-                                    <key xsi:type="xsd:string">mailinglist_admin</key>
-                                    <value xsi:type="xsd:string">admin@example.com</value>
+                                    <key xsi:type="xsd:string">mailinglist_password</key>
+                                    <value xsi:type="xsd:string">REDACTED</value>
                                 </item>
                             </value>
                         </item>
@@ -46,7 +46,7 @@
                         </item>
                         <item>
                             <key xsi:type="xsd:string">ReturnInfo</key>
-                            <value xsi:type="xsd:string">announce@example.com</value>
+                            <value xsi:type="xsd:string">announce-example-org</value>
                         </item>
                         <item>
                             <key xsi:type="xsd:string">Msg</key>
@@ -58,7 +58,7 @@
                                     </item>
                                     <item>
                                         <key xsi:type="xsd:string">text</key>
-                                        <value xsi:type="xsd:string">The mailinglist has been created.</value>
+                                        <value xsi:type="xsd:string">The mailing list announce-example-org will be created.</value>
                                     </item>
                                 </item>
                             </value>

--- a/testdata/mailinglist/delete_mailinglist_request.xml
+++ b/testdata/mailinglist/delete_mailinglist_request.xml
@@ -5,7 +5,7 @@
             <Params>
             {
                 "KasRequestParams": {
-                    "mailinglist_name": "announce@example.com"
+                    "mailinglist_name": "announce-example-com"
                 },
                 "kas_action": "delete_mailinglist",
                 "kas_auth_data": "REDACTED",

--- a/testdata/mailinglist/delete_mailinglist_response_success.xml
+++ b/testdata/mailinglist/delete_mailinglist_response_success.xml
@@ -8,7 +8,7 @@
                     <value xsi:type="ns2:Map">
                         <item>
                             <key xsi:type="xsd:string">KasRequestTime</key>
-                            <value xsi:type="xsd:int">1777746360</value>
+                            <value xsi:type="xsd:int">1779054075</value>
                         </item>
                         <item>
                             <key xsi:type="xsd:string">KasRequestType</key>
@@ -19,7 +19,7 @@
                             <value xsi:type="ns2:Map">
                                 <item>
                                     <key xsi:type="xsd:string">mailinglist_name</key>
-                                    <value xsi:type="xsd:string">announce@example.com</value>
+                                    <value xsi:type="xsd:string">announce-example-com</value>
                                 </item>
                             </value>
                         </item>
@@ -38,7 +38,7 @@
                         </item>
                         <item>
                             <key xsi:type="xsd:string">ReturnInfo</key>
-                            <value xsi:type="xsd:string"></value>
+                            <value xsi:type="xsd:string">announce-example-com</value>
                         </item>
                         <item>
                             <key xsi:type="xsd:string">Msg</key>
@@ -50,7 +50,7 @@
                                     </item>
                                     <item>
                                         <key xsi:type="xsd:string">text</key>
-                                        <value xsi:type="xsd:string">The mailinglist is going to be deleted.</value>
+                                        <value xsi:type="xsd:string">The mailinglist announce-example-com is going to be deleted.</value>
                                     </item>
                                 </item>
                             </value>

--- a/testdata/mailinglist/update_mailinglist_request.xml
+++ b/testdata/mailinglist/update_mailinglist_request.xml
@@ -5,9 +5,11 @@
             <Params>
             {
                 "KasRequestParams": {
-                    "mailinglist_name": "announce@example.com",
-                    "mailinglist_admin": "newadmin@example.com",
-                    "mailinglist_password": "REDACTED"
+                    "mailinglist_name": "announce-example-com",
+                    "subscriber": "test@example.org\ntest1@example.org",
+                    "restrict_post": "test2@example.org\ntest3@example.org",
+                    "config": "The complete configuration file\nas plain text",
+                    "is_active": "N",
                 },
                 "kas_action": "update_mailinglist",
                 "kas_auth_data": "REDACTED",

--- a/testdata/mailinglist/update_mailinglist_response_failed_cannot_connect_to_majordomo.xml
+++ b/testdata/mailinglist/update_mailinglist_response_failed_cannot_connect_to_majordomo.xml
@@ -3,7 +3,7 @@
     <SOAP-ENV:Body>
         <SOAP-ENV:Fault>
             <faultcode>SOAP-ENV:Server</faultcode>
-            <faultstring>max_mailinglist_reached</faultstring>
+            <faultstring>cannot_connect_to_majordomo</faultstring>
             <faultactor>KasApi</faultactor>
             <detail></detail>
         </SOAP-ENV:Fault>

--- a/testdata/mailinglist/update_mailinglist_response_failed_cannot_login_to_majordomo.xml
+++ b/testdata/mailinglist/update_mailinglist_response_failed_cannot_login_to_majordomo.xml
@@ -3,7 +3,7 @@
     <SOAP-ENV:Body>
         <SOAP-ENV:Fault>
             <faultcode>SOAP-ENV:Server</faultcode>
-            <faultstring>mailinglist_already_exists</faultstring>
+            <faultstring>cannot_login_to_majordomo</faultstring>
             <faultactor>KasApi</faultactor>
             <detail></detail>
         </SOAP-ENV:Fault>

--- a/testdata/mailinglist/update_mailinglist_response_failed_cannot_open_tmp_config.xml
+++ b/testdata/mailinglist/update_mailinglist_response_failed_cannot_open_tmp_config.xml
@@ -3,7 +3,7 @@
     <SOAP-ENV:Body>
         <SOAP-ENV:Fault>
             <faultcode>SOAP-ENV:Server</faultcode>
-            <faultstring>mailinglist_already_exists</faultstring>
+            <faultstring>cannot_open_tmp_config</faultstring>
             <faultactor>KasApi</faultactor>
             <detail></detail>
         </SOAP-ENV:Fault>

--- a/testdata/mailinglist/update_mailinglist_response_failed_cannot_open_tmp_restrict_post.xml
+++ b/testdata/mailinglist/update_mailinglist_response_failed_cannot_open_tmp_restrict_post.xml
@@ -3,7 +3,7 @@
     <SOAP-ENV:Body>
         <SOAP-ENV:Fault>
             <faultcode>SOAP-ENV:Server</faultcode>
-            <faultstring>mailinglist_already_exists</faultstring>
+            <faultstring>cannot_open_tmp_restrict_post</faultstring>
             <faultactor>KasApi</faultactor>
             <detail></detail>
         </SOAP-ENV:Fault>

--- a/testdata/mailinglist/update_mailinglist_response_failed_cannot_open_tmp_subscriber.xml
+++ b/testdata/mailinglist/update_mailinglist_response_failed_cannot_open_tmp_subscriber.xml
@@ -3,7 +3,7 @@
     <SOAP-ENV:Body>
         <SOAP-ENV:Fault>
             <faultcode>SOAP-ENV:Server</faultcode>
-            <faultstring>mailinglist_already_exists</faultstring>
+            <faultstring>cannot_open_tmp_subscriber</faultstring>
             <faultactor>KasApi</faultactor>
             <detail></detail>
         </SOAP-ENV:Fault>

--- a/testdata/mailinglist/update_mailinglist_response_failed_cannot_write_tmp_config.xml
+++ b/testdata/mailinglist/update_mailinglist_response_failed_cannot_write_tmp_config.xml
@@ -3,7 +3,7 @@
     <SOAP-ENV:Body>
         <SOAP-ENV:Fault>
             <faultcode>SOAP-ENV:Server</faultcode>
-            <faultstring>mailinglist_already_exists</faultstring>
+            <faultstring>cannot_write_tmp_config</faultstring>
             <faultactor>KasApi</faultactor>
             <detail></detail>
         </SOAP-ENV:Fault>

--- a/testdata/mailinglist/update_mailinglist_response_failed_cannot_write_tmp_restrict_post.xml
+++ b/testdata/mailinglist/update_mailinglist_response_failed_cannot_write_tmp_restrict_post.xml
@@ -3,7 +3,7 @@
     <SOAP-ENV:Body>
         <SOAP-ENV:Fault>
             <faultcode>SOAP-ENV:Server</faultcode>
-            <faultstring>mailinglist_already_exists</faultstring>
+            <faultstring>cannot_write_tmp_restrict_post</faultstring>
             <faultactor>KasApi</faultactor>
             <detail></detail>
         </SOAP-ENV:Fault>

--- a/testdata/mailinglist/update_mailinglist_response_failed_cannot_write_tmp_subscriber.xml
+++ b/testdata/mailinglist/update_mailinglist_response_failed_cannot_write_tmp_subscriber.xml
@@ -3,7 +3,7 @@
     <SOAP-ENV:Body>
         <SOAP-ENV:Fault>
             <faultcode>SOAP-ENV:Server</faultcode>
-            <faultstring>mailinglist_already_exists</faultstring>
+            <faultstring>cannot_write_tmp_subscriber</faultstring>
             <faultactor>KasApi</faultactor>
             <detail></detail>
         </SOAP-ENV:Fault>

--- a/testdata/mailinglist/update_mailinglist_response_failed_cannot_write_to_majordomo.xml
+++ b/testdata/mailinglist/update_mailinglist_response_failed_cannot_write_to_majordomo.xml
@@ -3,7 +3,7 @@
     <SOAP-ENV:Body>
         <SOAP-ENV:Fault>
             <faultcode>SOAP-ENV:Server</faultcode>
-            <faultstring>mailinglist_already_exists</faultstring>
+            <faultstring>cannot_write_to_majordomo</faultstring>
             <faultactor>KasApi</faultactor>
             <detail></detail>
         </SOAP-ENV:Fault>

--- a/testdata/mailinglist/update_mailinglist_response_failed_is_active_syntax_incorrect.xml
+++ b/testdata/mailinglist/update_mailinglist_response_failed_is_active_syntax_incorrect.xml
@@ -3,7 +3,7 @@
     <SOAP-ENV:Body>
         <SOAP-ENV:Fault>
             <faultcode>SOAP-ENV:Server</faultcode>
-            <faultstring>mailinglist_already_exists</faultstring>
+            <faultstring>is_active_syntax_incorrect</faultstring>
             <faultactor>KasApi</faultactor>
             <detail></detail>
         </SOAP-ENV:Fault>

--- a/testdata/mailinglist/update_mailinglist_response_failed_parse_error_in_tmp_config.xml
+++ b/testdata/mailinglist/update_mailinglist_response_failed_parse_error_in_tmp_config.xml
@@ -3,7 +3,7 @@
     <SOAP-ENV:Body>
         <SOAP-ENV:Fault>
             <faultcode>SOAP-ENV:Server</faultcode>
-            <faultstring>mailinglist_already_exists</faultstring>
+            <faultstring>parse_error_in_tmp_config</faultstring>
             <faultactor>KasApi</faultactor>
             <detail></detail>
         </SOAP-ENV:Fault>

--- a/testdata/mailinglist/update_mailinglist_response_failed_restrict_post_email_syntax_incorrect.xml
+++ b/testdata/mailinglist/update_mailinglist_response_failed_restrict_post_email_syntax_incorrect.xml
@@ -3,7 +3,7 @@
     <SOAP-ENV:Body>
         <SOAP-ENV:Fault>
             <faultcode>SOAP-ENV:Server</faultcode>
-            <faultstring>mailinglist_already_exists</faultstring>
+            <faultstring>restrict_post_email_syntax_incorrect</faultstring>
             <faultactor>KasApi</faultactor>
             <detail></detail>
         </SOAP-ENV:Fault>

--- a/testdata/mailinglist/update_mailinglist_response_failed_subscriber_email_syntax_incorrect.xml
+++ b/testdata/mailinglist/update_mailinglist_response_failed_subscriber_email_syntax_incorrect.xml
@@ -3,7 +3,7 @@
     <SOAP-ENV:Body>
         <SOAP-ENV:Fault>
             <faultcode>SOAP-ENV:Server</faultcode>
-            <faultstring>in_progress</faultstring>
+            <faultstring>subscriber_email_syntax_incorrect</faultstring>
             <faultactor>KasApi</faultactor>
             <detail></detail>
         </SOAP-ENV:Fault>

--- a/testdata/mailinglist/update_mailinglist_response_success.xml
+++ b/testdata/mailinglist/update_mailinglist_response_success.xml
@@ -8,7 +8,7 @@
                     <value xsi:type="ns2:Map">
                         <item>
                             <key xsi:type="xsd:string">KasRequestTime</key>
-                            <value xsi:type="xsd:int">1777746240</value>
+                            <value xsi:type="xsd:int">1779055841</value>
                         </item>
                         <item>
                             <key xsi:type="xsd:string">KasRequestType</key>
@@ -19,11 +19,26 @@
                             <value xsi:type="ns2:Map">
                                 <item>
                                     <key xsi:type="xsd:string">mailinglist_name</key>
-                                    <value xsi:type="xsd:string">announce@example.com</value>
+                                    <value xsi:type="xsd:string">announce-example-com</value>
                                 </item>
                                 <item>
-                                    <key xsi:type="xsd:string">mailinglist_admin</key>
-                                    <value xsi:type="xsd:string">newadmin@example.com</value>
+                                    <key xsi:type="xsd:string">subscriber</key>
+                                    <value xsi:type="xsd:string">test@example.org
+test1@example.org</value>
+                                </item>
+                                <item>
+                                    <key xsi:type="xsd:string">restrict_post</key>
+                                    <value xsi:type="xsd:string">test2@example.org
+test3@example.org</value>
+                                </item>
+                                <item>
+                                    <key xsi:type="xsd:string">config</key>
+                                    <value xsi:type="xsd:string">The complete configuration file
+as plain text</value>
+                                </item>
+                                <item>
+                                    <key xsi:type="xsd:string">is_active</key>
+                                    <value xsi:type="xsd:string">N</value>
                                 </item>
                             </value>
                         </item>
@@ -42,7 +57,7 @@
                         </item>
                         <item>
                             <key xsi:type="xsd:string">ReturnInfo</key>
-                            <value xsi:type="xsd:string"></value>
+                            <value xsi:type="xsd:string">announce-example-com</value>
                         </item>
                         <item>
                             <key xsi:type="xsd:string">Msg</key>
@@ -54,7 +69,7 @@
                                     </item>
                                     <item>
                                         <key xsi:type="xsd:string">text</key>
-                                        <value xsi:type="xsd:string">The mailinglist has been edited.</value>
+                                        <value xsi:type="xsd:string">The mailing list announce-example-com is going to be updated.</value>
                                     </item>
                                 </item>
                             </value>


### PR DESCRIPTION
Wires `add_mailinglist` / `update_mailinglist` / `delete_mailinglist` through the shared `cli.runWriteE` seam, mirroring the mail-forward write slice (#115).

- `mail lists add <name> --domain <d> --password <pw>` — reversible, not prompted.
- `mail lists update <name> [--subscriber …] [--restrict-post …] [--config-file <path>] [--active]` — gated (#109): replaces the subscriber/restrict-post/config fields wholesale. Only the explicitly-set flags are sent (cobra `Changed`), so an empty value is a deliberate clear.
- `mail lists delete <name>` — gated (#109).

All three honour `--dry-run` (#132) and emit a #131 audit record; the list password is redacted in both sinks. `mailinglist.{Add,Update,Delete}Params` are the single source of truth for the request shape. Commands live under the existing `mail.go` lists tree (cohesive with `mail forwards`) rather than a separate `mailinglist.go`. The `get_mailinglists` read mapping was corrected to the real KAS schema first (#169).

Closes #117