### PR TITLE
fix(cli): align mail command descriptions and cover mailinglist update assembly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -260,6 +260,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `kasapi-cli mail` help no longer under-describes its subtree: the
+  parent `Short` said only "Inspect …" while `forwards` and `lists`
+  now also add/update/delete. It now reads "Inspect mail accounts and
+  filters; inspect and manage forwards and mailing lists" (regenerated
+  in `docs/cli/`). Stale `NewMailCmd` comment and the
+  `update_mailinglist` field-constant doc comment corrected; the
+  destructive-writes doc now matches the gated `update` prompt wording.
+  Added a `mail lists update --dry-run` regression test pinning the
+  cobra-`Changed` field assembly (`--active`→Y/N, omitted-not-sent,
+  repeated `--subscriber` newline-join). #117 re-review follow-up.
+
 - Audit logfmt records no longer split across physical lines. A write
   field value containing a newline or carriage return (now reachable
   via `mail lists update --subscriber …` / `--config-file`) is escaped

--- a/docs/cli/kasapi-cli.md
+++ b/docs/cli/kasapi-cli.md
@@ -41,7 +41,7 @@ kasapi-cli [flags]
 * [kasapi-cli dns](kasapi-cli_dns.md)	 - Inspect DNS records for a zone
 * [kasapi-cli domains](kasapi-cli_domains.md)	 - Inspect domains owned by the authenticated account
 * [kasapi-cli ftpusers](kasapi-cli_ftpusers.md)	 - Inspect FTP users visible to the login (get_ftpusers)
-* [kasapi-cli mail](kasapi-cli_mail.md)	 - Inspect mail accounts, forwards, filters, and mailing lists
+* [kasapi-cli mail](kasapi-cli_mail.md)	 - Inspect mail accounts and filters; inspect and manage forwards and mailing lists
 * [kasapi-cli sambausers](kasapi-cli_sambausers.md)	 - Inspect Samba/CIFS users visible to the login (get_sambausers)
 * [kasapi-cli server](kasapi-cli_server.md)	 - Inspect the host server kasapi-cli is talking to
 * [kasapi-cli sessions](kasapi-cli_sessions.md)	 - Manage KAS session tokens (delete_session)

--- a/docs/cli/kasapi-cli_mail.md
+++ b/docs/cli/kasapi-cli_mail.md
@@ -1,6 +1,6 @@
 ## kasapi-cli mail
 
-Inspect mail accounts, forwards, filters, and mailing lists
+Inspect mail accounts and filters; inspect and manage forwards and mailing lists
 
 ### Options
 

--- a/docs/cli/kasapi-cli_mail_accounts.md
+++ b/docs/cli/kasapi-cli_mail_accounts.md
@@ -28,7 +28,7 @@ Inspect mail accounts (get_mailaccounts)
 
 ### SEE ALSO
 
-* [kasapi-cli mail](kasapi-cli_mail.md)	 - Inspect mail accounts, forwards, filters, and mailing lists
+* [kasapi-cli mail](kasapi-cli_mail.md)	 - Inspect mail accounts and filters; inspect and manage forwards and mailing lists
 * [kasapi-cli mail accounts get](kasapi-cli_mail_accounts_get.md)	 - Show details for a single mail account (get_mailaccounts with mail_login)
 * [kasapi-cli mail accounts list](kasapi-cli_mail_accounts_list.md)	 - List all mail accounts (get_mailaccounts)
 

--- a/docs/cli/kasapi-cli_mail_filters.md
+++ b/docs/cli/kasapi-cli_mail_filters.md
@@ -28,6 +28,6 @@ Inspect mail standard filters (get_mailstandardfilter)
 
 ### SEE ALSO
 
-* [kasapi-cli mail](kasapi-cli_mail.md)	 - Inspect mail accounts, forwards, filters, and mailing lists
+* [kasapi-cli mail](kasapi-cli_mail.md)	 - Inspect mail accounts and filters; inspect and manage forwards and mailing lists
 * [kasapi-cli mail filters list](kasapi-cli_mail_filters_list.md)	 - List the available standard mail filters (get_mailstandardfilter)
 

--- a/docs/cli/kasapi-cli_mail_forwards.md
+++ b/docs/cli/kasapi-cli_mail_forwards.md
@@ -28,7 +28,7 @@ Inspect and manage mail forwards (get/add/update/delete_mailforward)
 
 ### SEE ALSO
 
