### PR TITLE
feat(cronjob): write endpoints — add / update / delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Cronjob write endpoints (#118, #13 write slice):
+  `kasapi-cli cronjobs add --url <u> --comment <c> [schedule/mail
+  flags]`, `… update <cronjob-id> [flags]` and `… delete <cronjob-id>`
+  wire `add_cronjob` / `update_cronjob` / `delete_cronjob`. `update`
+  and `delete` are gated by the #109 confirmation prompt
+  (`update_cronjob` replaces every supplied field wholesale); `add` is
+  reversible and not prompted. All three honour `--dry-run` (#132) and
+  emit a #131 audit record; `--http-password` is redacted in both.
+  `update` sends only the explicitly-set flags (keyed on cobra
+  `Changed`), so an empty value is a deliberate "clear". The KAS wire
+  key for the notification address is `mail_adress` (single 'd', the
+  same quirk the read mapping documents). The `add`/`update`/`delete`
+  cronjob fixtures were corrected to the real KAS response shapes
+  beforehand.
+
 - Mailing-list write endpoints (#117, #13 write slice):
   `kasapi-cli mail lists add <name> --domain <d> --password <pw>`,
   `… update <name> [--subscriber …] [--restrict-post …]

--- a/docs/cli/kasapi-cli.md
+++ b/docs/cli/kasapi-cli.md
@@ -34,7 +34,7 @@ kasapi-cli [flags]
 * [kasapi-cli accounts](kasapi-cli_accounts.md)	 - Inspect KAS accounts owned by the authenticated login
 * [kasapi-cli completion](kasapi-cli_completion.md)	 - Generate the autocompletion script for the specified shell
 * [kasapi-cli config](kasapi-cli_config.md)	 - Inspect and bootstrap the kasapi-cli configuration
-* [kasapi-cli cronjobs](kasapi-cli_cronjobs.md)	 - Inspect cronjobs visible to the login (get_cronjobs)
+* [kasapi-cli cronjobs](kasapi-cli_cronjobs.md)	 - Inspect and manage cronjobs (get/add/update/delete_cronjob)
 * [kasapi-cli databases](kasapi-cli_databases.md)	 - Inspect databases visible to the login (get_databases)
 * [kasapi-cli ddnsusers](kasapi-cli_ddnsusers.md)	 - Inspect DDNS users visible to the login (get_ddnsusers)
 * [kasapi-cli directoryprotection](kasapi-cli_directoryprotection.md)	 - Inspect directory (htaccess) protections (get_directoryprotection)

--- a/docs/cli/kasapi-cli_cronjobs.md
+++ b/docs/cli/kasapi-cli_cronjobs.md
@@ -1,6 +1,6 @@
 ## kasapi-cli cronjobs
 
-Inspect cronjobs visible to the login (get_cronjobs)
+Inspect and manage cronjobs (get/add/update/delete_cronjob)
 
 ### Options
 
@@ -29,6 +29,9 @@ Inspect cronjobs visible to the login (get_cronjobs)
 ### SEE ALSO
 
 * [kasapi-cli](kasapi-cli.md)	 - Command-line client for the All-Inkl KAS API
+* [kasapi-cli cronjobs add](kasapi-cli_cronjobs_add.md)	 - Create a cronjob (add_cronjob)
+* [kasapi-cli cronjobs delete](kasapi-cli_cronjobs_delete.md)	 - Delete a cronjob (delete_cronjob)
 * [kasapi-cli cronjobs get](kasapi-cli_cronjobs_get.md)	 - Show details for a single cronjob (get_cronjobs with cronjob_id)
 * [kasapi-cli cronjobs list](kasapi-cli_cronjobs_list.md)	 - List all cronjobs (get_cronjobs, no filter)
+* [kasapi-cli cronjobs update](kasapi-cli_cronjobs_update.md)	 - Replace mutable fields of a cronjob (update_cronjob)
 

--- a/docs/cli/kasapi-cli_cronjobs_add.md
+++ b/docs/cli/kasapi-cli_cronjobs_add.md
@@ -1,15 +1,29 @@
-## kasapi-cli cronjobs get
+## kasapi-cli cronjobs add
 
-Show details for a single cronjob (get_cronjobs with cronjob_id)
+Create a cronjob (add_cronjob)
 
 ```
-kasapi-cli cronjobs get <cronjob-id> [flags]
+kasapi-cli cronjobs add --url <url> --comment <text> [schedule/mail flags] [flags]
 ```
 
 ### Options
 
 ```
-  -h, --help   help for get
+      --active                  whether the cronjob is active; pass --active=false to disable (default true)
+      --comment string          cronjob comment / label (required for add)
+      --day-of-month string     schedule day-of-month field (default "*")
+      --day-of-week string      schedule day-of-week field (0-7, Sun=0|7) (default "*")
+  -h, --help                    help for add
+      --hour string             schedule hour field (default "*")
+      --http-password string    HTTP basic-auth password for the call
+      --http-user string        HTTP basic-auth user for the call
+      --mail-address string     notification mail address (mail_adress)
+      --mail-condition string   when to send the notification mail
+      --mail-subject string     notification mail subject (default|comment) (default "default")
+      --minute string           schedule minute field (default "*")
+      --month string            schedule month field (default "*")
+      --protocol string         request protocol (http|https) (default "https")
+      --url string              URL to call (http_url; required for add)
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli/kasapi-cli_cronjobs_delete.md
+++ b/docs/cli/kasapi-cli_cronjobs_delete.md
@@ -1,15 +1,15 @@
-## kasapi-cli cronjobs get
+## kasapi-cli cronjobs delete
 
-Show details for a single cronjob (get_cronjobs with cronjob_id)
+Delete a cronjob (delete_cronjob)
 
 ```
-kasapi-cli cronjobs get <cronjob-id> [flags]
+kasapi-cli cronjobs delete <cronjob-id> [flags]
 ```
 
 ### Options
 
 ```
-  -h, --help   help for get
+  -h, --help   help for delete
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli/kasapi-cli_cronjobs_list.md
+++ b/docs/cli/kasapi-cli_cronjobs_list.md
@@ -32,5 +32,5 @@ kasapi-cli cronjobs list [flags]
 
 ### SEE ALSO
 
-* [kasapi-cli cronjobs](kasapi-cli_cronjobs.md)	 - Inspect cronjobs visible to the login (get_cronjobs)
+* [kasapi-cli cronjobs](kasapi-cli_cronjobs.md)	 - Inspect and manage cronjobs (get/add/update/delete_cronjob)
 

--- a/docs/cli/kasapi-cli_cronjobs_update.md
+++ b/docs/cli/kasapi-cli_cronjobs_update.md
@@ -1,15 +1,29 @@
-## kasapi-cli cronjobs get
+## kasapi-cli cronjobs update
 
-Show details for a single cronjob (get_cronjobs with cronjob_id)
+Replace mutable fields of a cronjob (update_cronjob)
 
 ```
-kasapi-cli cronjobs get <cronjob-id> [flags]
+kasapi-cli cronjobs update <cronjob-id> [schedule/mail flags] [flags]
 ```
 
 ### Options
 
 ```
-  -h, --help   help for get
+      --active                  whether the cronjob is active; pass --active=false to disable (default true)
+      --comment string          cronjob comment / label (required for add)
+      --day-of-month string     schedule day-of-month field (default "*")
+      --day-of-week string      schedule day-of-week field (0-7, Sun=0|7) (default "*")
+  -h, --help                    help for update
+      --hour string             schedule hour field (default "*")
+      --http-password string    HTTP basic-auth password for the call
+      --http-user string        HTTP basic-auth user for the call
+      --mail-address string     notification mail address (mail_adress)
+      --mail-condition string   when to send the notification mail
+      --mail-subject string     notification mail subject (default|comment) (default "default")
+      --minute string           schedule minute field (default "*")
+      --month string            schedule month field (default "*")
+      --protocol string         request protocol (http|https) (default "https")
+      --url string              URL to call (http_url; required for add)
 ```
 
 ### Options inherited from parent commands

--- a/docs/usage/destructive-writes.md
+++ b/docs/usage/destructive-writes.md
@@ -27,6 +27,15 @@ confirmation prompt phrases this as replacing the list's *settings*).
 The list password passed to `add` is redacted in the `--dry-run`
 preview and the audit record.
 
+[`cronjobs`](https://github.com/chmmou/kasapi-cli/issues/118) `add` /
+`update` / `delete` wire the same contract with the same policy:
+`update` and `delete` are gated; `add` is reversible and not prompted.
+`update` is gated because every field it sets is replaced wholesale
+(the confirmation prompt phrases this as replacing the cronjob's
+*settings*) and `update` sends only the explicitly-changed flags. Any
+`--http-password` passed to `add`/`update` is redacted in the
+`--dry-run` preview and the audit record.
+
 ## The contract
 
 Before a destructive call leaves the machine, the command prints a

--- a/internal/cli/cronjobs.go
+++ b/internal/cli/cronjobs.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/spf13/cobra"
 
@@ -10,16 +11,21 @@ import (
 )
 
 // NewCronjobsCmd returns the "kasapi-cli cronjobs" subcommand tree:
-// list (get_cronjobs, no filter) and get <cronjob-id> (get_cronjobs
-// with a cronjob_id filter).
+// list/get (get_cronjobs, list and singular) plus the add / update /
+// delete write endpoints (add_cronjob / update_cronjob /
+// delete_cronjob). update and delete are gated by the #109
+// confirmation prompt; add is reversible and not prompted.
 func NewCronjobsCmd(opts *RootOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "cronjobs",
-		Short: "Inspect cronjobs visible to the login (get_cronjobs)",
+		Short: "Inspect and manage cronjobs (get/add/update/delete_cronjob)",
 	}
 	cmd.AddCommand(
 		newCronjobsListCmd(opts),
 		newCronjobsGetCmd(opts),
+		newCronjobsAddCmd(opts),
+		newCronjobsUpdateCmd(opts),
+		newCronjobsDeleteCmd(opts),
 	)
 	return cmd
 }
@@ -42,6 +48,191 @@ func newCronjobsGetCmd(opts *RootOptions) *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		RunE: runGetE(opts, "get_cronjobs", func(c *api.Client, ctx context.Context, arg string) (cronjob.Cronjob, error) {
 			return cronjob.NewClient(c).Get(ctx, arg)
+		}),
+	}
+}
+
+// cronjobWriteFlags binds the shared add_cronjob / update_cronjob
+// request fields to a command. The same flag set serves both: add
+// reads every value (defaults included), update sends only the flags
+// the user explicitly changed (see cronjobChangedFields).
+type cronjobWriteFlags struct {
+	protocol      string
+	url           string
+	comment       string
+	minute        string
+	hour          string
+	dayOfMonth    string
+	month         string
+	dayOfWeek     string
+	httpUser      string
+	httpPassword  string
+	mailAddress   string
+	mailCondition string
+	mailSubject   string
+	active        bool
+}
+
+func (f *cronjobWriteFlags) bind(cmd *cobra.Command) {
+	fl := cmd.Flags()
+	fl.StringVar(&f.protocol, "protocol", "https", "request protocol (http|https)")
+	fl.StringVar(&f.url, "url", "", "URL to call (http_url; required for add)")
+	fl.StringVar(&f.comment, "comment", "", "cronjob comment / label (required for add)")
+	fl.StringVar(&f.minute, "minute", "*", "schedule minute field")
+	fl.StringVar(&f.hour, "hour", "*", "schedule hour field")
+	fl.StringVar(&f.dayOfMonth, "day-of-month", "*", "schedule day-of-month field")
+	fl.StringVar(&f.month, "month", "*", "schedule month field")
+	fl.StringVar(&f.dayOfWeek, "day-of-week", "*", "schedule day-of-week field (0-7, Sun=0|7)")
+	fl.StringVar(&f.httpUser, "http-user", "", "HTTP basic-auth user for the call")
+	fl.StringVar(&f.httpPassword, "http-password", "", "HTTP basic-auth password for the call")
+	fl.StringVar(&f.mailAddress, "mail-address", "", "notification mail address (mail_adress)")
+	fl.StringVar(&f.mailCondition, "mail-condition", "", "when to send the notification mail")
+	fl.StringVar(&f.mailSubject, "mail-subject", "default", "notification mail subject (default|comment)")
+	fl.BoolVar(&f.active, "active", true, "whether the cronjob is active; pass --active=false to disable")
+}
+
+func (f *cronjobWriteFlags) spec() cronjob.Spec {
+	return cronjob.Spec{
+		Protocol:      f.protocol,
+		HTTPURL:       f.url,
+		Comment:       f.comment,
+		Minute:        f.minute,
+		Hour:          f.hour,
+		DayOfMonth:    f.dayOfMonth,
+		Month:         f.month,
+		DayOfWeek:     f.dayOfWeek,
+		HTTPUser:      f.httpUser,
+		HTTPPassword:  f.httpPassword,
+		MailAdress:    f.mailAddress,
+		MailCondition: f.mailCondition,
+		MailSubject:   f.mailSubject,
+		IsActive:      boolToYN(f.active),
+	}
+}
+
+func boolToYN(b bool) string {
+	if b {
+		return "Y"
+	}
+	return "N"
+}
+
+func newCronjobsAddCmd(opts *RootOptions) *cobra.Command {
+	f := &cronjobWriteFlags{}
+	cmd := &cobra.Command{
+		Use:   "add --url <url> --comment <text> [schedule/mail flags]",
+		Short: "Create a cronjob (add_cronjob)",
+		Args:  cobra.NoArgs,
+		RunE: runWriteE(opts, func([]string) (writeSpec, error) {
+			if f.url == "" {
+				return writeSpec{}, fmt.Errorf("--url is required")
+			}
+			if f.comment == "" {
+				return writeSpec{}, fmt.Errorf("--comment is required")
+			}
+			s := f.spec()
+			return writeSpec{
+				action:      "add_cronjob",
+				destructive: false,
+				confirm:     ConfirmAction{Verb: "create", Resource: "cronjob", ID: f.comment},
+				params:      cronjob.AddParams(s),
+				dispatch: func(c *api.Client, ctx context.Context) (string, error) {
+					id, derr := cronjob.NewClient(c).Add(ctx, s)
+					if derr != nil {
+						return "", derr
+					}
+					return "created cronjob " + id, nil
+				},
+			}, nil
+		}),
+	}
+	f.bind(cmd)
+	return cmd
+}
+
+// cronjobChangedFields collects only the write flags the user
+// explicitly set into the update_cronjob field map (keyed on the
+// cronjob.Field* constants). Each field is a wholesale replacement and
+// an empty value is a meaningful set, so presence is keyed on cobra
+// Changed, not on the value being non-empty — the same pattern the
+// mailing-list update uses.
+func cronjobChangedFields(cmd *cobra.Command, f *cronjobWriteFlags) map[string]string {
+	fields := map[string]string{}
+	// flag name -> {KAS request key, current flag value}.
+	for flag, kv := range map[string][2]string{
+		"protocol":       {cronjob.FieldProtocol, f.protocol},
+		"url":            {cronjob.FieldHTTPURL, f.url},
+		"comment":        {cronjob.FieldComment, f.comment},
+		"minute":         {cronjob.FieldMinute, f.minute},
+		"hour":           {cronjob.FieldHour, f.hour},
+		"day-of-month":   {cronjob.FieldDayOfMonth, f.dayOfMonth},
+		"month":          {cronjob.FieldMonth, f.month},
+		"day-of-week":    {cronjob.FieldDayOfWeek, f.dayOfWeek},
+		"http-user":      {cronjob.FieldHTTPUser, f.httpUser},
+		"http-password":  {cronjob.FieldHTTPPassword, f.httpPassword},
+		"mail-address":   {cronjob.FieldMailAdress, f.mailAddress},
+		"mail-condition": {cronjob.FieldMailCondition, f.mailCondition},
+		"mail-subject":   {cronjob.FieldMailSubject, f.mailSubject},
+	} {
+		if cmd.Flags().Changed(flag) {
+			fields[kv[0]] = kv[1]
+		}
+	}
+	if cmd.Flags().Changed("active") {
+		fields[cronjob.FieldIsActive] = boolToYN(f.active)
+	}
+	return fields
+}
+
+func newCronjobsUpdateCmd(opts *RootOptions) *cobra.Command {
+	f := &cronjobWriteFlags{}
+	cmd := &cobra.Command{
+		Use:   "update <cronjob-id> [schedule/mail flags]",
+		Short: "Replace mutable fields of a cronjob (update_cronjob)",
+		Args:  cobra.ExactArgs(1),
+	}
+	cmd.RunE = runWriteE(opts, func(args []string) (writeSpec, error) {
+		id := args[0]
+		fields := cronjobChangedFields(cmd, f)
+		if len(fields) == 0 {
+			return writeSpec{}, fmt.Errorf("at least one field flag (e.g. --comment/--minute/--active) is required")
+		}
+		return writeSpec{
+			action:      "update_cronjob",
+			destructive: true,
+			confirm:     ConfirmAction{Verb: "replace the settings of", Resource: "cronjob", ID: id},
+			params:      cronjob.UpdateParams(id, fields),
+			dispatch: func(c *api.Client, ctx context.Context) (string, error) {
+				if derr := cronjob.NewClient(c).Update(ctx, id, fields); derr != nil {
+					return "", derr
+				}
+				return "updated cronjob " + id, nil
+			},
+		}, nil
+	})
+	f.bind(cmd)
+	return cmd
+}
+
+func newCronjobsDeleteCmd(opts *RootOptions) *cobra.Command {
+	return &cobra.Command{
+		Use:   "delete <cronjob-id>",
+		Short: "Delete a cronjob (delete_cronjob)",
+		Args:  cobra.ExactArgs(1),
+		RunE: runWriteE(opts, func(args []string) (writeSpec, error) {
+			id := args[0]
+			return writeSpec{
+				action:      "delete_cronjob",
+				destructive: true,
+				confirm:     ConfirmAction{Verb: "delete", Resource: "cronjob", ID: id},
+				params:      cronjob.DeleteParams(id),
+				dispatch: func(c *api.Client, ctx context.Context) (string, error) {
+					if derr := cronjob.NewClient(c).Delete(ctx, id); derr != nil {
+						return "", derr
+					}
+					return "deleted cronjob " + id, nil
+				},
+			}, nil
 		}),
 	}
 }

--- a/internal/cli/cronjobs_test.go
+++ b/internal/cli/cronjobs_test.go
@@ -2,6 +2,8 @@ package cli_test
 
 import (
 	"bytes"
+	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
 
@@ -21,9 +23,136 @@ func TestCronjobsCmdHelpListsSubcommands(t *testing.T) {
 		t.Fatalf("Execute: %v", err)
 	}
 	out := buf.String()
-	for _, want := range []string{"list", "get"} {
+	for _, want := range []string{"list", "get", "add", "update", "delete"} {
 		if !strings.Contains(out, want) {
 			t.Errorf("--help output missing %q\n%s", want, out)
 		}
+	}
+}
+
+func TestCronjobsAddRejectsBadInput(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		args []string
+	}{
+		{"missing --url", []string{"cronjobs", "add", "--comment", "c"}},
+		{"missing --comment", []string{"cronjobs", "add", "--url", "example.de/cron.php"}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			root, opts := cli.NewRootCmd()
+			root.AddCommand(cli.NewCronjobsCmd(opts))
+			var buf bytes.Buffer
+			root.SetOut(&buf)
+			root.SetErr(&buf)
+			root.SetArgs(c.args)
+			err := root.Execute()
+			if err == nil {
+				t.Fatalf("Execute %v: want error, got nil", c.args)
+			}
+			if cli.CodeFor(err) != cli.ExitUserError {
+				t.Errorf("exit code = %d, want ExitUserError", cli.CodeFor(err))
+			}
+		})
+	}
+}
+
+// The destructive cronjob subcommands (update/delete) must refuse on a
+// non-interactive stdin without --yes rather than dispatch unconfirmed.
+func TestCronjobsDestructiveRefuseNonTTY(t *testing.T) {
+	t.Parallel()
+	for _, args := range [][]string{
+		{"cronjobs", "delete", "324700"},
+		{"cronjobs", "update", "324700", "--comment", "x"},
+	} {
+		t.Run(args[1], func(t *testing.T) {
+			t.Parallel()
+			root, opts := cli.NewRootCmd()
+			root.AddCommand(cli.NewCronjobsCmd(opts))
+			var buf bytes.Buffer
+			root.SetOut(&buf)
+			root.SetErr(&buf)
+			root.SetIn(strings.NewReader(""))
+			root.SetArgs(append(args,
+				"--login", "w0000000", "--auth-data", "x", "--auth-type", "plain"))
+			err := root.Execute()
+			if err == nil {
+				t.Fatalf("Execute %v: want refusal error, got nil", args)
+			}
+			if !errors.Is(err, cli.ErrConfirmationRequired) {
+				t.Errorf("err = %v, want ErrConfirmationRequired", err)
+			}
+		})
+	}
+}
+
+// update_cronjob must send only the explicitly-changed flags (keyed on
+// cobra Changed), so an unset field never leaks into the request and an
+// empty value passed explicitly is a deliberate set.
+func TestCronjobsUpdateDryRunFieldAssembly(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name   string
+		args   []string
+		want   map[string]string
+		absent []string
+	}{
+		{
+			"single field",
+			[]string{"cronjobs", "update", "324700", "--comment", "Renamed"},
+			map[string]string{"cronjob_id": "324700", "cronjob_comment": "Renamed"},
+			[]string{"minute", "hour", "protocol", "is_active"},
+		},
+		{
+			"active false",
+			[]string{"cronjobs", "update", "324700", "--active=false"},
+			map[string]string{"cronjob_id": "324700", "is_active": "N"},
+			[]string{"cronjob_comment", "minute"},
+		},
+		{
+			"schedule fields only",
+			[]string{"cronjobs", "update", "324700", "--minute", "1", "--hour", "2"},
+			map[string]string{"cronjob_id": "324700", "minute": "1", "hour": "2"},
+			[]string{"is_active", "protocol"},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			root, opts := cli.NewRootCmd()
+			root.AddCommand(cli.NewCronjobsCmd(opts))
+			var out, errb bytes.Buffer
+			root.SetOut(&out)
+			root.SetErr(&errb)
+			args := append(append([]string{}, c.args...),
+				"--dry-run", "-o", "json",
+				"--login", "w0", "--auth-data", "x", "--auth-type", "plain")
+			root.SetArgs(args)
+			if err := root.Execute(); err != nil {
+				t.Fatalf("Execute %v: %v", args, err)
+			}
+			var got struct {
+				Action string            `json:"action"`
+				Params map[string]string `json:"params"`
+			}
+			if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+				t.Fatalf("unmarshal preview: %v\nstdout:%s", err, out.String())
+			}
+			if got.Action != "update_cronjob" {
+				t.Errorf("action = %q, want update_cronjob", got.Action)
+			}
+			for k, v := range c.want {
+				if got.Params[k] != v {
+					t.Errorf("params[%q] = %q, want %q (full: %v)", k, got.Params[k], v, got.Params)
+				}
+			}
+			for _, k := range c.absent {
+				if _, ok := got.Params[k]; ok {
+					t.Errorf("params[%q] present, want absent (full: %v)", k, got.Params)
+				}
+			}
+		})
 	}
 }

--- a/internal/cronjob/cronjob.go
+++ b/internal/cronjob/cronjob.go
@@ -80,22 +80,29 @@ func (c Cronjob) Target() string {
 // cli.Tabular.
 type CronjobList []Cronjob
 
-// Client groups the read endpoints scoped to cronjobs:
-// get_cronjobs (list and singular).
+// Client groups the read endpoint scoped to cronjobs (get_cronjobs,
+// list and singular) and the write endpoints add_cronjob /
+// update_cronjob / delete_cronjob (see write.go). The raw Caller is
+// kept alongside the read helper so the write methods can dispatch
+// their own KAS actions through the shared kaswrite seam.
 type Client struct {
 	lg kasread.ListGet[CronjobList, Cronjob]
+	c  Caller
 }
 
 // NewClient returns a Client backed by the given Caller.
 func NewClient(c Caller) *Client {
-	return &Client{lg: kasread.ListGet[CronjobList, Cronjob]{
-		Caller:    c,
-		Action:    "get_cronjobs",
-		Label:     "cronjob",
-		ArgName:   "id",
-		FilterKey: "cronjob_id",
-		Decoder:   DecodeCronjobs,
-	}}
+	return &Client{
+		lg: kasread.ListGet[CronjobList, Cronjob]{
+			Caller:    c,
+			Action:    "get_cronjobs",
+			Label:     "cronjob",
+			ArgName:   "id",
+			FilterKey: "cronjob_id",
+			Decoder:   DecodeCronjobs,
+		},
+		c: c,
+	}
 }
 
 // List calls get_cronjobs without parameters and decodes the response

--- a/internal/cronjob/fault_test.go
+++ b/internal/cronjob/fault_test.go
@@ -11,5 +11,10 @@ func TestFaultFixturesDecodeToDocumentedCodes(t *testing.T) {
 	testutil.AssertFaultFixtures(t, "cronjob", map[string]string{
 		"add_cronjob_response_failed_cronjob_comment_syntax_incorrect.xml": "cronjob_comment_syntax_incorrect",
 		"add_cronjob_response_failed_day_of_month_syntax_incorrect.xml":    "day_of_month_syntax_incorrect",
+		"add_cronjob_response_failed_missing_parameter.xml":                "missing_parameter",
+		"update_cronjob_response_failed_nothing_to_do.xml":                 "nothing_to_do",
+		"update_cronjob_response_failed_cronjob_id_not_found.xml":          "cronjob_not_found",
+		"delete_cronjob_response_failed_cronjob_id_not_found.xml":          "cronjob_id_not_found",
+		"delete_cronjob_response_failed_missing_parameter.xml":             "missing_parameter",
 	})
 }

--- a/internal/cronjob/write.go
+++ b/internal/cronjob/write.go
@@ -1,0 +1,161 @@
+package cronjob
+
+import (
+	"context"
+	"errors"
+
+	"github.com/chmmou/kasapi-cli/internal/kaswrite"
+)
+
+// ErrUnexpectedReturnString is the shared canonical post-call-contract
+// sentinel, re-exported so errors.Is(err, cronjob.ErrUnexpectedReturnString)
+// keeps working and the slice stays self-describing. See
+// kaswrite.ErrUnexpectedReturnString for the full contract.
+var ErrUnexpectedReturnString = kaswrite.ErrUnexpectedReturnString
+
+const (
+	addAction    = "add_cronjob"
+	updateAction = "update_cronjob"
+	deleteAction = "delete_cronjob"
+)
+
+// The Field-prefixed constants are the KAS request keys update_cronjob
+// accepts besides the cronjob_id identifier; AddParams uses the same
+// keys. Each is an optional wholesale replacement on update: only the
+// keys the caller explicitly sets are sent, so an empty string is a
+// meaningful value rather than "leave unchanged".
+//
+// FieldMailAdress mirrors the KAS wire key, which the API spells with a
+// single 'd' (mail_adress) — the same quirk the read-side Cronjob
+// struct documents. Both the add_cronjob and update_cronjob request
+// fixtures use the single-d spelling, so it is the authoritative
+// request key even though the documentation's parameter table is
+// inconsistent.
+const (
+	FieldProtocol      = "protocol"
+	FieldHTTPURL       = "http_url"
+	FieldComment       = "cronjob_comment"
+	FieldMinute        = "minute"
+	FieldHour          = "hour"
+	FieldDayOfMonth    = "day_of_month"
+	FieldMonth         = "month"
+	FieldDayOfWeek     = "day_of_week"
+	FieldHTTPUser      = "http_user"
+	FieldHTTPPassword  = "http_password"
+	FieldMailAdress    = "mail_adress"
+	FieldMailCondition = "mail_condition"
+	FieldMailSubject   = "mail_subject"
+	FieldIsActive      = "is_active"
+)
+
+// Spec carries the add_cronjob request fields. Protocol, HTTPURL,
+// Comment and the five schedule fields are required by the KAS API and
+// validated as non-empty before any SOAP call so the CLI can surface a
+// fast validation error; the remaining fields are optional and sent
+// verbatim (an empty value is sent as an empty string, matching the
+// captured add_cronjob request fixture).
+type Spec struct {
+	Protocol      string
+	HTTPURL       string
+	Comment       string
+	Minute        string
+	Hour          string
+	DayOfMonth    string
+	Month         string
+	DayOfWeek     string
+	HTTPUser      string
+	HTTPPassword  string
+	MailAdress    string
+	MailCondition string
+	MailSubject   string
+	IsActive      string
+}
+
+// Add creates a cronjob (add_cronjob) and returns the numeric cronjob
+// id the server assigns, as echoed in ReturnInfo (e.g. "324700").
+//
+// The eight KAS-required fields are validated before the SOAP call so
+// an obviously incomplete spec fails fast; the remaining schedule /
+// syntax validation is left to the API, whose documented faults
+// (minute_syntax_incorrect, time_not_allowed, …) surface verbatim
+// through the Caller.
+func (cl *Client) Add(ctx context.Context, s Spec) (string, error) {
+	if s.Protocol == "" || s.HTTPURL == "" || s.Comment == "" {
+		return "", errors.New("cronjob: add_cronjob requires a non-empty protocol, http url and comment")
+	}
+	if s.Minute == "" || s.Hour == "" || s.DayOfMonth == "" || s.Month == "" || s.DayOfWeek == "" {
+		return "", errors.New("cronjob: add_cronjob requires all five schedule fields (minute, hour, day_of_month, month, day_of_week)")
+	}
+	resp, err := kaswrite.Call(ctx, cl.c, "cronjob", addAction, AddParams(s))
+	if err != nil {
+		return "", err
+	}
+	return resp.Body.ReturnInfo.AsString(), nil
+}
+
+// AddParams builds the add_cronjob KAS request parameter map. It is the
+// single source of truth for the request shape so the CLI dry-run
+// preview / audit record and the dispatched call cannot diverge.
+func AddParams(s Spec) map[string]any {
+	return map[string]any{
+		FieldProtocol:      s.Protocol,
+		FieldHTTPURL:       s.HTTPURL,
+		FieldComment:       s.Comment,
+		FieldMinute:        s.Minute,
+		FieldHour:          s.Hour,
+		FieldDayOfMonth:    s.DayOfMonth,
+		FieldMonth:         s.Month,
+		FieldDayOfWeek:     s.DayOfWeek,
+		FieldHTTPUser:      s.HTTPUser,
+		FieldHTTPPassword:  s.HTTPPassword,
+		FieldMailAdress:    s.MailAdress,
+		FieldMailCondition: s.MailCondition,
+		FieldMailSubject:   s.MailSubject,
+		FieldIsActive:      s.IsActive,
+	}
+}
+
+// Update changes one or more mutable fields of an existing cronjob
+// (update_cronjob). fields holds only the keys the caller wants to
+// change (use the Field* constants); each is applied wholesale. id and
+// at least one field are required — update_cronjob with nothing to
+// change is rejected before the SOAP call (the API would fault
+// nothing_to_do).
+func (cl *Client) Update(ctx context.Context, id string, fields map[string]string) error {
+	if id == "" {
+		return errors.New("cronjob: update_cronjob requires a non-empty cronjob id")
+	}
+	if len(fields) == 0 {
+		return errors.New("cronjob: update_cronjob requires at least one field to change")
+	}
+	_, err := kaswrite.Call(ctx, cl.c, "cronjob", updateAction, UpdateParams(id, fields))
+	return err
+}
+
+// UpdateParams builds the update_cronjob KAS request parameter map
+// (single source of truth, see AddParams): the cronjob_id identifier
+// plus every caller-supplied mutable field verbatim.
+func UpdateParams(id string, fields map[string]string) map[string]any {
+	params := map[string]any{"cronjob_id": id}
+	for k, v := range fields {
+		params[k] = v
+	}
+	return params
+}
+
+// Delete removes a cronjob (delete_cronjob). A SOAP fault (e.g.
+// cronjob_id_not_found, in_progress) is surfaced verbatim by the Caller
+// so the caller can classify it via the api error helpers.
+func (cl *Client) Delete(ctx context.Context, id string) error {
+	if id == "" {
+		return errors.New("cronjob: delete_cronjob requires a non-empty cronjob id")
+	}
+	_, err := kaswrite.Call(ctx, cl.c, "cronjob", deleteAction, DeleteParams(id))
+	return err
+}
+
+// DeleteParams builds the delete_cronjob KAS request parameter map
+// (single source of truth, see AddParams).
+func DeleteParams(id string) map[string]any {
+	return map[string]any{"cronjob_id": id}
+}

--- a/internal/cronjob/write_test.go
+++ b/internal/cronjob/write_test.go
@@ -1,0 +1,180 @@
+package cronjob_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/chmmou/kasapi-cli/internal/cronjob"
+	"github.com/chmmou/kasapi-cli/internal/soap"
+	"github.com/chmmou/kasapi-cli/internal/testutil"
+)
+
+func sampleSpec() cronjob.Spec {
+	return cronjob.Spec{
+		Protocol:      "https",
+		HTTPURL:       "example.de/cron.php",
+		Comment:       "Hourly Cron",
+		Minute:        "59",
+		Hour:          "*",
+		DayOfMonth:    "*",
+		Month:         "*",
+		DayOfWeek:     "*",
+		MailAdress:    "cronjob@example.de",
+		MailCondition: "no-mail",
+		MailSubject:   "comment",
+		IsActive:      "Y",
+	}
+}
+
+func TestClientAdd(t *testing.T) {
+	t.Parallel()
+	resp := testutil.DecodeFixture(t, "cronjob/add_cronjob_response_success.xml")
+	fc := &testutil.FakeCaller{Resp: resp}
+	id, err := cronjob.NewClient(fc).Add(context.Background(), sampleSpec())
+	if err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if fc.GotAction != "add_cronjob" {
+		t.Errorf("action = %q, want add_cronjob", fc.GotAction)
+	}
+	if fc.GotParams["protocol"] != "https" || fc.GotParams["http_url"] != "example.de/cron.php" ||
+		fc.GotParams["cronjob_comment"] != "Hourly Cron" || fc.GotParams["minute"] != "59" {
+		t.Errorf("params = %v", fc.GotParams)
+	}
+	if fc.GotParams["mail_adress"] != "cronjob@example.de" {
+		t.Errorf("mail_adress param = %v, want cronjob@example.de (single-d wire key)", fc.GotParams["mail_adress"])
+	}
+	if id != "324700" {
+		t.Errorf("returned id = %q, want 324700 (fixture ReturnInfo)", id)
+	}
+}
+
+// A success-with-warning response (e.g. the unconfirmed-email notice)
+// still carries ReturnString=TRUE, so Add must treat it as success and
+// return the new id rather than wrapping ErrUnexpectedReturnString.
+func TestClientAddWarningStillSucceeds(t *testing.T) {
+	t.Parallel()
+	resp := testutil.DecodeFixture(t, "cronjob/add_cronjob_response_warning.xml")
+	id, err := cronjob.NewClient(&testutil.FakeCaller{Resp: resp}).Add(context.Background(), sampleSpec())
+	if err != nil {
+		t.Fatalf("Add (warning): %v", err)
+	}
+	if id != "324700" {
+		t.Errorf("returned id = %q, want 324700 (warning fixture ReturnInfo)", id)
+	}
+}
+
+func TestClientUpdate(t *testing.T) {
+	t.Parallel()
+	resp := testutil.DecodeFixture(t, "cronjob/update_cronjob_response_success.xml")
+	fc := &testutil.FakeCaller{Resp: resp}
+	fields := map[string]string{
+		cronjob.FieldComment: "Every hour Cron",
+		cronjob.FieldMinute:  "1",
+	}
+	if err := cronjob.NewClient(fc).Update(context.Background(), "324700", fields); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if fc.GotAction != "update_cronjob" {
+		t.Errorf("action = %q, want update_cronjob", fc.GotAction)
+	}
+	if fc.GotParams["cronjob_id"] != "324700" ||
+		fc.GotParams["cronjob_comment"] != "Every hour Cron" || fc.GotParams["minute"] != "1" {
+		t.Errorf("params = %v", fc.GotParams)
+	}
+}
+
+func TestClientDelete(t *testing.T) {
+	t.Parallel()
+	resp := testutil.DecodeFixture(t, "cronjob/delete_cronjob_response_success.xml")
+	fc := &testutil.FakeCaller{Resp: resp}
+	if err := cronjob.NewClient(fc).Delete(context.Background(), "324700"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if fc.GotAction != "delete_cronjob" {
+		t.Errorf("action = %q, want delete_cronjob", fc.GotAction)
+	}
+	if fc.GotParams["cronjob_id"] != "324700" {
+		t.Errorf("params = %v", fc.GotParams)
+	}
+}
+
+func TestWriteValidation(t *testing.T) {
+	t.Parallel()
+	c := cronjob.NewClient(&testutil.FakeCaller{})
+	ctx := context.Background()
+
+	missingURL := sampleSpec()
+	missingURL.HTTPURL = ""
+	if _, err := c.Add(ctx, missingURL); err == nil {
+		t.Error("Add missing http_url: err = nil, want validation error")
+	}
+	missingSchedule := sampleSpec()
+	missingSchedule.Minute = ""
+	if _, err := c.Add(ctx, missingSchedule); err == nil {
+		t.Error("Add missing minute: err = nil, want validation error")
+	}
+	if err := c.Update(ctx, "", map[string]string{cronjob.FieldComment: "x"}); err == nil {
+		t.Error("Update empty id: err = nil, want validation error")
+	}
+	if err := c.Update(ctx, "324700", nil); err == nil {
+		t.Error("Update no fields: err = nil, want validation error")
+	}
+	if err := c.Delete(ctx, ""); err == nil {
+		t.Error("Delete empty id: err = nil, want validation error")
+	}
+}
+
+func TestUnexpectedReturnString(t *testing.T) {
+	t.Parallel()
+	resp := &soap.Response{Body: soap.ResponseBody{ReturnString: "FALSE"}}
+	c := cronjob.NewClient(&testutil.FakeCaller{Resp: resp})
+	ctx := context.Background()
+	if _, err := c.Add(ctx, sampleSpec()); !errors.Is(err, cronjob.ErrUnexpectedReturnString) {
+		t.Errorf("Add err = %v, want ErrUnexpectedReturnString", err)
+	}
+	if err := c.Update(ctx, "324700", map[string]string{cronjob.FieldComment: "x"}); !errors.Is(err, cronjob.ErrUnexpectedReturnString) {
+		t.Errorf("Update err = %v, want ErrUnexpectedReturnString", err)
+	}
+	if err := c.Delete(ctx, "324700"); !errors.Is(err, cronjob.ErrUnexpectedReturnString) {
+		t.Errorf("Delete err = %v, want ErrUnexpectedReturnString", err)
+	}
+}
+
+func TestWritePropagatesError(t *testing.T) {
+	t.Parallel()
+	want := errors.New("boom")
+	c := cronjob.NewClient(&testutil.FakeCaller{Err: want})
+	ctx := context.Background()
+	if _, err := c.Add(ctx, sampleSpec()); !errors.Is(err, want) {
+		t.Errorf("Add err = %v, want %v", err, want)
+	}
+	if err := c.Update(ctx, "324700", map[string]string{cronjob.FieldComment: "x"}); !errors.Is(err, want) {
+		t.Errorf("Update err = %v, want %v", err, want)
+	}
+	if err := c.Delete(ctx, "324700"); !errors.Is(err, want) {
+		t.Errorf("Delete err = %v, want %v", err, want)
+	}
+}
+
+func TestParamBuilders(t *testing.T) {
+	t.Parallel()
+	add := cronjob.AddParams(sampleSpec())
+	if add["protocol"] != "https" || add["http_url"] != "example.de/cron.php" ||
+		add["cronjob_comment"] != "Hourly Cron" || add["minute"] != "59" ||
+		add["mail_adress"] != "cronjob@example.de" || add["is_active"] != "Y" {
+		t.Errorf("AddParams = %v", add)
+	}
+	if len(add) != 14 {
+		t.Errorf("AddParams has %d keys, want 14 (all add_cronjob request fields)", len(add))
+	}
+	upd := cronjob.UpdateParams("324700", map[string]string{cronjob.FieldComment: "c", cronjob.FieldHour: "2"})
+	if upd["cronjob_id"] != "324700" || upd["cronjob_comment"] != "c" || upd["hour"] != "2" {
+		t.Errorf("UpdateParams = %v", upd)
+	}
+	del := cronjob.DeleteParams("324700")
+	if len(del) != 1 || del["cronjob_id"] != "324700" {
+		t.Errorf("DeleteParams = %v", del)
+	}
+}

--- a/testdata/cronjob/add_cronjob_response_warning.xml
+++ b/testdata/cronjob/add_cronjob_response_warning.xml
@@ -90,7 +90,7 @@
                         </item>
                         <item>
                             <key xsi:type="xsd:string">ReturnInfo</key>
-                            <value xsi:type="xsd:string">123456</value>
+                            <value xsi:type="xsd:string">324700</value>
                         </item>
                         <item>
                             <key xsi:type="xsd:string">Msg</key>

--- a/testdata/cronjob/delete_cronjob_request.xml
+++ b/testdata/cronjob/delete_cronjob_request.xml
@@ -5,7 +5,7 @@
             <Params>
             {
                 "KasRequestParams": {
-                    "cronjob_id": "325208"
+                    "cronjob_id": "324700"
                 },
                 "kas_action": "delete_cronjob",
                 "kas_auth_data": "REDACTED",

--- a/testdata/cronjob/delete_cronjob_response_success.xml
+++ b/testdata/cronjob/delete_cronjob_response_success.xml
@@ -19,7 +19,7 @@
                             <value xsi:type="ns2:Map">
                                 <item>
                                     <key xsi:type="xsd:string">cronjob_id</key>
-                                    <value xsi:type="xsd:string">325208</value>
+                                    <value xsi:type="xsd:string">324700</value>
                                 </item>
                             </value>
                         </item>

--- a/testdata/cronjob/update_cronjob_response_success.xml
+++ b/testdata/cronjob/update_cronjob_response_success.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="https://kasapi.kasserver.com/soap/KasApi.php" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/" xmlns:ns2="http://xml.apache.org/xml-soap" SOAP-ENV:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="https://kasapi.kasserver.com/soap/KasApi.php" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:ns2="http://xml.apache.org/xml-soap" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/" SOAP-ENV:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
     <SOAP-ENV:Body>
         <ns1:KasApiResponse>
             <return xsi:type="ns2:Map">
@@ -8,15 +8,76 @@
                     <value xsi:type="ns2:Map">
                         <item>
                             <key xsi:type="xsd:string">KasRequestTime</key>
-                            <value xsi:type="xsd:int">1777579076</value>
+                            <value xsi:type="xsd:int">1779138190</value>
                         </item>
                         <item>
                             <key xsi:type="xsd:string">KasRequestType</key>
-                            <value xsi:type="xsd:string">get_cronjobs</value>
+                            <value xsi:type="xsd:string">update_cronjob</value>
                         </item>
                         <item>
                             <key xsi:type="xsd:string">KasRequestParams</key>
-                            <value SOAP-ENC:arrayType="xsd:ur-type[0]" xsi:type="SOAP-ENC:Array"/>
+                            <value xsi:type="ns2:Map">
+                                <item>
+                                    <key xsi:type="xsd:string">cronjob_id</key>
+                                    <value xsi:type="xsd:string">324700</value>
+                                </item>
+                                <item>
+                                    <key xsi:type="xsd:string">protocol</key>
+                                    <value xsi:type="xsd:string">https</value>
+                                </item>
+                                <item>
+                                    <key xsi:type="xsd:string">http_url</key>
+                                    <value xsi:type="xsd:string">example.de/cron.php</value>
+                                </item>
+                                <item>
+                                    <key xsi:type="xsd:string">cronjob_comment</key>
+                                    <value xsi:type="xsd:string">Every hour Cron</value>
+                                </item>
+                                <item>
+                                    <key xsi:type="xsd:string">minute</key>
+                                    <value xsi:type="xsd:string">1</value>
+                                </item>
+                                <item>
+                                    <key xsi:type="xsd:string">hour</key>
+                                    <value xsi:type="xsd:string">*/1</value>
+                                </item>
+                                <item>
+                                    <key xsi:type="xsd:string">day_of_month</key>
+                                    <value xsi:type="xsd:string">*</value>
+                                </item>
+                                <item>
+                                    <key xsi:type="xsd:string">month</key>
+                                    <value xsi:type="xsd:string">*</value>
+                                </item>
+                                <item>
+                                    <key xsi:type="xsd:string">day_of_week</key>
+                                    <value xsi:type="xsd:string">*</value>
+                                </item>
+                                <item>
+                                    <key xsi:type="xsd:string">http_user</key>
+                                    <value xsi:type="xsd:string"></value>
+                                </item>
+                                <item>
+                                    <key xsi:type="xsd:string">http_password</key>
+                                    <value xsi:type="xsd:string"></value>
+                                </item>
+                                <item>
+                                    <key xsi:type="xsd:string">mail_address</key>
+                                    <value xsi:type="xsd:string">cronjob@example.de</value>
+                                </item>
+                                <item>
+                                    <key xsi:type="xsd:string">mail_condition</key>
+                                    <value xsi:type="xsd:string">no-mail</value>
+                                </item>
+                                <item>
+                                    <key xsi:type="xsd:string">mail_subject</key>
+                                    <value xsi:type="xsd:string">comment</value>
+                                </item>
+                                <item>
+                                    <key xsi:type="xsd:string">is_active</key>
+                                    <value xsi:type="xsd:string">N</value>
+                                </item>
+                            </value>
                         </item>
                     </value>
                 </item>
@@ -33,145 +94,19 @@
                         </item>
                         <item>
                             <key xsi:type="xsd:string">ReturnInfo</key>
-                            <value SOAP-ENC:arrayType="ns2:Map[2]" xsi:type="SOAP-ENC:Array">
+                            <value xsi:type="xsd:string"></value>
+                        </item>
+                        <item>
+                            <key xsi:type="xsd:string">Msg</key>
+                            <value SOAP-ENC:arrayType="ns2:Map[1]" xsi:type="SOAP-ENC:Array">
                                 <item xsi:type="ns2:Map">
                                     <item>
-                                        <key xsi:type="xsd:string">cronjob_id</key>
-                                        <value xsi:type="xsd:string">325206</value>
+                                        <key xsi:type="xsd:string">type</key>
+                                        <value xsi:type="xsd:string">success</value>
                                     </item>
                                     <item>
-                                        <key xsi:type="xsd:string">cronjob_comment</key>
-                                        <value xsi:type="xsd:string">Hourly Cron</value>
-                                    </item>
-                                    <item>
-                                        <key xsi:type="xsd:string">shell_command</key>
-                                        <value xsi:nil="true"/>
-                                    </item>
-                                    <item>
-                                        <key xsi:type="xsd:string">timeout</key>
-                                        <value xsi:nil="true"/>
-                                    </item>
-                                    <item>
-                                        <key xsi:type="xsd:string">protocol</key>
-                                        <value xsi:type="xsd:string">https</value>
-                                    </item>
-                                    <item>
-                                        <key xsi:type="xsd:string">http_url</key>
-                                        <value xsi:type="xsd:string">example.de/cron.php</value>
-                                    </item>
-                                    <item>
-                                        <key xsi:type="xsd:string">http_user</key>
-                                        <value xsi:type="xsd:string"></value>
-                                    </item>
-                                    <item>
-                                        <key xsi:type="xsd:string">http_password</key>
-                                        <value xsi:type="xsd:string"></value>
-                                    </item>
-                                    <item>
-                                        <key xsi:type="xsd:string">minute</key>
-                                        <value xsi:type="xsd:string">59</value>
-                                    </item>
-                                    <item>
-                                        <key xsi:type="xsd:string">hour</key>
-                                        <value xsi:type="xsd:string">*</value>
-                                    </item>
-                                    <item>
-                                        <key xsi:type="xsd:string">day_of_month</key>
-                                        <value xsi:type="xsd:string">*</value>
-                                    </item>
-                                    <item>
-                                        <key xsi:type="xsd:string">month</key>
-                                        <value xsi:type="xsd:string">*</value>
-                                    </item>
-                                    <item>
-                                        <key xsi:type="xsd:string">day_of_week</key>
-                                        <value xsi:type="xsd:string">*</value>
-                                    </item>
-                                    <item>
-                                        <key xsi:type="xsd:string">mail_adress</key>
-                                        <value xsi:type="xsd:string">cronjob@example.de</value>
-                                    </item>
-                                    <item>
-                                        <key xsi:type="xsd:string">mail_condition</key>
-                                        <value xsi:type="xsd:string">no-mail</value>
-                                    </item>
-                                    <item>
-                                        <key xsi:type="xsd:string">mail_subject</key>
-                                        <value xsi:type="xsd:string">comment</value>
-                                    </item>
-                                    <item>
-                                        <key xsi:type="xsd:string">is_active</key>
-                                        <value xsi:type="xsd:string">N</value>
-                                    </item>
-                                </item>
-                                <item xsi:type="ns2:Map">
-                                    <item>
-                                        <key xsi:type="xsd:string">cronjob_id</key>
-                                        <value xsi:type="xsd:string">325208</value>
-                                    </item>
-                                    <item>
-                                        <key xsi:type="xsd:string">cronjob_comment</key>
-                                        <value xsi:type="xsd:string">Every hour Cron</value>
-                                    </item>
-                                    <item>
-                                        <key xsi:type="xsd:string">shell_command</key>
-                                        <value xsi:nil="true"/>
-                                    </item>
-                                    <item>
-                                        <key xsi:type="xsd:string">timeout</key>
-                                        <value xsi:nil="true"/>
-                                    </item>
-                                    <item>
-                                        <key xsi:type="xsd:string">protocol</key>
-                                        <value xsi:type="xsd:string">https</value>
-                                    </item>
-                                    <item>
-                                        <key xsi:type="xsd:string">http_url</key>
-                                        <value xsi:type="xsd:string">example.de/cron.php</value>
-                                    </item>
-                                    <item>
-                                        <key xsi:type="xsd:string">http_user</key>
-                                        <value xsi:type="xsd:string"></value>
-                                    </item>
-                                    <item>
-                                        <key xsi:type="xsd:string">http_password</key>
-                                        <value xsi:type="xsd:string"></value>
-                                    </item>
-                                    <item>
-                                        <key xsi:type="xsd:string">minute</key>
-                                        <value xsi:type="xsd:string">59</value>
-                                    </item>
-                                    <item>
-                                        <key xsi:type="xsd:string">hour</key>
-                                        <value xsi:type="xsd:string">*/1</value>
-                                    </item>
-                                    <item>
-                                        <key xsi:type="xsd:string">day_of_month</key>
-                                        <value xsi:type="xsd:string">*</value>
-                                    </item>
-                                    <item>
-                                        <key xsi:type="xsd:string">month</key>
-                                        <value xsi:type="xsd:string">*</value>
-                                    </item>
-                                    <item>
-                                        <key xsi:type="xsd:string">day_of_week</key>
-                                        <value xsi:type="xsd:string">*</value>
-                                    </item>
-                                    <item>
-                                        <key xsi:type="xsd:string">mail_adress</key>
-                                        <value xsi:type="xsd:string">cronjob@example.de</value>
-                                    </item>
-                                    <item>
-                                        <key xsi:type="xsd:string">mail_condition</key>
-                                        <value xsi:type="xsd:string">no-mail</value>
-                                    </item>
-                                    <item>
-                                        <key xsi:type="xsd:string">mail_subject</key>
-                                        <value xsi:type="xsd:string">comment</value>
-                                    </item>
-                                    <item>
-                                        <key xsi:type="xsd:string">is_active</key>
-                                        <value xsi:type="xsd:string">N</value>
+                                        <key xsi:type="xsd:string">text</key>
+                                        <value xsi:type="xsd:string">The cronjob will be changed.</value>
                                     </item>
                                 </item>
                             </value>


### PR DESCRIPTION
Wires `add_cronjob` / `update_cronjob` / `delete_cronjob` as the next #13 write slice, through the shared `kaswrite` seam.

- `kasapi-cli cronjobs add --url <u> --comment <c> [schedule/mail flags]` — reversible, not prompted.
- `… update <cronjob-id> [flags]` — gated (#109); sends only cobra-`Changed` flags (each replaced wholesale).
- `… delete <cronjob-id>` — gated (#109).

All three honour `--dry-run` (#132) and emit a #131 audit record; `--http-password` is redacted. Notification-address wire key is the single-d `mail_adress` (matches the read mapping and both request fixtures). The add/update/delete cronjob response fixtures were corrected to the real KAS shapes beforehand.

Closes #118