### PR TITLE
fix(cronjob): require explicit --minute/--hour for add

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Cronjob write endpoints (#118, #13 write slice):
-  `kasapi-cli cronjobs add --url <u> --comment <c> [schedule/mail
-  flags]`, `… update <cronjob-id> [flags]` and `… delete <cronjob-id>`
+  `kasapi-cli cronjobs add --url <u> --comment <c> --minute <m> --hour
+  <h> [flags]`, `… update <cronjob-id> [flags]` and `… delete
+  <cronjob-id>`
   wire `add_cronjob` / `update_cronjob` / `delete_cronjob`. `update`
   and `delete` are gated by the #109 confirmation prompt
   (`update_cronjob` replaces every supplied field wholesale); `add` is

--- a/docs/cli/kasapi-cli_cronjobs_add.md
+++ b/docs/cli/kasapi-cli_cronjobs_add.md
@@ -3,7 +3,7 @@
 Create a cronjob (add_cronjob)
 
 ```
-kasapi-cli cronjobs add --url <url> --comment <text> [schedule/mail flags] [flags]
+kasapi-cli cronjobs add --url <url> --comment <text> --minute <m> --hour <h> [flags]
 ```
 
 ### Options
@@ -14,13 +14,13 @@ kasapi-cli cronjobs add --url <url> --comment <text> [schedule/mail flags] [flag
       --day-of-month string     schedule day-of-month field (default "*")
       --day-of-week string      schedule day-of-week field (0-7, Sun=0|7) (default "*")
   -h, --help                    help for add
-      --hour string             schedule hour field (default "*")
+      --hour string             schedule hour field (required for add)
       --http-password string    HTTP basic-auth password for the call
       --http-user string        HTTP basic-auth user for the call
       --mail-address string     notification mail address (mail_adress)
       --mail-condition string   when to send the notification mail
       --mail-subject string     notification mail subject (default|comment) (default "default")
-      --minute string           schedule minute field (default "*")
+      --minute string           schedule minute field (required for add)
       --month string            schedule month field (default "*")
       --protocol string         request protocol (http|https) (default "https")
       --url string              URL to call (http_url; required for add)

--- a/docs/cli/kasapi-cli_cronjobs_update.md
+++ b/docs/cli/kasapi-cli_cronjobs_update.md
@@ -14,13 +14,13 @@ kasapi-cli cronjobs update <cronjob-id> [schedule/mail flags] [flags]
       --day-of-month string     schedule day-of-month field (default "*")
       --day-of-week string      schedule day-of-week field (0-7, Sun=0|7) (default "*")
   -h, --help                    help for update
-      --hour string             schedule hour field (default "*")
+      --hour string             schedule hour field (required for add)
       --http-password string    HTTP basic-auth password for the call
       --http-user string        HTTP basic-auth user for the call
       --mail-address string     notification mail address (mail_adress)
       --mail-condition string   when to send the notification mail
       --mail-subject string     notification mail subject (default|comment) (default "default")
-      --minute string           schedule minute field (default "*")
+      --minute string           schedule minute field (required for add)
       --month string            schedule month field (default "*")
       --protocol string         request protocol (http|https) (default "https")
       --url string              URL to call (http_url; required for add)

--- a/internal/cli/cronjobs.go
+++ b/internal/cli/cronjobs.go
@@ -78,8 +78,8 @@ func (f *cronjobWriteFlags) bind(cmd *cobra.Command) {
 	fl.StringVar(&f.protocol, "protocol", "https", "request protocol (http|https)")
 	fl.StringVar(&f.url, "url", "", "URL to call (http_url; required for add)")
 	fl.StringVar(&f.comment, "comment", "", "cronjob comment / label (required for add)")
-	fl.StringVar(&f.minute, "minute", "*", "schedule minute field")
-	fl.StringVar(&f.hour, "hour", "*", "schedule hour field")
+	fl.StringVar(&f.minute, "minute", "", "schedule minute field (required for add)")
+	fl.StringVar(&f.hour, "hour", "", "schedule hour field (required for add)")
 	fl.StringVar(&f.dayOfMonth, "day-of-month", "*", "schedule day-of-month field")
 	fl.StringVar(&f.month, "month", "*", "schedule month field")
 	fl.StringVar(&f.dayOfWeek, "day-of-week", "*", "schedule day-of-week field (0-7, Sun=0|7)")
@@ -120,7 +120,7 @@ func boolToYN(b bool) string {
 func newCronjobsAddCmd(opts *RootOptions) *cobra.Command {
 	f := &cronjobWriteFlags{}
 	cmd := &cobra.Command{
-		Use:   "add --url <url> --comment <text> [schedule/mail flags]",
+		Use:   "add --url <url> --comment <text> --minute <m> --hour <h> [flags]",
 		Short: "Create a cronjob (add_cronjob)",
 		Args:  cobra.NoArgs,
 		RunE: runWriteE(opts, func([]string) (writeSpec, error) {
@@ -129,6 +129,9 @@ func newCronjobsAddCmd(opts *RootOptions) *cobra.Command {
 			}
 			if f.comment == "" {
 				return writeSpec{}, fmt.Errorf("--comment is required")
+			}
+			if f.minute == "" || f.hour == "" {
+				return writeSpec{}, fmt.Errorf("--minute and --hour are required")
 			}
 			s := f.spec()
 			return writeSpec{

--- a/internal/cli/cronjobs_test.go
+++ b/internal/cli/cronjobs_test.go
@@ -38,6 +38,7 @@ func TestCronjobsAddRejectsBadInput(t *testing.T) {
 	}{
 		{"missing --url", []string{"cronjobs", "add", "--comment", "c"}},
 		{"missing --comment", []string{"cronjobs", "add", "--url", "example.de/cron.php"}},
+		{"missing schedule", []string{"cronjobs", "add", "--url", "example.de/cron.php", "--comment", "c"}},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {

--- a/internal/cronjob/write.go
+++ b/internal/cronjob/write.go
@@ -84,7 +84,7 @@ func (cl *Client) Add(ctx context.Context, s Spec) (string, error) {
 		return "", errors.New("cronjob: add_cronjob requires a non-empty protocol, http url and comment")
 	}
 	if s.Minute == "" || s.Hour == "" || s.DayOfMonth == "" || s.Month == "" || s.DayOfWeek == "" {
-		return "", errors.New("cronjob: add_cronjob requires all five schedule fields (minute, hour, day_of_month, month, day_of_week)")
+		return "", errors.New("cronjob: add_cronjob requires --minute and --hour (and non-empty day_of_month/month/day_of_week)")
 	}
 	resp, err := kaswrite.Call(ctx, cl.c, "cronjob", addAction, AddParams(s))
 	if err != nil {

--- a/internal/cronjob/write_test.go
+++ b/internal/cronjob/write_test.go
@@ -110,10 +110,15 @@ func TestWriteValidation(t *testing.T) {
 	if _, err := c.Add(ctx, missingURL); err == nil {
 		t.Error("Add missing http_url: err = nil, want validation error")
 	}
-	missingSchedule := sampleSpec()
-	missingSchedule.Minute = ""
-	if _, err := c.Add(ctx, missingSchedule); err == nil {
+	missingMinute := sampleSpec()
+	missingMinute.Minute = ""
+	if _, err := c.Add(ctx, missingMinute); err == nil {
 		t.Error("Add missing minute: err = nil, want validation error")
+	}
+	missingHour := sampleSpec()
+	missingHour.Hour = ""
+	if _, err := c.Add(ctx, missingHour); err == nil {
+		t.Error("Add missing hour: err = nil, want validation error")
 	}
 	if err := c.Update(ctx, "", map[string]string{cronjob.FieldComment: "x"}); err == nil {
 		t.Error("Update empty id: err = nil, want validation error")


### PR DESCRIPTION
Review follow-up for #118.

`cronjobs add` defaulted `--minute`/`--hour` to `*`, so a non-prompted `add` with no schedule flags silently created a cronjob running every minute. Both frequency-driving fields now have no default and are required (validated like `--url`/`--comment`); `--day-of-month`/`--month`/`--day-of-week` keep the safe `*` default. Tests, CHANGELOG and regenerated CLI docs updated accordingly.