-* [kasapi-cli mail](kasapi-cli_mail.md)	 - Inspect mail accounts, forwards, filters, and mailing lists
+* [kasapi-cli mail](kasapi-cli_mail.md)	 - Inspect mail accounts and filters; inspect and manage forwards and mailing lists
 * [kasapi-cli mail forwards add](kasapi-cli_mail_forwards_add.md)	 - Create a mail forward (add_mailforward)
 * [kasapi-cli mail forwards delete](kasapi-cli_mail_forwards_delete.md)	 - Delete a mail forward (delete_mailforward)
 * [kasapi-cli mail forwards get](kasapi-cli_mail_forwards_get.md)	 - Show details for a single mail forward (get_mailforwards with mail_forward)

--- a/docs/cli/kasapi-cli_mail_lists.md
+++ b/docs/cli/kasapi-cli_mail_lists.md
@@ -28,7 +28,7 @@ Inspect and manage mailing lists (get/add/update/delete_mailinglist)
 
 ### SEE ALSO
 
-* [kasapi-cli mail](kasapi-cli_mail.md)	 - Inspect mail accounts, forwards, filters, and mailing lists
+* [kasapi-cli mail](kasapi-cli_mail.md)	 - Inspect mail accounts and filters; inspect and manage forwards and mailing lists
 * [kasapi-cli mail lists add](kasapi-cli_mail_lists_add.md)	 - Create a mailing list (add_mailinglist)
 * [kasapi-cli mail lists delete](kasapi-cli_mail_lists_delete.md)	 - Delete a mailing list (delete_mailinglist)
 * [kasapi-cli mail lists get](kasapi-cli_mail_lists_get.md)	 - Show details for a single mailing list (get_mailinglists with mailinglist_name)

--- a/docs/usage/destructive-writes.md
+++ b/docs/usage/destructive-writes.md
@@ -20,10 +20,12 @@ creates and is reversible, so it is **not** prompted. All three honour
 
 [`mail lists`](https://github.com/chmmou/kasapi-cli/issues/117) `add` /
 `update` / `delete` wire the same contract with the same policy:
-`update` (it replaces the subscriber / restrict-post / config fields
-wholesale) and `delete` are gated; `add` is reversible and not
-prompted. The list password passed to `add` is redacted in the
-`--dry-run` preview and the audit record.
+`update` and `delete` are gated; `add` is reversible and not prompted.
+`update` is gated because the fields it sets — subscriber,
+restrict-post and config — are each replaced wholesale (the
+confirmation prompt phrases this as replacing the list's *settings*).
+The list password passed to `add` is redacted in the `--dry-run`
+preview and the audit record.
 
 ## The contract
 

--- a/internal/cli/mail.go
+++ b/internal/cli/mail.go
@@ -15,13 +15,14 @@ import (
 	"github.com/chmmou/kasapi-cli/internal/mailinglist"
 )
 
-// NewMailCmd returns the "kasapi-cli mail" subcommand tree, grouping
-// the mail-related read endpoints (mail accounts; later forwards,
-// filters, mailing lists).
+// NewMailCmd returns the "kasapi-cli mail" subcommand tree: accounts
+// and standard filters are read-only (get_mailaccounts /
+// get_mailstandardfilter), while forwards and mailing lists are read
+// plus the add/update/delete write endpoints.
 func NewMailCmd(opts *RootOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "mail",
-		Short: "Inspect mail accounts, forwards, filters, and mailing lists",
+		Short: "Inspect mail accounts and filters; inspect and manage forwards and mailing lists",
 	}
 	cmd.AddCommand(
 		newMailAccountsCmd(opts),

--- a/internal/cli/mail_test.go
+++ b/internal/cli/mail_test.go
@@ -2,6 +2,7 @@ package cli_test
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"strings"
 	"testing"
@@ -219,6 +220,78 @@ func TestMailListsDestructiveRefuseNonTTY(t *testing.T) {
 			}
 			if !errors.Is(err, cli.ErrConfirmationRequired) {
 				t.Errorf("err = %v, want ErrConfirmationRequired", err)
+			}
+		})
+	}
+}
+
+// The mail lists update field assembly is the most intricate part of
+// the slice: only flags the user explicitly set are sent (keyed on
+// cobra Changed), --active maps to is_active Y/N, and --subscriber /
+// --restrict-post repeats join with a newline. --dry-run renders the
+// exact KAS params it would dispatch as JSON, so this asserts the
+// assembly end to end without a network call.
+func TestMailListsUpdateDryRunFieldAssembly(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name   string
+		args   []string
+		want   map[string]string
+		absent []string
+	}{
+		{
+			"active true",
+			[]string{"mail", "lists", "update", "L", "--active"},
+			map[string]string{"mailinglist_name": "L", "is_active": "Y"},
+			[]string{"subscriber", "restrict_post", "config"},
+		},
+		{
+			"active false",
+			[]string{"mail", "lists", "update", "L", "--active=false"},
+			map[string]string{"mailinglist_name": "L", "is_active": "N"},
+			nil,
+		},
+		{
+			"subscriber repeats join with newline",
+			[]string{"mail", "lists", "update", "L", "--subscriber", "a@x.de", "--subscriber", "b@x.de"},
+			map[string]string{"mailinglist_name": "L", "subscriber": "a@x.de\nb@x.de"},
+			[]string{"is_active"},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			root, opts := cli.NewRootCmd()
+			root.AddCommand(cli.NewMailCmd(opts))
+			var out, errb bytes.Buffer
+			root.SetOut(&out)
+			root.SetErr(&errb)
+			args := append(append([]string{}, c.args...),
+				"--dry-run", "-o", "json",
+				"--login", "w0", "--auth-data", "x", "--auth-type", "plain")
+			root.SetArgs(args)
+			if err := root.Execute(); err != nil {
+				t.Fatalf("Execute %v: %v", args, err)
+			}
+			var got struct {
+				Action string            `json:"action"`
+				Params map[string]string `json:"params"`
+			}
+			if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+				t.Fatalf("unmarshal preview: %v\nstdout:%s", err, out.String())
+			}
+			if got.Action != "update_mailinglist" {
+				t.Errorf("action = %q, want update_mailinglist", got.Action)
+			}
+			for k, v := range c.want {
+				if got.Params[k] != v {
+					t.Errorf("params[%q] = %q, want %q (full: %v)", k, got.Params[k], v, got.Params)
+				}
+			}
+			for _, k := range c.absent {
+				if _, ok := got.Params[k]; ok {
+					t.Errorf("params[%q] present, want absent (full: %v)", k, got.Params)
+				}
 			}
 		})
 	}

