### PR TITLE
fix: redact German passwort spelling; extend fault-fixture coverage repo-wide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -260,6 +260,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Audit redaction now also catches the German "passwort" spelling.
+  `redactParam` matched only the English `password`/`passwd` substrings,
+  so real KAS keys such as `ftp_passwort` / `db_passwort` would have
+  reached an audit / `--dry-run` record unredacted once a write slice
+  sends them. No current write endpoint does, so this is a latent fix;
+  `"passwort"` is now in the substring rule and covered by a test.
+  (Full-project review follow-up.)
+
+- Fault-fixture contract coverage extended to every module. The shared
+  `testutil.AssertFaultFixtures` anchor asserts every captured
+  `testdata/<module>/*_response_failed_*.xml` decodes to a
+  `*soap.FaultError` with a non-empty code (plus curated per-module
+  documented-code samples); the two write slices were refactored onto
+  it so there is one pattern. Previously only `mailforward` /
+  `mailinglist` had this; the read modules' ~370 fault fixtures were
+  unreferenced. `internal/auth/doc.go` now states its adapter layer so
+  its legitimate `internal/transport` dependency is not misread as a
+  layering violation. (Full-project review follow-up.)
+
 - `kasapi-cli mail` help no longer under-describes its subtree: the
   parent `Short` said only "Inspect …" while `forwards` and `lists`
   now also add/update/delete. It now reads "Inspect mail accounts and

--- a/internal/account/fault_test.go
+++ b/internal/account/fault_test.go
@@ -1,0 +1,15 @@
+package account_test
+
+import (
+	"testing"
+
+	"github.com/chmmou/kasapi-cli/internal/testutil"
+)
+
+func TestFaultFixturesDecodeToDocumentedCodes(t *testing.T) {
+	t.Parallel()
+	testutil.AssertFaultFixtures(t, "account", map[string]string{
+		"add_account_response_failed_account_comment_syntax_incorrect.xml":      "account_comment_syntax_incorrect",
+		"add_account_response_failed_account_contact_mail_syntax_incorrect.xml": "account_contact_mail_syntax_incorrect",
+	})
+}

--- a/internal/auth/doc.go
+++ b/internal/auth/doc.go
@@ -14,5 +14,11 @@
 // caching the token and refreshing it the next time api.Client observes
 // an auth failure and calls Invalidate.
 //
+// Layer: auth is an outer-layer adapter (like soap, transport, api and
+// cli), not a domain/use-case package. It performs the KasAuth HTTP
+// exchange and therefore legitimately depends on internal/transport;
+// the "domain packages must not import transport" rule in
+// docs/go/ARCHITECTURE.md does not apply here.
+//
 // See issue #5.
 package auth

