### PR TITLE
refactor: extract shared kaswrite post-call contract seam

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Extracted the shared KAS write post-call contract (transport-error
+  passthrough + nil-response guard + `ReturnString="TRUE"` check) from
+  the duplicated per-module private `call` methods in `mailforward` /
+  `mailinglist` / `session` into one `internal/kaswrite` seam, the
+  write-side counterpart of `internal/kasread`. There is now one
+  canonical `errors.Is` sentinel (`kaswrite.ErrUnexpectedReturnString`);
+  the per-module `ErrUnexpectedReturnString` are re-export aliases of
+  it, so `errors.Is(err, <module>.ErrUnexpectedReturnString)` keeps
+  working. No behaviour change; the wrapped error message is now uniform
+  (`kaswrite: …`).
+
 ### Added
 
 - Mailing-list write endpoints (#117, #13 write slice):

--- a/internal/kaswrite/kaswrite.go
+++ b/internal/kaswrite/kaswrite.go
@@ -1,0 +1,56 @@
+// Package kaswrite provides the shared write-side seam for the KAS API.
+// It enforces the canonical post-call contract every write endpoint
+// shares — a non-fault response must echo ReturnString="TRUE" — and is
+// the write-side counterpart of kasread.ListGet. Domain write packages
+// keep their typed Add/Update/Delete validators and dispatch through
+// Call, so the nil-guard + ReturnString check lives in exactly one
+// place instead of being hand-inlined per module.
+package kaswrite
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/chmmou/kasapi-cli/internal/kasread"
+	"github.com/chmmou/kasapi-cli/internal/soap"
+)
+
+// Caller is the subset of *api.Client the write seam depends on. It is
+// the same interface the read seam already defines, so a single Caller
+// type spans both seams (re-export idiom — exactly like session already
+// does `type Caller = kasread.Caller`) and tests reuse the shared
+// testutil.FakeCaller without redefining the contract.
+type Caller = kasread.Caller
+
+// ErrUnexpectedReturnString is returned by Call when the KAS call
+// succeeds at the transport level (no SOAP fault) but the server's
+// ReturnString is not "TRUE" — an API-drift / contract violation.
+// Callers (and the domain write packages that re-export this exact
+// value) may errors.Is against it to tell a protocol-shape regression
+// apart from a transport or KAS-fault error; the wrapped message
+// carries the action and the observed value.
+var ErrUnexpectedReturnString = errors.New("kaswrite: unexpected ReturnString (want TRUE)")
+
+// Call dispatches a write action through caller and enforces the shared
+// post-call contract: a transport error propagates verbatim; a nil
+// response without an error is a Caller-contract violation reported
+// with label and action; a non-fault response whose ReturnString is
+// not "TRUE" wraps ErrUnexpectedReturnString so a future API drift
+// fails the mapping test instead of silently passing. label is the
+// domain module name used only for the nil-response diagnostic.
+func Call(
+	ctx context.Context, caller Caller, label, action string, params map[string]any,
+) (*soap.Response, error) {
+	resp, err := caller.Call(ctx, action, params)
+	if err != nil {
+		return nil, err
+	}
+	if resp == nil {
+		return nil, fmt.Errorf("%s: %s: nil response without error from Caller", label, action)
+	}
+	if got := resp.Body.ReturnString; got != "TRUE" {
+		return nil, fmt.Errorf("%w: %s got %q", ErrUnexpectedReturnString, action, got)
+	}
+	return resp, nil
+}