--- a/internal/mailinglist/write.go
+++ b/internal/mailinglist/write.go
@@ -23,13 +23,14 @@ const (
 	deleteAction = "delete_mailinglist"
 )
 
-// UpdateFields enumerates the KAS request keys update_mailinglist
-// accepts besides the mailinglist_name identifier. Each is an optional
-// wholesale replacement: subscriber / restrictPost are RFC2822 address
-// lists (newline-separated), config is the complete list configuration
-// as plain text, and isActive toggles the list (Y|N). Only the keys the
-// caller explicitly sets are sent, so an empty string is a meaningful
-// "clear" rather than "leave unchanged".
+// The Field-prefixed constants are the KAS request keys
+// update_mailinglist accepts besides the mailinglist_name identifier.
+// FieldSubscriber / FieldRestrictPost are RFC2822 address lists
+// (newline-separated), FieldConfig is the complete list configuration
+// as plain text, and FieldIsActive toggles the list (Y|N). Each is an
+// optional wholesale replacement; only the keys the caller explicitly
+// sets are sent, so an empty string is a meaningful "clear" rather than
+// "leave unchanged".
 const (
 	FieldSubscriber   = "subscriber"
 	FieldRestrictPost = "restrict_post"


### PR DESCRIPTION
#117 re-review follow-up (no Blocker; Shoulds + documentation consistency).

- `mail` parent `Short` under-described its subtree ("Inspect …" while `forwards`/`lists` also add/update/delete) — now accurate and regenerated across `docs/cli/`.
- Stale `NewMailCmd` comment and the `update_mailinglist` field-constant doc comment (named a non-existent `UpdateFields`) corrected.
- `destructive-writes.md` now matches the gated `update` prompt wording instead of over-claiming a wholesale field replace.
- New `TestMailListsUpdateDryRunFieldAssembly`: `--dry-run` JSON-preview test pinning the cobra-`Changed` field assembly (`--active`→Y/N, omitted-not-sent, repeated `--subscriber` newline-join), which had no automated coverage.