### PR TITLE
docs(cronjob): document KAS mail_address/mail_adress fixture echo (closes #168)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `testdata/cronjob/{add_cronjob_response_success,add_cronjob_response_warning,update_cronjob_response_success}.xml`
+  carry a top-of-file XML comment documenting that KAS itself echoes
+  the notification address under `mail_address` (double d) in the
+  `KasRequestParams` echo block, while the documented request key is
+  `mail_adress` (single d). The read/write mapping uses the single-d
+  key and never reads the echo, so the captured fixtures keep the
+  typo verbatim instead of being normalised. Closes the last code
+  Nice-to-have from #168.
+
 - Address the post-write-phase nice-to-have bundle from #168:
   - `kaswrite.Call` now prefixes the module label onto the wrapped
     `ErrUnexpectedReturnString` message, so a regression in e.g.

--- a/testdata/cronjob/add_cronjob_response_success.xml
+++ b/testdata/cronjob/add_cronjob_response_success.xml
@@ -1,4 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- KAS echoes the notification address under "mail_address" (double d) in the
+     KasRequestParams block below, while the documented request key is
+     "mail_adress" (single d) — see internal/cronjob/write.go FieldMailAdress.
+     KAS itself is inconsistent here; the read/write mapping always uses the
+     single-d key and never reads this echo block, so the typo is preserved
+     verbatim as captured rather than normalised. -->
 <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="https://kasapi.kasserver.com/soap/KasApi.php" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:ns2="http://xml.apache.org/xml-soap" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/" SOAP-ENV:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
     <SOAP-ENV:Body>
         <ns1:KasApiResponse>

--- a/testdata/cronjob/add_cronjob_response_warning.xml
+++ b/testdata/cronjob/add_cronjob_response_warning.xml
@@ -1,4 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- KAS echoes the notification address under "mail_address" (double d) in the
+     KasRequestParams block below, while the documented request key is
+     "mail_adress" (single d) — see internal/cronjob/write.go FieldMailAdress.
+     KAS itself is inconsistent here; the read/write mapping always uses the
+     single-d key and never reads this echo block, so the typo is preserved
+     verbatim as captured rather than normalised. -->
 <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="https://kasapi.kasserver.com/soap/KasApi.php" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:ns2="http://xml.apache.org/xml-soap" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/" SOAP-ENV:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
     <SOAP-ENV:Body>
         <ns1:KasApiResponse>

--- a/testdata/cronjob/update_cronjob_response_success.xml
+++ b/testdata/cronjob/update_cronjob_response_success.xml
@@ -1,4 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- KAS echoes the notification address under "mail_address" (double d) in the
+     KasRequestParams block below, while the documented request key is
+     "mail_adress" (single d) — see internal/cronjob/write.go FieldMailAdress.
+     KAS itself is inconsistent here; the read/write mapping always uses the
+     single-d key and never reads this echo block, so the typo is preserved
+     verbatim as captured rather than normalised. -->
 <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="https://kasapi.kasserver.com/soap/KasApi.php" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:ns2="http://xml.apache.org/xml-soap" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/" SOAP-ENV:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
     <SOAP-ENV:Body>
         <ns1:KasApiResponse>


### PR DESCRIPTION
## Summary

Final code item of the #168 nice-to-have bundle. The three echo-bearing cronjob response fixtures (`add` success + warning, `update` success) now carry a top-of-file XML comment explaining KAS's own request/response key inconsistency:

- Request key (documented + read/write mapping): `mail_adress` (single d).
- Response `KasRequestParams` echo: `mail_address` (double d).

The mapping code never reads the echo block, so the captured fixture data is preserved verbatim rather than normalised. The comment removes a future-reader hazard ("is this a typo in our fixture?") without distorting the recording.

Items 6 (`UpdateParams` map ordering) and 7 (cronjob `add` audit `Target = --comment`) stay accepted-as-noted per the original review comments.

Closes #168.