### PR TITLE
fix(cli): escape newlines in audit logfmt field values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -260,6 +260,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Audit logfmt records no longer split across physical lines. A write
+  field value containing a newline or carriage return (now reachable
+  via `mail lists update --subscriber …` / `--config-file`) is escaped
+  to the two-character `\n` / `\r` inside a quoted value in the stderr
+  `logfmt` line, so a logfmt consumer can parse each record atomically.
+  The JSON-Lines `--audit-log` sink was already correct. (#117
+  re-review follow-up.)
+
 - `get_mailinglists` response mapping corrected to the real KAS
   schema. The `mailinglist.MailingList` model previously carried
   `mailinglist_admin` / `mailinglist_url`, which the API does not

--- a/internal/cli/audit.go
+++ b/internal/cli/audit.go
@@ -129,15 +129,19 @@ func (r AuditRecord) logfmt() string {
 	return b.String()
 }
 
-// quoteIfNeeded wraps v in double quotes (escaping \ and ") when it is
-// empty or contains whitespace, a quote, or '=' so the logfmt line
-// stays unambiguous to split on.
+// quoteIfNeeded wraps v in double quotes when it is empty or contains
+// whitespace, a quote, or '=' so the logfmt line stays unambiguous to
+// split on. Backslash and quote are escaped; a newline or carriage
+// return is escaped to the two-character \n / \r so a single field
+// value can never split the record across physical lines (multi-line
+// values reach here via e.g. update_mailinglist --subscriber /
+// --config-file).
 func quoteIfNeeded(v string) string {
 	if v == "" {
 		return `""`
 	}
-	if strings.ContainsAny(v, " \t\"=") {
-		return `"` + strings.NewReplacer(`\`, `\\`, `"`, `\"`).Replace(v) + `"`
+	if strings.ContainsAny(v, " \t\r\n\"=") {
+		return `"` + strings.NewReplacer(`\`, `\\`, `"`, `\"`, "\n", `\n`, "\r", `\r`).Replace(v) + `"`
 	}
 	return v
 }

--- a/internal/cli/audit_test.go
+++ b/internal/cli/audit_test.go
@@ -105,6 +105,34 @@ func TestAuditRecordLogfmt(t *testing.T) {
 	}
 }
 
+// A field value containing a newline (e.g. update_mailinglist
+// --subscriber a@x --subscriber b@x, or --config-file content) must not
+// split the stderr audit record across physical lines: the embedded
+// newline is escaped to the two-character \n inside a quoted value, so
+// the record stays a single logfmt line.
+func TestAuditRecordLogfmtEscapesNewlines(t *testing.T) {
+	t.Parallel()
+	var stderr bytes.Buffer
+	rec := cli.AuditRecord{
+		Time:    time.Date(2026, 5, 18, 12, 0, 0, 0, time.UTC),
+		Login:   "w0000001",
+		Action:  "update_mailinglist",
+		Target:  "announce-example-com",
+		Outcome: "success",
+		Fields:  cli.RedactParams(map[string]any{"subscriber": "a@x.de\nb@x.de"}),
+	}
+	if err := cli.WriteAudit(&stderr, nil, rec); err != nil {
+		t.Fatalf("WriteAudit: %v", err)
+	}
+	line := stderr.String()
+	if got := strings.Count(line, "\n"); got != 1 {
+		t.Errorf("record spans %d newlines, want exactly 1 (the terminator):\n%q", got, line)
+	}
+	if !strings.Contains(line, `subscriber="a@x.de\nb@x.de"`) {
+		t.Errorf("newline not escaped to \\n in:\n%q", line)
+	}
+}
+
 func TestWriteAuditFileJSONL(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()


### PR DESCRIPTION
`quoteIfNeeded` escaped backslash and quote but not a newline / carriage return, so a write field value containing one — now reachable via `mail lists update --subscriber …` / `--config-file` — split the stderr logfmt audit record across physical lines and broke atomic parsing. It now also triggers quoting on `\r`/`\n` and escapes them to the two-character `\n` / `\r`. The JSON-Lines `--audit-log` sink was already correct.

#117 re-review follow-up.