--- a/internal/cli/audit.go
+++ b/internal/cli/audit.go
@@ -73,7 +73,11 @@ func redactParam(key string) bool {
 	if _, ok := auditSecretParams[k]; ok {
 		return true
 	}
-	for _, frag := range []string{"password", "passwd", "secret", "token", "auth_data"} {
+	// "passwort" is the German spelling the KAS API uses for several
+	// keys (ftp_passwort, db_passwort, …); it must be caught alongside
+	// the English "password" so a future write slice sending one is
+	// redaction-safe by default.
+	for _, frag := range []string{"password", "passwort", "passwd", "secret", "token", "auth_data"} {
 		if strings.Contains(k, frag) {
 			return true
 		}

--- a/internal/cli/audit_test.go
+++ b/internal/cli/audit_test.go
@@ -22,11 +22,13 @@ func TestRedactParams(t *testing.T) {
 		"new_password":  "p4ss",
 		"api_token":     "abc123",   // substring rule
 		"db_secret":     "shh",      // substring rule
+		"ftp_passwort":  "geheim",   // German spelling, substring rule
+		"db_passwort":   "geheim2",  // German spelling, substring rule
 		"record_id":     42,         // non-string, kept
 		"comment":       "hi there", // kept verbatim
 	}
 	got := cli.RedactParams(in)
-	for _, secret := range []string{"mail_password", "auth_data", "new_password", "api_token", "db_secret"} {
+	for _, secret := range []string{"mail_password", "auth_data", "new_password", "api_token", "db_secret", "ftp_passwort", "db_passwort"} {
 		if got[secret] != "<redacted>" {
 			t.Errorf("RedactParams[%q] = %q, want <redacted>", secret, got[secret])
 		}
@@ -42,7 +44,8 @@ func TestRedactParams(t *testing.T) {
 	}
 	// No secret value may survive anywhere in the rendered map.
 	for k, v := range got {
-		if strings.Contains(v, "hunter2") || strings.Contains(v, "topsecret") || strings.Contains(v, "abc123") {
+		if strings.Contains(v, "hunter2") || strings.Contains(v, "topsecret") || strings.Contains(v, "abc123") ||
+			strings.Contains(v, "geheim") {
 			t.Errorf("secret leaked via %q = %q", k, v)
 		}
 	}

--- a/internal/cronjob/fault_test.go
+++ b/internal/cronjob/fault_test.go
@@ -1,0 +1,15 @@
+package cronjob_test
+
+import (
+	"testing"
+
+	"github.com/chmmou/kasapi-cli/internal/testutil"
+)
+
+func TestFaultFixturesDecodeToDocumentedCodes(t *testing.T) {
+	t.Parallel()
+	testutil.AssertFaultFixtures(t, "cronjob", map[string]string{
+		"add_cronjob_response_failed_cronjob_comment_syntax_incorrect.xml": "cronjob_comment_syntax_incorrect",
+		"add_cronjob_response_failed_day_of_month_syntax_incorrect.xml":    "day_of_month_syntax_incorrect",
+	})
+}

--- a/internal/database/fault_test.go
+++ b/internal/database/fault_test.go
@@ -1,0 +1,15 @@
+package database_test
+
+import (
+	"testing"
+
+	"github.com/chmmou/kasapi-cli/internal/testutil"
+)
+
+func TestFaultFixturesDecodeToDocumentedCodes(t *testing.T) {
+	t.Parallel()
+	testutil.AssertFaultFixtures(t, "database", map[string]string{
+		"update_database_response_failed_database_allowed_hosts_syntax_incorrect.xml": "database_allowed_hosts_syntax_incorrect",
+		"update_database_response_failed_database_comment_syntax_incorrect.xml":       "database_comment_syntax_incorrect",
+	})
+}

--- a/internal/ddns/fault_test.go
+++ b/internal/ddns/fault_test.go
@@ -1,0 +1,15 @@
+package ddns_test
+
+import (
+	"testing"
+
+	"github.com/chmmou/kasapi-cli/internal/testutil"
+)
+
+func TestFaultFixturesDecodeToDocumentedCodes(t *testing.T) {
+	t.Parallel()
+	testutil.AssertFaultFixtures(t, "ddns", map[string]string{
+		"add_ddnsuser_response_failed_ddns_limit_reached.xml":       "ddns_limit_reached",
+		"add_ddnsuser_response_failed_dns_settings_not_allowed.xml": "dns_settings_not_allowed",
+	})
+}

--- a/internal/directoryprotection/fault_test.go
+++ b/internal/directoryprotection/fault_test.go
@@ -1,0 +1,15 @@
+package directoryprotection_test
+
+import (
+	"testing"
+
+	"github.com/chmmou/kasapi-cli/internal/testutil"
+)
+
+func TestFaultFixturesDecodeToDocumentedCodes(t *testing.T) {
+	t.Parallel()
+	testutil.AssertFaultFixtures(t, "directoryprotection", map[string]string{
+		"add_directoryprotection_response_failed_directory_authname_syntax_incorrect.xml": "directory_authname_syntax_incorrect",
+		"add_directoryprotection_response_failed_directory_password_syntax_incorrect.xml": "directory_password_syntax_incorrect",
+	})
+}

--- a/internal/dns/fault_test.go
+++ b/internal/dns/fault_test.go
@@ -1,0 +1,15 @@
+package dns_test
+
+import (
+	"testing"
+
+	"github.com/chmmou/kasapi-cli/internal/testutil"
+)
+
+func TestFaultFixturesDecodeToDocumentedCodes(t *testing.T) {
+	t.Parallel()
+	testutil.AssertFaultFixtures(t, "dns", map[string]string{
+		"add_dns_settings_response_failed_dns_settings_not_allowed.xml": "dns_settings_not_allowed",
+		"add_dns_settings_response_failed_missing_parameter.xml":        "missing_parameter",
+	})
+}

--- a/internal/domain/fault_test.go
+++ b/internal/domain/fault_test.go
@@ -1,0 +1,15 @@
+package domain_test
+
+import (
+	"testing"
+
+	"github.com/chmmou/kasapi-cli/internal/testutil"
+)
+
+func TestFaultFixturesDecodeToDocumentedCodes(t *testing.T) {
+	t.Parallel()
+	testutil.AssertFaultFixtures(t, "domain", map[string]string{
+		"add_domain_response_failed_account_is_dummyaccount.xml":      "account_is_dummyaccount",
+		"add_domain_response_failed_domain_path_syntax_incorrect.xml": "domain_path_syntax_incorrect",
+	})
+}

--- a/internal/ftpuser/fault_test.go
+++ b/internal/ftpuser/fault_test.go
@@ -1,0 +1,15 @@
+package ftpuser_test
+
+import (
+	"testing"
+
+	"github.com/chmmou/kasapi-cli/internal/testutil"
+)
+
+func TestFaultFixturesDecodeToDocumentedCodes(t *testing.T) {
+	t.Parallel()
+	testutil.AssertFaultFixtures(t, "ftpuser", map[string]string{
+		"add_ftpuser_response_failed_ftp_comment_syntax_incorrect.xml": "ftp_comment_syntax_incorrect",
+		"add_ftpuser_response_failed_ftp_path_syntax_incorrect.xml":    "ftp_path_syntax_incorrect",
+	})
+}

--- a/internal/mailaccount/fault_test.go
+++ b/internal/mailaccount/fault_test.go
@@ -1,0 +1,15 @@
+package mailaccount_test
+
+import (
+	"testing"
+
+	"github.com/chmmou/kasapi-cli/internal/testutil"
+)
+
+func TestFaultFixturesDecodeToDocumentedCodes(t *testing.T) {
+	t.Parallel()
+	testutil.AssertFaultFixtures(t, "mailaccount", map[string]string{
+		"add_mailaccount_response_failed_copy_adress_like_mailaccount.xml": "copy_adress_like_mailaccount",
+		"add_mailaccount_response_failed_copy_adress_syntax_incorrect.xml": "copy_adress_syntax_incorrect",
+	})
+}

--- a/internal/mailfilter/fault_test.go
+++ b/internal/mailfilter/fault_test.go
@@ -1,0 +1,15 @@
+package mailfilter_test
+
+import (
+	"testing"
+
+	"github.com/chmmou/kasapi-cli/internal/testutil"
+)
+
+func TestFaultFixturesDecodeToDocumentedCodes(t *testing.T) {
+	t.Parallel()
+	testutil.AssertFaultFixtures(t, "mailfilter", map[string]string{
+		"add_mailstandardfilter_response_failed_action_syntax_incorrect.xml": "action_syntax_incorrect",
+		"add_mailstandardfilter_response_failed_filter_doesnt_exist.xml":     "filter_doesnt_exist",
+	})
+}

--- a/internal/mailforward/write_test.go
+++ b/internal/mailforward/write_test.go
@@ -3,9 +3,6 @@ package mailforward_test
 import (
 	"context"
 	"errors"
-	"os"
-	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/chmmou/kasapi-cli/internal/mailforward"
@@ -138,51 +135,17 @@ func TestParamBuilders(t *testing.T) {
 }
 
 // TestFaultFixturesDecodeToDocumentedCodes binds the captured
-// *_response_failed_*.xml fixtures to the KAS contract: each must
-// decode to a *soap.FaultError carrying a non-empty fault code, and a
-// representative documented sample must carry the exact code. This is
-// the fixture↔contract anchor for the write slice (faults reach the
-// domain layer as Caller errors in production).
+// *_response_failed_*.xml fixtures to the KAS contract via the shared
+// testutil.AssertFaultFixtures anchor: each must decode to a
+// *soap.FaultError with a non-empty fault code, and the curated samples
+// must carry the exact documented code (faults reach the domain layer
+// as Caller errors in production).
 func TestFaultFixturesDecodeToDocumentedCodes(t *testing.T) {
 	t.Parallel()
-	dir := filepath.Join(testutil.RepoRoot(t), "testdata", "mailforward")
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		t.Fatalf("read fixture dir: %v", err)
-	}
-	want := map[string]string{
+	testutil.AssertFaultFixtures(t, "mailforward", map[string]string{
 		"add_mailforward_response_failed_missing_parameter.xml":                "missing_parameter",
 		"add_mailforward_response_failed_mail_forward_exists_as_forward.xml":   "mail_forward_exists_as_forward",
 		"update_mailforward_response_failed_nothing_to_do.xml":                 "nothing_to_do",
 		"delete_mailforward_response_failed_mail_forward_not_found_in_kas.xml": "mail_forward_not_found_in_kas",
-	}
-	seen := 0
-	for _, e := range entries {
-		name := e.Name()
-		if !strings.Contains(name, "_response_failed_") {
-			continue
-		}
-		seen++
-		//nolint:gosec // G304: fixture path is rooted at the repo testdata/ dir.
-		f, oerr := os.Open(filepath.Join(dir, name))
-		if oerr != nil {
-			t.Fatalf("open %s: %v", name, oerr)
-		}
-		_, derr := soap.Decode(f)
-		_ = f.Close()
-		var fe *soap.FaultError
-		if !errors.As(derr, &fe) {
-			t.Errorf("%s: decode err = %v, want *soap.FaultError", name, derr)
-			continue
-		}
-		if fe.Fault.String == "" {
-			t.Errorf("%s: empty fault code", name)
-		}
-		if code, ok := want[name]; ok && fe.Fault.String != code {
-			t.Errorf("%s: fault = %q, want %q", name, fe.Fault.String, code)
-		}
-	}
-	if seen == 0 {
-		t.Fatal("no fault fixtures found under testdata/mailforward/")
-	}
+	})
 }

--- a/internal/mailinglist/write_test.go
+++ b/internal/mailinglist/write_test.go
@@ -3,9 +3,6 @@ package mailinglist_test
 import (
 	"context"
 	"errors"
-	"os"
-	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/chmmou/kasapi-cli/internal/mailinglist"
@@ -150,54 +147,19 @@ func TestParamBuilders(t *testing.T) {
 }
 
 // TestFaultFixturesDecodeToDocumentedCodes binds the captured
-// *_response_failed_*.xml fixtures to the KAS contract: each must
-// decode to a *soap.FaultError carrying a non-empty fault code, and a
-// representative documented sample must carry the exact code. The
+// *_response_failed_*.xml fixtures to the KAS contract via the shared
+// testutil.AssertFaultFixtures anchor. The
 // add_mailinglist_..._mailinglist_mailinglist_domain_doesnt_exist
-// fixture is the reason this is an explicit map rather than a
-// filename-suffix derivation: its filename duplicates the mailinglist_
-// prefix while the fault code does not.
+// sample is pinned because its filename duplicates the mailinglist_
+// prefix while the fault code does not — a code drift the curated map
+// would catch.
 func TestFaultFixturesDecodeToDocumentedCodes(t *testing.T) {
 	t.Parallel()
-	dir := filepath.Join(testutil.RepoRoot(t), "testdata", "mailinglist")
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		t.Fatalf("read fixture dir: %v", err)
-	}
-	want := map[string]string{
+	testutil.AssertFaultFixtures(t, "mailinglist", map[string]string{
 		"add_mailinglist_response_failed_missing_parameter.xml":                           "missing_parameter",
 		"add_mailinglist_response_failed_mailinglist_mailinglist_domain_doesnt_exist.xml": "mailinglist_domain_doesnt_exist",
 		"update_mailinglist_response_failed_nothing_to_do.xml":                            "nothing_to_do",
 		"update_mailinglist_response_failed_subscriber_email_syntax_incorrect.xml":        "subscriber_email_syntax_incorrect",
 		"delete_mailinglist_response_failed_mailinglist_not_found.xml":                    "mailinglist_not_found",
-	}
-	seen := 0
-	for _, e := range entries {
-		name := e.Name()
-		if !strings.Contains(name, "_response_failed_") {
-			continue
-		}
-		seen++
-		//nolint:gosec // G304: fixture path is rooted at the repo testdata/ dir.
-		f, oerr := os.Open(filepath.Join(dir, name))
-		if oerr != nil {
-			t.Fatalf("open %s: %v", name, oerr)
-		}
-		_, derr := soap.Decode(f)
-		_ = f.Close()
-		var fe *soap.FaultError
-		if !errors.As(derr, &fe) {
-			t.Errorf("%s: decode err = %v, want *soap.FaultError", name, derr)
-			continue
-		}
-		if fe.Fault.String == "" {
-			t.Errorf("%s: empty fault code", name)
-		}
-		if code, ok := want[name]; ok && fe.Fault.String != code {
-			t.Errorf("%s: fault = %q, want %q", name, fe.Fault.String, code)
-		}
-	}
-	if seen == 0 {
-		t.Fatal("no fault fixtures found under testdata/mailinglist/")
-	}
+	})
 }

--- a/internal/sambauser/fault_test.go
+++ b/internal/sambauser/fault_test.go
@@ -1,0 +1,15 @@
+package sambauser_test
+
+import (
+	"testing"
+
+	"github.com/chmmou/kasapi-cli/internal/testutil"
+)
+
+func TestFaultFixturesDecodeToDocumentedCodes(t *testing.T) {
+	t.Parallel()
+	testutil.AssertFaultFixtures(t, "sambauser", map[string]string{
+		"add_sambauser_response_failed_couldnt_get_kas_ressources.xml": "couldnt_get_kas_ressources",
+		"add_sambauser_response_failed_max_sambauser_reached.xml":      "max_sambauser_reached",
+	})
+}

--- a/internal/session/fault_test.go
+++ b/internal/session/fault_test.go
@@ -1,0 +1,15 @@
+package session_test
+
+import (
+	"testing"
+
+	"github.com/chmmou/kasapi-cli/internal/testutil"
+)
+
+func TestFaultFixturesDecodeToDocumentedCodes(t *testing.T) {
+	t.Parallel()
+	testutil.AssertFaultFixtures(t, "session", map[string]string{
+		"add_session_response_failed_otp_pin_incorrect.xml":  "otp_pin_incorrect",
+		"delete_session_response_failed_unknown_session.xml": "unknown_session",
+	})
+}

--- a/internal/softwareinstall/fault_test.go
+++ b/internal/softwareinstall/fault_test.go
@@ -1,0 +1,15 @@
+package softwareinstall_test
+
+import (
+	"testing"
+
+	"github.com/chmmou/kasapi-cli/internal/testutil"
+)
+
+func TestFaultFixturesDecodeToDocumentedCodes(t *testing.T) {
+	t.Parallel()
+	testutil.AssertFaultFixtures(t, "softwareinstall", map[string]string{
+		"add_softwareinstall_response_failed_admin_mail_syntax_incorrect.xml": "admin_mail_syntax_incorrect",
+		"add_softwareinstall_response_failed_admin_password_forbidden.xml":    "admin_password_forbidden",
+	})
+}

--- a/internal/subdomain/fault_test.go
+++ b/internal/subdomain/fault_test.go
@@ -1,0 +1,15 @@
+package subdomain_test
+
+import (
+	"testing"
+
+	"github.com/chmmou/kasapi-cli/internal/testutil"
+)
+
+func TestFaultFixturesDecodeToDocumentedCodes(t *testing.T) {
+	t.Parallel()
+	testutil.AssertFaultFixtures(t, "subdomain", map[string]string{
+		"add_subdomain_response_failed_account_is_dummyaccount.xml":                "account_is_dummyaccount",
+		"add_subdomain_response_failed_domain_for_this_subdomain_doesnt_exist.xml": "domain_for_this_subdomain_doesnt_exist",
+	})
+}

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -9,9 +9,11 @@ package testutil
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/chmmou/kasapi-cli/internal/soap"
@@ -56,6 +58,60 @@ func DecodeFixture(t *testing.T, relPath string) *soap.Response {
 		t.Fatalf("decode %s: %v", relPath, err)
 	}
 	return resp
+}
+
+// AssertFaultFixtures binds a module's captured fault fixtures to the
+// KAS contract: every testdata/<module>/*_response_failed_*.xml must
+// decode to a *soap.FaultError with a non-empty Fault.String, and each
+// entry in want (fixture filename -> expected fault code) must match
+// exactly. It is the fixture<->contract anchor every module reuses so a
+// captured fault fixture cannot silently drift from its documented KAS
+// code. module is the testdata/ subdirectory (e.g. "ftpuser"); the
+// empty string scans the shared top-level response_failed_*.xml set.
+// want may be nil to assert only the universal invariant; pin a few
+// representative documented codes there to also catch a code drift.
+func AssertFaultFixtures(t *testing.T, module string, want map[string]string) {
+	t.Helper()
+	dir := filepath.Join(RepoRoot(t), "testdata", module)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read fixture dir %s: %v", dir, err)
+	}
+	seen := 0
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		moduleFault := module != "" && strings.Contains(name, "_response_failed_")
+		sharedFault := module == "" && strings.HasPrefix(name, "response_failed_") &&
+			strings.HasSuffix(name, ".xml")
+		if !moduleFault && !sharedFault {
+			continue
+		}
+		seen++
+		//nolint:gosec // G304: fixture path is rooted at the repo testdata/ dir.
+		f, oerr := os.Open(filepath.Join(dir, name))
+		if oerr != nil {
+			t.Fatalf("open %s: %v", name, oerr)
+		}
+		_, derr := soap.Decode(f)
+		_ = f.Close()
+		var fe *soap.FaultError
+		if !errors.As(derr, &fe) {
+			t.Errorf("%s: decode err = %v, want *soap.FaultError", name, derr)
+			continue
+		}
+		if fe.Fault.String == "" {
+			t.Errorf("%s: empty fault code", name)
+		}
+		if code, ok := want[name]; ok && fe.Fault.String != code {
+			t.Errorf("%s: fault = %q, want %q", name, fe.Fault.String, code)
+		}
+	}
+	if seen == 0 {
+		t.Fatalf("no fault fixtures found for module %q", module)
+	}
 }
 
 // FakeCaller is a minimal stub for the Caller interface implemented by


### PR DESCRIPTION
Full-project fresh-eyes code-review follow-up. No Blocker; one security `Should` + coverage/doc `Nice-to-have`s.

- **Security:** `audit.redactParam` matched only the English `password`/`passwd` substrings, so real KAS keys `ftp_passwort` / `db_passwort` would reach an audit / `--dry-run` record **unredacted** once a write slice sends them. `"passwort"` added to the substring rule (latent — no current write endpoint sends one) + `TestRedactParams` cases.
- **Coverage:** new shared `testutil.AssertFaultFixtures` anchor — every `testdata/<module>/*_response_failed_*.xml` must decode to a `*soap.FaultError` with a non-empty code, plus curated per-module documented-code samples. Wired into the 14 implemented read modules (~370 previously-unreferenced fault fixtures now contract-checked) and the two write slices refactored onto it (one pattern, not three).
- **Doc:** `internal/auth/doc.go` states its outer-adapter layer so its legitimate `internal/transport` dependency is not misread as a layering violation.

No CLI surface change. Placeholder modules (chown/ssl/symlink) get the same anchor when their #13 slice lands.