--- a/internal/kaswrite/kaswrite_test.go
+++ b/internal/kaswrite/kaswrite_test.go
@@ -1,0 +1,69 @@
+package kaswrite_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/chmmou/kasapi-cli/internal/kaswrite"
+	"github.com/chmmou/kasapi-cli/internal/soap"
+	"github.com/chmmou/kasapi-cli/internal/testutil"
+)
+
+func TestCallSuccessPassthrough(t *testing.T) {
+	t.Parallel()
+	resp := testutil.DecodeFixture(t, "mailforward/add_mailforward_response_success.xml")
+	fc := &testutil.FakeCaller{Resp: resp}
+	got, err := kaswrite.Call(context.Background(), fc, "mailforward", "add_mailforward", nil)
+	if err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	if got != resp {
+		t.Errorf("Call resp = %p, want passthrough of %p", got, resp)
+	}
+	if fc.GotAction != "add_mailforward" {
+		t.Errorf("action = %q, want add_mailforward", fc.GotAction)
+	}
+}
+
+func TestCallRejectsNilResponse(t *testing.T) {
+	t.Parallel()
+	fc := &testutil.FakeCaller{Resp: nil, Err: nil}
+	_, err := kaswrite.Call(context.Background(), fc, "session", "delete_session", nil)
+	if err == nil {
+		t.Fatal("Call err = nil, want error for nil response without error from Caller")
+	}
+	if errors.Is(err, kaswrite.ErrUnexpectedReturnString) {
+		t.Errorf("nil-response err = %v, must NOT be ErrUnexpectedReturnString", err)
+	}
+	if !strings.Contains(err.Error(), "session") || !strings.Contains(err.Error(), "delete_session") {
+		t.Errorf("err = %q, want it to contain label+action", err)
+	}
+}
+
+func TestCallRejectsNonTrueReturnString(t *testing.T) {
+	t.Parallel()
+	resp := &soap.Response{Body: soap.ResponseBody{ReturnString: "FALSE"}}
+	fc := &testutil.FakeCaller{Resp: resp}
+	_, err := kaswrite.Call(context.Background(), fc, "mailinglist", "update_mailinglist", nil)
+	if !errors.Is(err, kaswrite.ErrUnexpectedReturnString) {
+		t.Fatalf("Call err = %v, want errors.Is ErrUnexpectedReturnString", err)
+	}
+	if !strings.Contains(err.Error(), "update_mailinglist") || !strings.Contains(err.Error(), "FALSE") {
+		t.Errorf("err = %q, want it to contain the action and the observed value", err)
+	}
+}
+
+func TestCallPropagatesCallerError(t *testing.T) {
+	t.Parallel()
+	want := errors.New("boom")
+	fc := &testutil.FakeCaller{Err: want}
+	_, err := kaswrite.Call(context.Background(), fc, "mailforward", "add_mailforward", nil)
+	if !errors.Is(err, want) {
+		t.Fatalf("Call err = %v, want %v wrapped", err, want)
+	}
+	if errors.Is(err, kaswrite.ErrUnexpectedReturnString) {
+		t.Errorf("transport err = %v, must NOT be ErrUnexpectedReturnString", err)
+	}
+}

--- a/internal/mailforward/write.go
+++ b/internal/mailforward/write.go
@@ -3,20 +3,16 @@ package mailforward
 import (
 	"context"
 	"errors"
-	"fmt"
 	"strconv"
 
-	"github.com/chmmou/kasapi-cli/internal/soap"
+	"github.com/chmmou/kasapi-cli/internal/kaswrite"
 )
 
