### PR TITLE
fix(database): align delete fixtures + test to the d0123460 lifecycle

### DIFF
--- a/internal/database/write_test.go
+++ b/internal/database/write_test.go
@@ -89,13 +89,13 @@ func TestClientDelete(t *testing.T) {
 	t.Parallel()
 	resp := testutil.DecodeFixture(t, "database/delete_database_response_success.xml")
 	fc := &testutil.FakeCaller{Resp: resp}
-	if err := database.NewClient(fc).Delete(context.Background(), "d0123456"); err != nil {
+	if err := database.NewClient(fc).Delete(context.Background(), "d0123460"); err != nil {
 		t.Fatalf("Delete: %v", err)
 	}
 	if fc.GotAction != "delete_database" {
 		t.Errorf("action = %q, want delete_database", fc.GotAction)
 	}
-	if fc.GotParams["database_login"] != "d0123456" {
+	if fc.GotParams["database_login"] != "d0123460" {
 		t.Errorf("params = %v", fc.GotParams)
 	}
 }

--- a/testdata/database/delete_database_request.xml
+++ b/testdata/database/delete_database_request.xml
@@ -5,12 +5,12 @@
             <Params>
             {
                 "KasRequestParams": {
-                    "database_login": "d0123456"
+                    "database_login": "d0123460"
                 },
                 "kas_action": "delete_database",
-                "kas_auth_data": "{{kas_auth_data_session}}",
-                "kas_auth_type": "{{kas_auth_type_session}}",
-                "kas_login": "{{kas_login}}"
+                "kas_auth_data": "REDACTED",
+                "kas_auth_type": "session",
+                "kas_login": "w0000000"
             }
             </Params>
         </tns:KasApi>

--- a/testdata/database/delete_database_response_success.xml
+++ b/testdata/database/delete_database_response_success.xml
@@ -19,7 +19,7 @@
                             <value xsi:type="ns2:Map">
                                 <item>
                                     <key xsi:type="xsd:string">database_login</key>
-                                    <value xsi:type="xsd:string">d0123456</value>
+                                    <value xsi:type="xsd:string">d0123460</value>
                                 </item>
                             </value>
                         </item>
@@ -50,7 +50,7 @@
                                     </item>
                                     <item>
                                         <key xsi:type="xsd:string">text</key>
-                                        <value xsi:type="xsd:string">The database d0123456 has been deleted.</value>
+                                        <value xsi:type="xsd:string">The database d0123460 has been deleted.</value>
                                     </item>
                                 </item>
                             </value>


### PR DESCRIPTION
## Summary

The add/get/update fixtures all narrate the lifecycle of a single hypothetical database `d0123460`. The delete fixtures (request + response echo) were the lone outlier — both showed `d0123456` — and `TestClientDelete` tracked them. Harmless at runtime (FakeCaller stubs the call) but broke the slice-wide narrative.

- `testdata/database/delete_database_request.xml`: `database_login` → `d0123460`; auth envelope placeholders → `REDACTED` to match the other request fixtures.
- `testdata/database/delete_database_response_success.xml`: request-echo + success message → `d0123460`.
- `internal/database/write_test.go::TestClientDelete`: track the new fixture login.

The list fixture (`get_databases_response_success.xml`, 5 entries `d0123456..d0123460`) is intentionally unchanged; the read tests assert against the first entry (`d0123456`) by index, which remains correct.