-// ErrUnexpectedReturnString is returned by the write methods when the
-// KAS call succeeds at the transport level (no SOAP fault) but the
-// server's ReturnString is not "TRUE" — an API-drift / contract
-// violation. Callers may errors.Is against it to tell a protocol-shape
-// regression apart from a transport or KAS-fault error; the wrapped
-// message carries the action and the observed value. Mirrors
-// session.ErrUnexpectedReturnString.
-var ErrUnexpectedReturnString = errors.New("mailforward: unexpected ReturnString (want TRUE)")
+// ErrUnexpectedReturnString is the shared canonical post-call-contract
+// sentinel, re-exported so errors.Is(err, mailforward.ErrUnexpectedReturnString)
+// keeps working and the slice stays self-describing. See
+// kaswrite.ErrUnexpectedReturnString for the full contract.
+var ErrUnexpectedReturnString = kaswrite.ErrUnexpectedReturnString
 
 const (
 	addAction    = "add_mailforward"
@@ -38,7 +34,7 @@ func (cl *Client) Add(ctx context.Context, localPart, domainPart string, targets
 	if len(targets) == 0 {
 		return "", errors.New("mailforward: add_mailforward requires at least one target")
 	}
-	resp, err := cl.call(ctx, addAction, AddParams(localPart, domainPart, targets))
+	resp, err := kaswrite.Call(ctx, cl.c, "mailforward", addAction, AddParams(localPart, domainPart, targets))
 	if err != nil {
 		return "", err
 	}
@@ -67,7 +63,7 @@ func (cl *Client) Update(ctx context.Context, address string, targets []string) 
 	if len(targets) == 0 {
 		return errors.New("mailforward: update_mailforward requires at least one target")
 	}
-	_, err := cl.call(ctx, updateAction, UpdateParams(address, targets))
+	_, err := kaswrite.Call(ctx, cl.c, "mailforward", updateAction, UpdateParams(address, targets))
 	return err
 }
 
@@ -87,7 +83,7 @@ func (cl *Client) Delete(ctx context.Context, address string) error {
 	if address == "" {
 		return errors.New("mailforward: delete_mailforward requires a non-empty mail forward address")
 	}
-	_, err := cl.call(ctx, deleteAction, DeleteParams(address))
+	_, err := kaswrite.Call(ctx, cl.c, "mailforward", deleteAction, DeleteParams(address))
 	return err
 }
 
@@ -95,24 +91,6 @@ func (cl *Client) Delete(ctx context.Context, address string) error {
 // (single source of truth, see AddParams).
 func DeleteParams(address string) map[string]any {
 	return map[string]any{"mail_forward": address}
-}
-
-// call dispatches a write action and enforces the shared post-call
-// contract: a non-fault response must echo ReturnString="TRUE";
-// anything else wraps ErrUnexpectedReturnString so a future API drift
-// fails the mapping test instead of silently passing.
-func (cl *Client) call(ctx context.Context, action string, params map[string]any) (*soap.Response, error) {
-	resp, err := cl.c.Call(ctx, action, params)
-	if err != nil {
-		return nil, err
-	}
-	if resp == nil {
-		return nil, fmt.Errorf("mailforward: %s: nil response without error from Caller", action)
-	}
-	if got := resp.Body.ReturnString; got != "TRUE" {
-		return nil, fmt.Errorf("%w: %s got %q", ErrUnexpectedReturnString, action, got)
-	}
-	return resp, nil
 }
 
 // addTargets writes the targets slice into params as the KAS-numbered

--- a/internal/mailinglist/write.go
+++ b/internal/mailinglist/write.go
@@ -3,19 +3,15 @@ package mailinglist
 import (
 	"context"
 	"errors"
-	"fmt"
 
-	"github.com/chmmou/kasapi-cli/internal/soap"
+	"github.com/chmmou/kasapi-cli/internal/kaswrite"
 )
 
-// ErrUnexpectedReturnString is returned by the write methods when the
-// KAS call succeeds at the transport level (no SOAP fault) but the
-// server's ReturnString is not "TRUE" — an API-drift / contract
-// violation. Callers may errors.Is against it to tell a protocol-shape
-// regression apart from a transport or KAS-fault error; the wrapped
-// message carries the action and the observed value. Mirrors
-// mailforward.ErrUnexpectedReturnString.
-var ErrUnexpectedReturnString = errors.New("mailinglist: unexpected ReturnString (want TRUE)")
+// ErrUnexpectedReturnString is the shared canonical post-call-contract
+// sentinel, re-exported so errors.Is(err, mailinglist.ErrUnexpectedReturnString)
+// keeps working and the slice stays self-describing. See
+// kaswrite.ErrUnexpectedReturnString for the full contract.
+var ErrUnexpectedReturnString = kaswrite.ErrUnexpectedReturnString
 
 const (
 	addAction    = "add_mailinglist"
@@ -53,7 +49,7 @@ func (cl *Client) Add(ctx context.Context, name, domain, password string) (strin
 	if password == "" {
 		return "", errors.New("mailinglist: add_mailinglist requires a non-empty password")
 	}
-	resp, err := cl.call(ctx, addAction, AddParams(name, domain, password))
+	resp, err := kaswrite.Call(ctx, cl.c, "mailinglist", addAction, AddParams(name, domain, password))
 	if err != nil {
 		return "", err
 	}
@@ -84,7 +80,7 @@ func (cl *Client) Update(ctx context.Context, name string, fields map[string]str
 	if len(fields) == 0 {
 		return errors.New("mailinglist: update_mailinglist requires at least one field to change")
 	}
-	_, err := cl.call(ctx, updateAction, UpdateParams(name, fields))
+	_, err := kaswrite.Call(ctx, cl.c, "mailinglist", updateAction, UpdateParams(name, fields))
 	return err
 }
 
@@ -106,7 +102,7 @@ func (cl *Client) Delete(ctx context.Context, name string) error {
 	if name == "" {
 		return errors.New("mailinglist: delete_mailinglist requires a non-empty mailing list name")
 	}
-	_, err := cl.call(ctx, deleteAction, DeleteParams(name))
+	_, err := kaswrite.Call(ctx, cl.c, "mailinglist", deleteAction, DeleteParams(name))
 	return err
 }
 
@@ -114,22 +110,4 @@ func (cl *Client) Delete(ctx context.Context, name string) error {
 // (single source of truth, see AddParams).
 func DeleteParams(name string) map[string]any {
 	return map[string]any{"mailinglist_name": name}
-}
-
-// call dispatches a write action and enforces the shared post-call
-// contract: a non-fault response must echo ReturnString="TRUE";
-// anything else wraps ErrUnexpectedReturnString so a future API drift
-// fails the mapping test instead of silently passing.
-func (cl *Client) call(ctx context.Context, action string, params map[string]any) (*soap.Response, error) {
-	resp, err := cl.c.Call(ctx, action, params)
-	if err != nil {
-		return nil, err
-	}
-	if resp == nil {
-		return nil, fmt.Errorf("mailinglist: %s: nil response without error from Caller", action)
-	}
-	if got := resp.Body.ReturnString; got != "TRUE" {
-		return nil, fmt.Errorf("%w: %s got %q", ErrUnexpectedReturnString, action, got)
-	}
-	return resp, nil
 }

--- a/internal/session/client.go
+++ b/internal/session/client.go
@@ -2,24 +2,23 @@ package session
 
 import (
 	"context"
-	"errors"
-	"fmt"
 
-	"github.com/chmmou/kasapi-cli/internal/kasread"
+	"github.com/chmmou/kasapi-cli/internal/kaswrite"
 )
 
-// ErrUnexpectedReturnString is returned by Delete when delete_session
-// responds without a SOAP fault but ReturnString is not "TRUE" (API
-// drift / contract violation). Callers may errors.Is against it to
-// distinguish a protocol-shape regression from a transport or fault
-// error; the wrapped message carries the observed value.
-var ErrUnexpectedReturnString = errors.New("session: delete_session: unexpected ReturnString (want TRUE)")
+// ErrUnexpectedReturnString is the shared canonical post-call-contract
+// sentinel, re-exported so errors.Is(err, session.ErrUnexpectedReturnString)
+// keeps working and the slice stays self-describing. See
+// kaswrite.ErrUnexpectedReturnString for the full contract.
+var ErrUnexpectedReturnString = kaswrite.ErrUnexpectedReturnString
 
 // Caller is the subset of *api.Client this package's KAS-side use case
-// depends on. Reusing the shared kasread.Caller keeps tests free of
+// depends on. delete_session dispatches through the kaswrite write
+// seam, so the alias resolves there (kaswrite.Caller is the same
+// underlying type as kasread.Caller); reusing it keeps tests free of
 // network setup: a testutil.FakeCaller can return a *soap.Response
 // decoded from a fixture.
-type Caller = kasread.Caller
+type Caller = kaswrite.Caller
 
 // deleteSessionAction is the KAS action that invalidates the session
 // identified by the (login, token) tuple supplied as kas_auth_data /
@@ -47,19 +46,11 @@ func NewClient(c Caller) *Client { return &Client{c: c} }
 // A SOAP fault (e.g. unknown_session for an already-dead token) is
 // surfaced verbatim by the Caller and returned so the caller can
 // classify it via the api error helpers. On a non-fault response the
-// server echoes ReturnString="TRUE"; any other value is treated as a
-// contract violation (wrapping ErrUnexpectedReturnString) so a future
-// API drift fails the mapping test instead of silently passing.
+// shared kaswrite seam enforces the post-call contract: the server
+// must echo ReturnString="TRUE"; any other value wraps
+// ErrUnexpectedReturnString so a future API drift fails the mapping
+// test instead of silently passing.
 func (cl *Client) Delete(ctx context.Context) error {
-	resp, err := cl.c.Call(ctx, deleteSessionAction, nil)
-	if err != nil {
-		return err
-	}
-	if resp == nil {
-		return fmt.Errorf("session: %s: nil response without error from Caller", deleteSessionAction)
-	}
-	if got := resp.Body.ReturnString; got != "TRUE" {
-		return fmt.Errorf("%w: got %q", ErrUnexpectedReturnString, got)
-	}
-	return nil
+	_, err := kaswrite.Call(ctx, cl.c, "session", deleteSessionAction, nil)
+	return err
 }


### PR DESCRIPTION
Unifies the duplicated KAS write post-call contract (transport-error passthrough, nil-response guard, ReturnString="TRUE" check) from `mailforward`, `mailinglist` and `session` into one `internal/kaswrite` seam — the write-side counterpart of `internal/kasread`. One canonical `errors.Is` sentinel (`kaswrite.ErrUnexpectedReturnString`); the per-module sentinels become re-export aliases so `errors.Is(err, <module>.ErrUnexpectedReturnString)` keeps working. No behaviour change; no CLI surface change.